### PR TITLE
common/cpu: default microcode updates to enableRedistributableFirmware

### DIFF
--- a/common/cpu/amd/default.nix
+++ b/common/cpu/amd/default.nix
@@ -1,3 +1,6 @@
+{ config, lib, ... }:
+
 {
-  hardware.cpu.amd.updateMicrocode = true;
+  hardware.cpu.amd.updateMicrocode =
+    lib.mkDefault config.hardware.enableRedistributableFirmware;
 }

--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -1,9 +1,10 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   boot.initrd.kernelModules = [ "i915" ];
 
-  hardware.cpu.intel.updateMicrocode = lib.mkDefault true;
+  hardware.cpu.intel.updateMicrocode =
+    lib.mkDefault config.hardware.enableRedistributableFirmware;
   
   hardware.opengl.extraPackages = with pkgs; [
     vaapiIntel


### PR DESCRIPTION
This should alleviate concerns raised in https://github.com/NixOS/nixpkgs/issues/33018.