### PR TITLE
x230: remove acpi_call

### DIFF
--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -7,11 +7,7 @@
   ];
 
   boot = {
-    extraModulePackages = with config.boot.kernelPackages; [
-      acpi_call
-    ];
     kernelModules = [
-      "acpi_call"
       "tpm-rng"
     ];
   };


### PR DESCRIPTION
When i use the profile on my X230, wifi stopped working.

I investigated and found out that it works when i remove the `acpi_call` kernel module.

So i propose just removing it. (i don't know what it is supposed to do)

Maybe it is a serious bug that should be reported upstream.

dmesg with broke wifi: http://termbin.com/08vj

cc @yegortimoshenko @makefu 

---

 - system: `"x86_64-linux"`
 - host os: `Linux 4.9.80, NixOS, 17.09.2955.76614894f34 (Hummingbird)`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 1.11.16`
 - channels(davidak): `""`
 - channels(root): `"nixos-17.09.2955.76614894f34, nixos-hardware"`
 - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs`
