### PR TITLE
common/pc: disable ath3k if non-free firmware is not available

### DIFF
--- a/common/pc/default.nix
+++ b/common/pc/default.nix
@@ -1,5 +1,9 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
+  boot.blacklistedKernelModules = lib.optionals (!config.hardware.enableRedistributableFirmware) [
+    "ath3k"
+  ];
+
   services.xserver.libinput.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
`ath3k` requires non-free firmware.

This improves boot speed if `enableRedistributableFirmware` is false.