### PR TITLE
Specify a correct unit description

### DIFF
--- a/common/pc/laptop/cpu-throttling-bug.nix
+++ b/common/pc/laptop/cpu-throttling-bug.nix
@@ -6,7 +6,7 @@
   # See https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X1_Carbon_(Gen_6)#Power_management.2FThrottling_issues
   systemd.services.cpu-throttling = {
     enable = true;
-    description = "Sets the offset to 3 °C, so the new trip point is 97 °C";
+    description = "CPU Throttling Fix";
     documentation = [
       "https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X1_Carbon_(Gen_6)#Power_management.2FThrottling_issues"
     ];
@@ -22,7 +22,7 @@
 
   systemd.timers.cpu-throttling = {
     enable = true;
-    description = "Set cpu heating limit to 97 °C";
+    description = "CPU Throttling Fix";
     documentation = [
       "https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X1_Carbon_(Gen_6)#Power_management.2FThrottling_issues"
     ];


### PR DESCRIPTION
The systemd unit has an incorrect specification. The intent of the description is as per systemd documentation (https://www.freedesktop.org/software/systemd/man/systemd.unit.html):

```
Description=¶

    A human readable name for the unit. This is used by systemd (and other UIs) as the label for the unit, so this string should identify the unit rather than describe it, despite the name. "Apache2 Web
            Server" is a good example. Bad examples are "high-performance light-weight
            HTTP server" (too generic) or "Apache2" (too specific and meaningless for people who do not know Apache). systemd will use this string as a noun in status messages ("Starting
            description...", "Started
            description.", "Reached target
            description.", "Failed to start
            description."), so it should be capitalized, and should not be a full sentence or a phrase with a continous verb. Bad examples include "exiting the container" or "updating the database once per
            day.".```
```
This is what you see in the log right now
```
Jul 04 16:59:42 Verleihnix systemd[1]: Starting Sets the offset to 3 °C, so the new trip point is 97 °C...
Jul 04 16:59:42 Verleihnix systemd[1]: Started Sets the offset to 3 °C, so the new trip point is 97 °C.
```