### PR TITLE
lenovo/thinkpad/x230: add coreboot sub-profile

### DIFF
--- a/lenovo/thinkpad/x230/common.nix
+++ b/lenovo/thinkpad/x230/common.nix
@@ -1,0 +1,8 @@
+{
+  imports = [
+    ../.
+    ../../../common/cpu/intel
+  ];
+
+  boot.kernelModules = [ "tpm-rng" ];
+}

--- a/lenovo/thinkpad/x230/coreboot/default.nix
+++ b/lenovo/thinkpad/x230/coreboot/default.nix
@@ -1,0 +1,3 @@
+{
+  imports = [ ../common.nix ];
+}

--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -1,19 +1,6 @@
-{ config, lib, pkgs, ... }:
-
 {
   imports = [
-    ../.
-    ../../../common/cpu/intel
+    ./common.nix
     ../../../common/pc/laptop/acpi_call.nix
   ];
-
-  boot = {
-    kernelModules = [
-      "tpm-rng"
-    ];
-  };
-
-  services.xserver.deviceSection = lib.mkDefault ''
-    Option "TearFree" "true"
-  '';
 }


### PR DESCRIPTION
ACPI call is not supported by Coreboot, also it pulls in `mei_me` module which causes warnings if laptop runs on cleaned ME image (which, while orthogonal to Coreboot, typically goes hand in hand).