### PR TITLE
apple: disable services.mbpfan

### DIFF
--- a/apple/default.nix
+++ b/apple/default.nix
@@ -7,6 +7,4 @@
 
   hardware.facetimehd.enable = lib.mkDefault
     (config.nixpkgs.config.allowUnfree or false);
-
-  services.mbpfan.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
Causes overheating on MacBook Air 4,x and 6,x.