### PR TITLE
pcengines/apu: expose GRUB over serial

### DIFF
--- a/pcengines/apu/default.nix
+++ b/pcengines/apu/default.nix
@@ -1,3 +1,8 @@
 {
   boot.kernelParams = [ "console=ttyS0,115200n8" ];
+  boot.loader.grub.extraConfig = "
+    serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
+    terminal_input serial
+    terminal_output serial
+  ";
 }


### PR DESCRIPTION
Prior to this commit, an apu's boot would go through stages of varying visibility:
1. BIOS: exposed to serial
2. GRUB: not exposed to serial
3. Linux: exposed to serial

This commit changes (2) to be visible over serial, so the entire boot is visible over serial.

Tested on nixos 18.09 on a https://www.pcengines.ch/apu1d.htm

References:
* https://www.gnu.org/software/grub/manual/grub/grub.html#Serial-terminal
* https://github.com/NixOS/nixpkgs/issues/37013#issuecomment-379226915