### PR TITLE
thinkpad: minor trackpoint fixes

### DIFF
--- a/lenovo/thinkpad/default.nix
+++ b/lenovo/thinkpad/default.nix
@@ -1,9 +1,10 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   imports = [ ../../common/pc/laptop ];
 
   hardware.trackpoint.enable = lib.mkDefault true;
+  hardware.trackpoint.emulateWheel = lib.mkDefault config.hardware.trackpoint.enable;
 
   # Fingerprint reader: login and unlock with fingerprint (if you add one with `fprintd-enroll`)
   # services.fprintd.enable = true;

--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -12,4 +12,8 @@
     ../../../../common/pc/laptop/acpi_call.nix
     ../../../../common/pc/laptop/cpu-throttling-bug.nix
   ];
+
+  # New ThinkPads have a different TrackPoint manufacturer/name.
+  # See also https://certification.ubuntu.com/catalog/component/input/5313/input%3ATPPS/2ElanTrackPoint/
+  hardware.trackpoint.device = "TPPS/2 Elan TrackPoint";
 }


### PR DESCRIPTION
* Enable wheel emulation by default if trackpoint support is enabled
* Set proper TrackPoint name for ThinkPad X1 Carbon 6th Gen

Please refer to the commit messages for further details :) 