### PR TITLE
t450s: fix trackpoint configuration at boot

### DIFF
--- a/lenovo/thinkpad/t450s/default.nix
+++ b/lenovo/thinkpad/t450s/default.nix
@@ -6,4 +6,15 @@
     ../../../common/pc/laptop/acpi_call.nix
     ../.
   ];
+
+  systemd.paths.trackpoint = {
+    pathConfig = {
+      PathExists = "/sys/devices/rmi4-00/rmi4-00.fn03/serio2";
+      Unit = "trackpoint.service";
+    };
+  };
+
+  systemd.services.trackpoint.script = ''
+    ${config.systemd.package}/bin/udevadm trigger --attr-match=name="${config.hardware.trackpoint.device}"
+  '';
 }


### PR DESCRIPTION
as i discussed in detail in [this issue on nixpkgs](https://github.com/NixOS/nixpkgs/issues/56512), the t450s (and likely other models) have a problem where they do not create the sysfs attributes for the trackpoint device early enough in the boot process for udev to configure them. this pull request adds a (sadly device-specific) method for triggering udev to configure the device once the sysfs path appears.