### PR TITLE
cpu/intel: early KMS

### DIFF
--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -1,6 +1,8 @@
 { lib, pkgs, ... }:
 
 {
+  boot.initrd.kernelModules = [ "i915" ];
+
   hardware.cpu.intel.updateMicrocode = lib.mkDefault true;
   
   hardware.opengl.extraPackages = with pkgs; [


### PR DESCRIPTION
https://wiki.archlinux.org/index.php/Kernel_mode_setting#Early_KMS_start

Rationale is to provide a somewhat nicer boot experience.