### PR TITLE
enable fstrim on SSDs

### DIFF
--- a/common/pc/ssd/default.nix
+++ b/common/pc/ssd/default.nix
@@ -4,4 +4,6 @@
   boot.kernel.sysctl = {
     "vm.swappiness" = lib.mkDefault 1;
   };
+
+  services.fstrim.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
This will run TRIM once a week using a systemd timer. Running TRIM regularly
will improves the performance and increases the SSDs lifespan. Since it is based
on the utillinux no additional package is required.