### PR TITLE
treewide: drop hardware-configuration.nix boilerplate

### DIFF
--- a/apple/macbook-pro-10-1.nix
+++ b/apple/macbook-pro-10-1.nix
@@ -5,20 +5,6 @@
     [ ../lib/kernel-version.nix
     ];
 
-  ## BEGIN from generated hardware-configuration
-  ## Probably better to just use a freshly generated hardware.configuration.nix
-  ## than this, but including for reference.
-  #imports =
-  #  [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
-  #  ];
-  #
-  #boot.initrd.availableKernelModules = [ "xhci_pci" "ehci_pci" "ahci" "usbhid" "sd_mod" "sdhci_pci" ];
-  #boot.kernelModules = [ "kvm-intel" "wl" ];
-  #boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
-  #
-  #nix.maxJobs = lib.mkDefault 8;
-  ## END from generated hardware-configuration
-
   # Use the systemd-boot efi boot loader. (From default generated configuration.nix)
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;

--- a/dell/xps-15-9550.nix
+++ b/dell/xps-15-9550.nix
@@ -5,21 +5,6 @@
     [ ../lib/kernel-version.nix
     ];
 
-  ## BEGIN from generated hardware-configuration
-  ## Probably better to just use a freshly generated hardware.configuration.nix
-  ## than this, but including for reference.
-  #imports =
-  #  [ <nixos/modules/hardware/network/broadcom-43xx.nix>
-  #    <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
-  #  ];
-  #
-  #boot.initrd.availableKernelModules = [ "xhci_pci" "ahci" "nvme" "rtsx_pci_sdmmc" ];
-  #boot.kernelModules = [ "kvm-intel" ];
-  #boot.extraModulePackages = [ ];
-  #
-  #nix.maxJobs = 8;
-  ## END from generated hardware-configuration
-
   # Use the systemd-boot efi boot loader. (From default generated configuration.nix)
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;

--- a/lenovo/thinkpad/t460s.nix
+++ b/lenovo/thinkpad/t460s.nix
@@ -6,17 +6,6 @@
       ./general-intel.nix
     ];
 
-  ## BEGIN from generated hardware-configuration
-  ## Probably better to just use a freshly generated hardware.configuration.nix
-  ## than this, but including for reference.
-  # boot.initrd.availableKernelModules = [ "xhci_pci" "nvme" "usb_storage" "sd_mod" "rtsx_pci_sdmmc" ];
-  # boot.kernelModules = [ "kvm-intel" ];
-  # boot.extraModulePackages = [  ];
-  #
-  #
-  # nix.maxJobs = lib.mkDefault 4;
-  ## END from generated hardware-configuration
-
   # Use the gummiboot efi boot loader. (From default generated configuration.nix)
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;


### PR DESCRIPTION
hardware-configuration.nix is still relied upon for hard drive configuration, and it handles variations of hardware (custom configurations, subrevisions).