### PR TITLE
Add a basic t480s profile

### DIFF
--- a/lenovo/thinkpad/acpi_call.nix
+++ b/lenovo/thinkpad/acpi_call.nix
@@ -1,0 +1,10 @@
+# acpi_call makes tlp work for newer thinkpads
+
+{ config, ... }:
+
+{
+  boot = {
+    kernelModules = [ "acpi_call" ];
+    extraModulePackages = with config.boot.kernelPackages; [ acpi_call ];
+  };
+}

--- a/lenovo/thinkpad/t480s/default.nix
+++ b/lenovo/thinkpad/t480s/default.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../acpi_call.nix
+    ../.
+  ];
+}

--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -4,14 +4,11 @@
   imports = [
     ../.
     ../../../common/cpu/intel
+    ../acpi_call.nix
   ];
 
   boot = {
-    extraModulePackages = with config.boot.kernelPackages; [
-      acpi_call
-    ];
     kernelModules = [
-      "acpi_call"
       "tpm-rng"
     ];
   };


### PR DESCRIPTION
Things seem to mostly work well (except the trackpad, which I haven't figured out yet).

We do want `acpi_call` for tlp, though.