### PR TITLE
thinkpad: cleanup

### DIFF
--- a/lenovo/ideapad/z510.nix
+++ b/lenovo/ideapad/z510.nix
@@ -1,10 +1,8 @@
-# NOTE: this doesn't inherit from the `general.nix`
-# as z510 is not a ThinkPad
-
 { config, pkgs, ... }:
+
 {
   hardware.cpu.intel.updateMicrocode = true;
-  
+
   # see https://github.com/NixOS/nixpkgs/issues/18356
   # found buggy driver with method https://wiki.ubuntu.com/DebuggingKernelSuspend
   boot.blacklistedKernelModules = [ "nouveau" ];

--- a/lenovo/thinkpad/general-intel.nix
+++ b/lenovo/thinkpad/general-intel.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   boot.kernelModules = mkDefault [ "kvm-intel" ];
   services.xserver.videoDrivers = [ "intel" ];

--- a/lenovo/thinkpad/general.nix
+++ b/lenovo/thinkpad/general.nix
@@ -1,6 +1,8 @@
-{ pkgs, lib, ... }:
+{ lib, pkgs, ... }:
 
-with lib;
+let
+  inherit (lib) mkDefault;
+in
 
 {
   hardware.trackpoint = mkDefault {

--- a/lenovo/thinkpad/general.nix
+++ b/lenovo/thinkpad/general.nix
@@ -5,20 +5,7 @@ let
 in
 
 {
-  hardware.trackpoint = mkDefault {
-    enable = true;
-    emulateWheel = true;
-  };
-
-  hardware.enableRedistributableFirmware = mkDefault true;
-  services.tlp.enable = true;
-
-  services.xserver = mkDefault {
-    synaptics.enable = false;
-    libinput.enable = true;
-  };
-
-  environment.systemPackages = [ pkgs.acpi ];
-
-  sound.enableMediaKeys = mkDefault true;
+  hardware.trackpoint.enable = mkDefault true;
+  services.tlp.enable = mkDefault true;
+  services.xserver.libinput.enable = mkDefault true;
 }

--- a/lenovo/thinkpad/t410.nix
+++ b/lenovo/thinkpad/t410.nix
@@ -6,11 +6,22 @@
   boot = {
     kernelParams = [
       # Kernel GPU Savings Options (NOTE i915 chipset only)
-      "drm.debug=0" "drm.vblankoffdelay=1" "i915.semaphores=1" "i915.modeset=1"
-      "i915.use_mmio_flip=1" "i915.powersave=1" "i915.enable_ips=1"
-      "i915.disable_power_well=1" "i915.enable_hangcheck=1"
-      "i915.enable_cmd_parser=1" "i915.fastboot=0" "i915.enable_ppgtt=1"
-      "i915.reset=0" "i915.lvds_use_ssc=0" "i915.enable_psr=0" "vblank_mode=0"
+      "drm.debug=0"
+      "drm.vblankoffdelay=1"
+      "i915.semaphores=1"
+      "i915.modeset=1"
+      "i915.use_mmio_flip=1"
+      "i915.powersave=1"
+      "i915.enable_ips=1"
+      "i915.disable_power_well=1"
+      "i915.enable_hangcheck=1"
+      "i915.enable_cmd_parser=1"
+      "i915.fastboot=0"
+      "i915.enable_ppgtt=1"
+      "i915.reset=0"
+      "i915.lvds_use_ssc=0"
+      "i915.enable_psr=0"
+      "vblank_mode=0"
       "i915.i915_enable_rc6=1"
     ];
     blacklistedKernelModules = [

--- a/lenovo/thinkpad/t460s.nix
+++ b/lenovo/thinkpad/t460s.nix
@@ -1,10 +1,10 @@
 { config, pkgs, ... }:
 
 {
-  imports =
-    [ ../lib/kernel-version.nix
-      ./general-intel.nix
-    ];
+  imports = [
+    ../lib/kernel-version.nix
+    ./general-intel.nix
+  ];
 
   ## BEGIN from generated hardware-configuration
   ## Probably better to just use a freshly generated hardware.configuration.nix

--- a/lenovo/thinkpad/x140e.nix
+++ b/lenovo/thinkpad/x140e.nix
@@ -15,5 +15,5 @@
   };
 
   # video card
-  services.xserver.videoDrivers = ["ati"];
+  services.xserver.videoDrivers = [ "ati" ];
 }

--- a/lenovo/thinkpad/x220i-tablet.nix
+++ b/lenovo/thinkpad/x220i-tablet.nix
@@ -8,7 +8,7 @@
 
   boot = {
     kernelModules = [ "tp_smapi" ];
-    extraModulePackages = [ config.boot.kernelPackages.tp_smapi ];
+    extraModulePackages = with config.boot.kernelPackages; [ tp_smapi ];
   };
 
   # hard disk protection if the laptop falls


### PR DESCRIPTION
* `hardware.trackpoint.emulateWheel = true;` is very biased, this module is only for ThinkPads anyway, so default value should be used
* All options should have smaller priority than user-set values (e.g. `services.tlp.enable`)
* Hardware profile should not pull in stuff into system environment unless it's hardware-specific (`pkgs.acpi` is not)
* `sound.mediaKeys` clashes with DE, e.g. Xfce handling sound keys
* Drop redundant `synaptics.enable = false;`