### PR TITLE
lenovo x1 carbon gen6: update S3 suspend

### DIFF
--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -2,7 +2,9 @@
 # standing with kernel 4.6.11 is the following wiki page:
 # https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X1_Carbon_(Gen_6). The
 # TrackPoint and TouchPad issues there seem to have been fixed already.
-
+#
+# Enable the lower-power S3 suspend state by upgrading the BIOS to version >= 1.30,
+# then manually selecting Linux in the power management section.
 { config, pkgs, ... }:
 {
   imports = [
@@ -18,15 +20,4 @@
     CPU_SCALING_GOVERNOR_ON_BAT=powersave
     ENERGY_PERF_POLICY_ON_BAT=powersave
   '';
-
-  # Enable S3 suspend state: you have to manually follow the
-  # instructions shown here: https://delta-xi.net/#056 in order to
-  # produce the ACPI patched table. Put the CPIO archive in /boot and
-  # then enable the following lines
-  # boot.kernelParams = [
-  #   "mem_sleep_default=deep"
-  # ];
-  # boot.initrd.prepend = [
-  #   "${/boot/acpi_override}"
-  # ];
 }


### PR DESCRIPTION
With UEFI >= 1.30, there's an explicit option to enable S3 power management.
Once this is selected, S3 is enabled and "deep" is selected as the default
/sys/power/mem_sleep value without requiring any kernel boot parameters.