### PR TITLE
purism/librem/13v3: disable wifi hardware crypt

### DIFF
--- a/purism/librem/13v3/default.nix
+++ b/purism/librem/13v3/default.nix
@@ -10,4 +10,8 @@
     evdev:atkbd:dmi:bvn*:bvr*:bd*:svnPurism*:pn*Librem13v3*:pvr*
      KEYBOARD_KEY_56=backslash
   '';
+  boot.extraModprobeConfig = ''
+    options ath9k blink=0 btcoex_enable=0 bt_ant_diversity=1 ps_enable=1 nohwcrypt=1
+  '';
+
 }


### PR DESCRIPTION
 ...to stop output buffer from overflowing

I had the problem with nixos on my librem 13v3 that wifi disconnects constantly is generally poor.  Content of this PR fixed this for me.