### PR TITLE
Fix unusable Lenovo Thinkpad X1 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ imports = [
 | Lenovo ThinkPad X230              | `<nixos-hardware/lenovo/thinkpad/x230>`      |
 | Lenovo ThinkPad X250              | `<nixos-hardware/lenovo/thinkpad/x250>`      |
 | Lenovo ThinkPad X270              | `<nixos-hardware/lenovo/thinkpad/x270>`      |
-| [Lenovo ThinkPad X1 gen6][]       | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`|
+| [Lenovo ThinkPad X1 (6th Gen)][]  | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`|
 | [Microsoft Surface Pro 3][]       | `<nixos-hardware/microsoft/surface-pro/3>`   |
 | PC Engines APU                    | `<nixos-hardware/pcengines/apu>`             |
 | [Raspberry Pi 2][]                | `<nixos-hardware/raspberry-pi/2>`            |
@@ -55,7 +55,7 @@ imports = [
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1
 [Dell XPS 15 9550]: dell/xps/15-9550
 [Inverse Path USB armory]: inversepath/usbarmory
-[Lenovo ThinkPad X1 gen6]: lenovo/thinkpad/x1/6th-gen
+[Lenovo ThinkPad X1 (6th Gen)]: lenovo/thinkpad/x1/6th-gen
 [Microsoft Surface Pro 3]: microsoft/surface-pro/3
 [Raspberry Pi 2]: raspberry-pi/2
 [Samsung Series 9 NP900X3C]: samsung/np900x3c

--- a/README.md
+++ b/README.md
@@ -22,34 +22,34 @@ imports = [
 
 ## Profiles
 
-| Model                             | Path                                       |
-| --------------------------------- | ------------------------------------------ |
-| [Acer Aspire 4810T][]             | `<nixos-hardware/acer/aspire/4810t>`       |
-| Airis N990                        | `<nixos-hardware/airis/n990>`              |
-| Apple MacBook Air 4,X             | `<nixos-hardware/apple/macbook-air/4>`     |
-| Apple MacBook Air 6,X             | `<nixos-hardware/apple/macbook-air/6>`     |
-| [Apple MacBook Pro 10,1][]        | `<nixos-hardware/apple/macbook-pro/10-1>`  |
-| Apple MacBook Pro 12,1            | `<nixos-hardware/apple/macbook-pro/12-1>`  |
-| [Dell XPS 15 9550][]              | `<nixos-hardware/dell/xps/15-9550>`        |
-| [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`   |
-| Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`     |
-| Lenovo ThinkPad T410              | `<nixos-hardware/lenovo/thinkpad/t410>`    |
-| Lenovo ThinkPad T440p             | `<nixos-hardware/lenovo/thinkpad/t440p>`   |
-| Lenovo ThinkPad T460s             | `<nixos-hardware/lenovo/thinkpad/t460s>`   |
-| Lenovo ThinkPad X140e             | `<nixos-hardware/lenovo/thinkpad/x140e>`   |
-| Lenovo ThinkPad X220              | `<nixos-hardware/lenovo/thinkpad/x220>`    |
-| Lenovo ThinkPad X230              | `<nixos-hardware/lenovo/thinkpad/x230>`    |
-| Lenovo ThinkPad X250              | `<nixos-hardware/lenovo/thinkpad/x250>`    |
-| Lenovo ThinkPad X270              | `<nixos-hardware/lenovo/thinkpad/x270>`    |
-| [Microsoft Surface Pro 3][]       | `<nixos-hardware/microsoft/surface-pro/3>` |
-| PC Engines APU                    | `<nixos-hardware/pcengines/apu>`           |
-| [Raspberry Pi 2][]                | `<nixos-hardware/raspberry-pi/2>`          |
-| [Samsung Series 9 NP900X3C][]     | `<nixos-hardware/samsung/np900x3c>`        |
-| [Purism Librem 13v3][]            | `<nixos-hardware/purism/librem/13v3>`      |
-| Supermicro A1SRi-2758F            | `<nixos-hardware/supermicro/a1sri-2758f>`  |
-| Supermicro X10SLL-F               | `<nixos-hardware/supermicro/x10sll-f>`     |
-| [Toshiba Chromebook 2 `swanky`][] | `<nixos-hardware/toshiba/swanky>`          |
+| Model                             | Path                                         |
+| --------------------------------- | -------------------------------------------- |
+| [Acer Aspire 4810T][]             | `<nixos-hardware/acer/aspire/4810t>`         |
+| Airis N990                        | `<nixos-hardware/airis/n990>`                |
+| Apple MacBook Air 4,X             | `<nixos-hardware/apple/macbook-air/4>`       |
+| Apple MacBook Air 6,X             | `<nixos-hardware/apple/macbook-air/6>`       |
+| [Apple MacBook Pro 10,1][]        | `<nixos-hardware/apple/macbook-pro/10-1>`    |
+| Apple MacBook Pro 12,1            | `<nixos-hardware/apple/macbook-pro/12-1>`    |
+| [Dell XPS 15 9550][]              | `<nixos-hardware/dell/xps/15-9550>`          |
+| [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`     |
+| Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`       |
+| Lenovo ThinkPad T410              | `<nixos-hardware/lenovo/thinkpad/t410>`      |
+| Lenovo ThinkPad T440p             | `<nixos-hardware/lenovo/thinkpad/t440p>`     |
+| Lenovo ThinkPad T460s             | `<nixos-hardware/lenovo/thinkpad/t460s>`     |
+| Lenovo ThinkPad X140e             | `<nixos-hardware/lenovo/thinkpad/x140e>`     |
+| Lenovo ThinkPad X220              | `<nixos-hardware/lenovo/thinkpad/x220>`      |
+| Lenovo ThinkPad X230              | `<nixos-hardware/lenovo/thinkpad/x230>`      |
+| Lenovo ThinkPad X250              | `<nixos-hardware/lenovo/thinkpad/x250>`      |
+| Lenovo ThinkPad X270              | `<nixos-hardware/lenovo/thinkpad/x270>`      |
 | [Lenovo ThinkPad X1 gen6][]       | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`|
+| [Microsoft Surface Pro 3][]       | `<nixos-hardware/microsoft/surface-pro/3>`   |
+| PC Engines APU                    | `<nixos-hardware/pcengines/apu>`             |
+| [Raspberry Pi 2][]                | `<nixos-hardware/raspberry-pi/2>`            |
+| [Samsung Series 9 NP900X3C][]     | `<nixos-hardware/samsung/np900x3c>`          |
+| [Purism Librem 13v3][]            | `<nixos-hardware/purism/librem/13v3>`        |
+| Supermicro A1SRi-2758F            | `<nixos-hardware/supermicro/a1sri-2758f>`    |
+| Supermicro X10SLL-F               | `<nixos-hardware/supermicro/x10sll-f>`       |
+| [Toshiba Chromebook 2 `swanky`][] | `<nixos-hardware/toshiba/swanky>`            |
 
 [Acer Aspire 4810T]: acer/aspire/4810t
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ imports = [
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1
 [Dell XPS 15 9550]: dell/xps/15-9550
 [Inverse Path USB armory]: inversepath/usbarmory
+[Lenovo ThinkPad X1 gen6]: lenovo/thinkpad/x1/6th-gen
 [Microsoft Surface Pro 3]: microsoft/surface-pro/3
 [Raspberry Pi 2]: raspberry-pi/2
 [Samsung Series 9 NP900X3C]: samsung/np900x3c

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ imports = [
 | Supermicro A1SRi-2758F            | `<nixos-hardware/supermicro/a1sri-2758f>`  |
 | Supermicro X10SLL-F               | `<nixos-hardware/supermicro/x10sll-f>`     |
 | [Toshiba Chromebook 2 `swanky`][] | `<nixos-hardware/toshiba/swanky>`          |
+| [Lenovo ThinkPad X1 gen6][]       | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`|
 
 [Acer Aspire 4810T]: acer/aspire/4810t
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1

--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -27,6 +27,6 @@
   #   "mem_sleep_default=deep"
   # ];
   # boot.initrd.prepend = [
-  #   "/boot/acpi_override"
+  #   "${/boot/acpi_override}"
   # ];
 }

--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -7,7 +7,7 @@
 {
   imports = [
     ../.
-    ../../cpu-throttling.nix
+    ../../cpu-throttling-bug.nix
     ../../acpi_call.nix
   ];
 


### PR DESCRIPTION
Just a couple of commits to fix the X1 profile.  The first fixes the reference to a file that was renamed and the second  fixes acpi override file.