### PR TITLE
x230: init

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 lenovo/thinkpad/x250 @Mic92
+lenovo/thinkpad/x230 @makefu

--- a/README.org
+++ b/README.org
@@ -32,6 +32,7 @@ should look like:
 | Lenovo ThinkPad T460s     | ~<nixos-hardware/lenovo/thinkpad/t460s>~   |
 | Lenovo ThinkPad X140e     | ~<nixos-hardware/lenovo/thinkpad/x140e>~   |
 | Lenovo ThinkPad X220      | ~<nixos-hardware/lenovo/thinkpad/x220>~    |
+| Lenovo ThinkPad X230      | ~<nixos-hardware/lenovo/thinkpad/x230>~    |
 | Lenovo ThinkPad X250      | ~<nixos-hardware/lenovo/thinkpad/x250>~    |
 | [[file:microsoft/surface-pro/3][Microsoft Surface Pro 3]]   | ~<nixos-hardware/microsoft/surface-pro/3>~ |
 | [[file:raspberry-pi/2][Raspberry Pi 2]]            | ~<nixos-hardware/raspberry-pi/2>~          |

--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib; {
+  imports = [
+    ../.
+    ../../../common/cpu/intel
+  ];
+
+  boot = {
+    kernelModules = [
+      "acpi_call"
+      "tpm-rng"
+    ];
+    extraModulePackages = with config.boot.kernelPackages; [
+      acpi_call
+    ];
+  };
+
+  hardware.opengl.extraPackages = with pkgs; [
+    vaapiIntel
+    vaapiVdpau
+    libvdpau-va-gl
+  ];
+}


### PR DESCRIPTION
This PR introduces X230 to the nixos-hardware repo.

For Battery Management and power control `acpi_call` is used instead of `tp-smapi`. Additionally,  `va` and `vdpau`acceleration is enabled.
`tpm-rng` provides an extra entropy source for rngd (which is enabled by default).