### PR TITLE
lenovo/thinkpad/x260: Init

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ imports = [
 | Lenovo ThinkPad X220              | `<nixos-hardware/lenovo/thinkpad/x220>`      |
 | Lenovo ThinkPad X230              | `<nixos-hardware/lenovo/thinkpad/x230>`      |
 | Lenovo ThinkPad X250              | `<nixos-hardware/lenovo/thinkpad/x250>`      |
+| [Lenovo ThinkPad X260][]          | `<nixos-hardware/lenovo/thinkpad/x260>`    |
 | Lenovo ThinkPad X270              | `<nixos-hardware/lenovo/thinkpad/x270>`      |
 | [Lenovo ThinkPad X1 (6th Gen)][]  | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`|
 | [Microsoft Surface Pro 3][]       | `<nixos-hardware/microsoft/surface-pro/3>`   |
@@ -56,6 +57,7 @@ imports = [
 [Dell XPS 15 9550]: dell/xps/15-9550
 [Inverse Path USB armory]: inversepath/usbarmory
 [Lenovo ThinkPad X1 (6th Gen)]: lenovo/thinkpad/x1/6th-gen
+[Lenovo ThinkPad X260]: lenovo/thinkpad/x260
 [Microsoft Surface Pro 3]: microsoft/surface-pro/3
 [Raspberry Pi 2]: raspberry-pi/2
 [Samsung Series 9 NP900X3C]: samsung/np900x3c

--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,7 @@ in
   lenovo-thinkpad-x220 = buildProfile ./lenovo/thinkpad/x220;
   lenovo-thinkpad-x230 = buildProfile ./lenovo/thinkpad/x230;
   lenovo-thinkpad-x250 = buildProfile ./lenovo/thinkpad/x250;
+  lenovo-thinkpad-x260 = buildProfile ./lenovo/thinkpad/x260;
 
   microsoft-surface-pro-3 = buildProfile ./microsoft/surface-pro/3;
 

--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -7,6 +7,6 @@
 
   # https://wiki.archlinux.org/index.php/TLP#Btrfs
   services.tlp.extraConfig = ''
-    SATA_LINKPWR_ON_BAT=max_performance
+    SATA_LINKPWR_ON_BAT=med_power_with_dipm
   '';
 }

--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -1,0 +1,20 @@
+{
+  imports = [
+    ../.
+    ../acpi_call.nix
+    ../../../common/cpu/intel
+  ];
+
+  # See https://linrunner.de/en/tlp/docs/tlp-faq.html#battery https://wiki.archlinux.org/index.php/TLP#Btrfs
+  services.tlp.extraConfig = ''
+    START_CHARGE_THRESH_BAT0=75
+    STOP_CHARGE_THRESH_BAT0=80
+    START_CHARGE_THRESH_BAT1=75
+    STOP_CHARGE_THRESH_BAT1=80
+
+    SATA_LINKPWR_ON_BAT=max_performance
+
+    CPU_SCALING_GOVERNOR_ON_BAT=powersave
+    ENERGY_PERF_POLICY_ON_BAT=powersave
+  '';
+}

--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -5,16 +5,8 @@
     ../../../common/cpu/intel
   ];
 
-  # See https://linrunner.de/en/tlp/docs/tlp-faq.html#battery https://wiki.archlinux.org/index.php/TLP#Btrfs
+  # https://wiki.archlinux.org/index.php/TLP#Btrfs
   services.tlp.extraConfig = ''
-    START_CHARGE_THRESH_BAT0=75
-    STOP_CHARGE_THRESH_BAT0=80
-    START_CHARGE_THRESH_BAT1=75
-    STOP_CHARGE_THRESH_BAT1=80
-
     SATA_LINKPWR_ON_BAT=max_performance
-
-    CPU_SCALING_GOVERNOR_ON_BAT=powersave
-    ENERGY_PERF_POLICY_ON_BAT=powersave
   '';
 }


### PR DESCRIPTION
Added a profile for x260.
- TLP config includes a fix for BTRFS(the first line), which e.g. is not present in config for x1 6th gen. AFAIK this should not influence the performance too much, yet it should prevent possible bugs/data corruption, which BTRFS users may encounter otherwise, hence I think it's a good idea to put it there.
- While working on this I noticed that most of the other ThinkPad profiles do not include the `acpi_call`, which is required, e.g. for TLP to work. Did not include the fixes, as that is out of scope of this PR.
- Maybe it would be a good idea to extract the TLP config into a (shared) function, which would generate powersaving config given the battery count?