### PR TITLE
lenovo-x1: removed battery TLP threshholds

### DIFF
--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -12,12 +12,4 @@
     ../../../../common/pc/laptop/acpi_call.nix
     ../../../../common/pc/laptop/cpu-throttling-bug.nix
   ];
-
-  # See https://linrunner.de/en/tlp/docs/tlp-faq.html#battery
-  services.tlp.extraConfig = ''
-    START_CHARGE_THRESH_BAT0=75
-    STOP_CHARGE_THRESH_BAT0=80
-    CPU_SCALING_GOVERNOR_ON_BAT=powersave
-    ENERGY_PERF_POLICY_ON_BAT=powersave
-  '';
 }


### PR DESCRIPTION
Fixes #98 , as it should not be set.