### PR TITLE
toshiba/swanky: switch to default kernels

### DIFF
--- a/toshiba/swanky/default.nix
+++ b/toshiba/swanky/default.nix
@@ -13,9 +13,6 @@ in
     ../../common/pc/laptop
   ];
 
-  # Sound only properly works out of the box on 4.18+ kernels.
-  boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
-
   # Required for screen brightness control:
   boot.kernelParams = [ "acpi_backlight=vendor" ];
 


### PR DESCRIPTION
Both unstable and 19.03 come with 4.19+ kernels
making this option obsolete.

Disclaimer: I don't own this hardware and my change is purely based
on the comment in the code.