### PR TITLE
thinkpads: refactorings + modularization + some new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ imports = [
 | [Dell XPS 15 9550][]              | `<nixos-hardware/dell/xps/15-9550>`          |
 | [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`     |
 | Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`       |
+| Lenovo ThinkPad (generic)         | `<nixos-hardware/lenovo/thinkpad>`           |
 | Lenovo ThinkPad T410              | `<nixos-hardware/lenovo/thinkpad/t410>`      |
 | Lenovo ThinkPad T430              | `<nixos-hardware/lenovo/thinkpad/t430>`      |
 | Lenovo ThinkPad T440s             | `<nixos-hardware/lenovo/thinkpad/t440s>`     |

--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -1,14 +1,51 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }: let
+  inherit (lib) types;
+in {
+  options.hardware.cpu.intel.enable = lib.mkEnableOption "Intel specific settings" // {
+    default = true;
+  };
+  options.hardware.cpu.intel.max-frequency = lib.mkOption {
+    type = with types; nullOr int;
+    default = 100;
+    example = 75;
+    description = ''
+      Limits the maximum P-State that will be requested by system driver.
+      This allows varying CPU performance (reduce CPU heating and battery usage).
+      Supported for SandyBridge+ Intel processors.
 
-{
-  boot.initrd.kernelModules = [ "i915" ];
+      The value is percentage. 100 gives best performance (default), 0 gives
+      worst performance (though it doesn't stop the CPU, it just sets minimal
+      possible frequency). `null` disables this setting.
 
-  hardware.cpu.intel.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
-  
-  hardware.opengl.extraPackages = with pkgs; [
-    vaapiIntel
-    vaapiVdpau
-    libvdpau-va-gl
-  ];
+      Exact frequency values can be checked with `cpupower frequency-info`.
+
+      https://www.kernel.org/doc/Documentation/cpu-freq/intel-pstate.txt
+    '';
+  };
+
+  config = lib.mkIf config.hardware.cpu.intel.enable {
+    boot.initrd.kernelModules = [ "i915" ];
+
+    hardware.cpu.intel.updateMicrocode =
+      lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+    hardware.opengl.extraPackages = with pkgs; [
+      vaapiIntel
+      vaapiVdpau
+      libvdpau-va-gl
+    ];
+
+    system.activationScripts.cpu-frequency-set = let
+      max-freq = config.hardware.cpu.intel.max-frequency;
+    in lib.mkIf (max-freq != null) {
+      text = ''
+        max_perf_pct=/sys/devices/system/cpu/intel_pstate/max_perf_pct
+        value=${toString max-freq}
+        if [[ -f $max_perf_pct ]]; then
+          echo $value > $max_perf_pct
+        fi
+      '';
+      deps = [];
+    };
+  };
 }

--- a/common/pc/laptop/acpi_call.nix
+++ b/common/pc/laptop/acpi_call.nix
@@ -1,10 +1,17 @@
-# acpi_call makes tlp work for newer thinkpads
-
-{ config, ... }:
-
-{
-  boot = {
-    kernelModules = [ "acpi_call" ];
-    extraModulePackages = with config.boot.kernelPackages; [ acpi_call ];
+{ config, lib, ... }: let
+  inherit (lib) types;
+in {
+  options.boot.acpi_call.enable = lib.mkOption {
+    type = types.bool;
+    default = true;
+    description = ''
+      `acpi_call` kernel module is used for battery charge
+      thresholds and recalibration on Sandy Bridge and newer models
+      (X220/T420, X230/T430 et al.)
+    '';
+  };
+  config = lib.mkIf config.boot.acpi_call.enable {
+    boot.kernelModules = [ "acpi_call" ];
+    boot.extraModulePackages = with config.boot.kernelPackages; [ acpi_call ];
   };
 }

--- a/lenovo/thinkpad/default.nix
+++ b/lenovo/thinkpad/default.nix
@@ -1,10 +1,87 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }: let
 
-{
-  imports = [ ../../common/pc/laptop ];
+  inherit (lib) types;
 
-  hardware.trackpoint.enable = lib.mkDefault true;
+in {
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/laptop/acpi_call.nix
+    ../../common/cpu/intel
+  ];
 
-  # Fingerprint reader: login and unlock with fingerprint (if you add one with `fprintd-enroll`)
-  # services.fprintd.enable = true;
+  options.hardware.battery.powersave = lib.mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Enable some battery saving services.
+
+      See also `hardware.cpu.intel.max-frequency` in common/cpu/intel module,
+      which can be used to reduce power usage by CPU to minimum.
+    '';
+  };
+
+  options.hardware.battery.optimize = lib.mkOption {
+    type = types.enum [ "mostly-pluggedin" "lifetime" "runtime" ];
+    default = "runtime";
+    description = ''
+      Set battery charging parameters:
+      - runtime: always charge to maximum capacity
+      - lifetime: stop charging at 80% capacity, to increase battery lifetime
+      - mostly-pluggedin: stop charging at 50% capacity, useful for laptops
+        with mostly plugged-in AC cable.
+
+      In case full battery charge is needed, use `tlp fullcharge`
+      to remove thresholds temporarily.
+
+      Based on https://linrunner.de/en/tlp/docs/tlp-faq.html#battery
+    '';
+  };
+
+  options.hardware.fingerprint.enable = lib.mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Enables fingerprint reader device (available on some ThinkPads).
+
+      To login and unlock with fingerprint, enroll first with `fprintd-enroll`.
+    '';
+  };
+
+  config = lib.mkMerge [
+
+    (lib.mkIf (config.hardware.battery.powersave
+        || config.hardware.battery.optimize != "runtime") {
+      environment.systemPackages = [ pkgs.tlp ];
+      services.tlp.enable = true;
+    })
+
+    (lib.mkIf config.hardware.battery.powersave {
+      powerManagement.powertop.enable = true;
+
+      services.tlp.extraConfig = ''
+        CPU_SCALING_GOVERNOR_ON_BAT=powersave
+        ENERGY_PERF_POLICY_ON_BAT=powersave
+      '';
+    })
+
+    (lib.mkIf (config.hardware.battery.optimize == "lifetime") {
+      services.tlp.extraConfig = ''
+        START_CHARGE_THRESH_BAT0=75
+        STOP_CHARGE_THRESH_BAT0=80
+      '';
+    })
+
+    (lib.mkIf (config.hardware.battery.optimize == "mostly-pluggedin") {
+      services.tlp.extraConfig = ''
+        START_CHARGE_THRESH_BAT0=40
+        STOP_CHARGE_THRESH_BAT0=50
+      '';
+    })
+
+    {
+      services.fprintd.enable = lib.mkDefault config.hardware.fingerprint.enable;
+
+      hardware.trackpoint.enable = lib.mkDefault true;
+    }
+  ];
 }

--- a/lenovo/thinkpad/t410/default.nix
+++ b/lenovo/thinkpad/t410/default.nix
@@ -4,8 +4,9 @@
   imports = [
     ../.
     ../tp-smapi.nix
-    ../../../common/cpu/intel
   ];
+  # doesn't support acpi_call
+  boot.acpi_call.enable = false;
 
   boot = {
     # TODO: this configuration seems to be very aggressive.

--- a/lenovo/thinkpad/t410/default.nix
+++ b/lenovo/thinkpad/t410/default.nix
@@ -5,10 +5,11 @@
     ../.
     ../tp-smapi.nix
   ];
-  # doesn't support acpi_call
-  boot.acpi_call.enable = false;
 
   boot = {
+    # doesn't support acpi_call
+    acpi_call.enable = false;
+
     # TODO: this configuration seems to be very aggressive.
     # Ask @peti if it's stable or not.
     kernelParams = [

--- a/lenovo/thinkpad/t430/default.nix
+++ b/lenovo/thinkpad/t430/default.nix
@@ -3,7 +3,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
   ];
 
   boot = {

--- a/lenovo/thinkpad/t440p/default.nix
+++ b/lenovo/thinkpad/t440p/default.nix
@@ -3,7 +3,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
   ];
 
   boot = {

--- a/lenovo/thinkpad/t440s/default.nix
+++ b/lenovo/thinkpad/t440s/default.nix
@@ -3,8 +3,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
   ];
 
   boot = {

--- a/lenovo/thinkpad/t450s/default.nix
+++ b/lenovo/thinkpad/t450s/default.nix
@@ -2,8 +2,6 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
     ../.
   ];
 }

--- a/lenovo/thinkpad/t460s/default.nix
+++ b/lenovo/thinkpad/t460s/default.nix
@@ -2,7 +2,6 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
     ../.
   ];
 

--- a/lenovo/thinkpad/t480s/default.nix
+++ b/lenovo/thinkpad/t480s/default.nix
@@ -2,8 +2,6 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/laptop/cpu-throttling-bug.nix
     ../.
   ];

--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -9,7 +9,6 @@
 {
   imports = [
     ../.
-    ../../../../common/pc/laptop/acpi_call.nix
     ../../../../common/pc/laptop/cpu-throttling-bug.nix
   ];
 }

--- a/lenovo/thinkpad/x1/default.nix
+++ b/lenovo/thinkpad/x1/default.nix
@@ -1,6 +1,5 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
   ];
 }

--- a/lenovo/thinkpad/x140e/default.nix
+++ b/lenovo/thinkpad/x140e/default.nix
@@ -6,6 +6,10 @@
     ../../../common/cpu/amd
   ];
 
+  hardware.cpu.intel.enable = false;
+  # I'm not sure whether acpi_call works on this laptop
+  boot.acpi_call.enable = false;
+
   boot.extraModprobeConfig = lib.mkDefault ''
     options snd_hda_intel enable=0,1
   '';

--- a/lenovo/thinkpad/x220/default.nix
+++ b/lenovo/thinkpad/x220/default.nix
@@ -3,8 +3,9 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
     ../../../common/pc/laptop/hdd # TODO: reverse compat
     ../tp-smapi.nix
   ];
+  # doesn't support acpi_call
+  boot.acpi_call.enable = false;
 }

--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -3,8 +3,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
   ];
 
   boot = {

--- a/lenovo/thinkpad/x250/default.nix
+++ b/lenovo/thinkpad/x250/default.nix
@@ -1,6 +1,5 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
   ];
 }

--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -1,8 +1,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
   ];
 
   # https://wiki.archlinux.org/index.php/TLP#Btrfs

--- a/lenovo/thinkpad/x270/default.nix
+++ b/lenovo/thinkpad/x270/default.nix
@@ -1,6 +1,5 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/intel
   ];
 }


### PR DESCRIPTION
- convert `common/cpu/intel` and `common/pc/laptop/acpi_call` to proper
  modules. This allows a) descriptions and b) enable/disable instead of `import`
- enable both for thinkpad by default. Disable explicitly in specific profiles
  (for example, AMD ThinkPads don't need those). This is mostly to remove
  repetitions and make a "generic" ThinkPad config (I have E470 but none of
  profiles matches my needs).
- add `hardware.cpu.intel.max-frequency` option, which allows reducing
  CPU performance (a bit duplicates powerManagement.cpufreq.max but it's
  a separate mechanism). Perhaps should eventually move to nixpkgs?
- add `hardware.battery.powersave`, which enables some non-controversial
  power saving services. Disabled by default.
- add `hardware.battery.optimize`, which documents nuances of battery
  lifetime. Basically, ressurects deleted in https://github.com/NixOS/nixos-hardware/pull/100 code
  but disabled by default.
- convert a comment about fprintd into an option `hardware.fingerprint.enable`,
  with description

What you think about this? I'm now using those options as:
```
  imports = [
    <nixos-hardware/lenovo/thinkpad>
  ];
  hardware.battery.powersave = true;
  hardware.battery.optimize = "mostly-pluggedin";
  hardware.fingerprint.enable = true;
  # increase nixos-rebuild time from 4.3s to 4.7s
  hardware.cpu.intel.max-frequency = 90;
```