### PR TITLE
Add better pulseaudio support for thinkpad t490

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ imports = [
 | Lenovo ThinkPad T460s             | `<nixos-hardware/lenovo/thinkpad/t460s>`     |
 | Lenovo ThinkPad T470s             | `<nixos-hardware/lenovo/thinkpad/t470s>`     |
 | Lenovo ThinkPad T480s             | `<nixos-hardware/lenovo/thinkpad/t480s>`     |
+| Lenovo ThinkPad T490              | `<nixos-hardware/lenovo/thinkpad/t490>`      |
 | Lenovo ThinkPad X140e             | `<nixos-hardware/lenovo/thinkpad/x140e>`     |
 | Lenovo ThinkPad X220              | `<nixos-hardware/lenovo/thinkpad/x220>`      |
 | Lenovo ThinkPad X230              | `<nixos-hardware/lenovo/thinkpad/x230>`      |

--- a/lenovo/thinkpad/t490/default.nix
+++ b/lenovo/thinkpad/t490/default.nix
@@ -1,0 +1,30 @@
+{ nixos, pkgs, config, stdenv, ... }:
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/laptop/cpu-throttling-bug.nix
+    ../.
+  ];
+
+  services = {
+    # This fixes the pulseaudio profiles of the Thinkpad T490.
+    # The laptop contains a single audio card with 5 sub-devices. Default pulseaudio only offers a single sink
+    # which can only be switched between speaker/HDMI via a manual profile change.
+    # This configures a profile set for pulseaudio which offers multiple sinks corresponding to the
+    # speaker + 4 HDMI ports. This allows the user to play audio streams on the speaker and any of the 4 HDMI/USB-C
+    # ports at the same time.
+    udev.extraRules = let
+      t490ProfileSet = ./t490-profile-set.conf;
+    in ''
+    SUBSYSTEM!="sound", GOTO="pulseaudio_end"
+    ACTION!="change", GOTO="pulseaudio_end"
+    KERNEL!="card*", GOTO="pulseaudio_end"
+
+    # Lenovo T490
+    ATTRS{subsystem_vendor}=="0x17aa", ATTRS{subsystem_device}=="0x2279", ENV{PULSE_PROFILE_SET}="${t490ProfileSet}"
+
+    LABEL="pulseaudio_end"
+    '';
+  };
+}

--- a/lenovo/thinkpad/t490/t490-profile-set.conf
+++ b/lenovo/thinkpad/t490/t490-profile-set.conf
@@ -1,0 +1,107 @@
+[Profile speaker+hdmi-stereo]
+description = Speaker + HDMI Stereo
+output-mappings = analog-stereo hdmi-stereo hdmi-stereo-extra1 hdmi-stereo-extra2
+input-mappings = analog-stereo
+
+[Mapping analog-stereo]
+device-strings = front:%f
+channel-map = left,right
+paths-output = analog-output analog-output-lineout analog-output-speaker analog-output-headphones analog-output-headphones-2
+paths-input = analog-input-front-mic analog-input-rear-mic analog-input-internal-mic analog-input-dock-mic analog-input analog-input-mic analog-input-linein analog-input-aux analog-input-video analog-input-tvtuner analog-input-fm analog-input-mic-line analog-input-headphone-mic analog-input-headset-mic
+priority = 15
+
+[Mapping hdmi-stereo]
+description = Stereo (HDMI)
+device-strings = hdmi:%f
+paths-output = hdmi-output-0
+channel-map = left,right
+priority = 6
+direction = output
+
+[Mapping hdmi-stereo-extra1]
+description = Stereo (HDMI 2)
+device-strings = hdmi:%f,1
+paths-output = hdmi-output-1
+channel-map = left,right
+priority = 8
+direction = output
+
+[Mapping hdmi-stereo-extra2]
+description = Stereo (HDMI 3)
+device-strings = hdmi:%f,2
+paths-output = hdmi-output-2
+channel-map = left,right
+priority = 6
+direction = output
+
+[Profile speaker+hdmi-surround]
+description = Speaker + HDMI 5.1
+output-mappings = analog-stereo hdmi-surround hdmi-surround-extra1 hdmi-surround-extra2
+input-mappings = analog-stereo
+
+[Mapping analog-stereo]
+device-strings = front:%f
+channel-map = left,right
+paths-output = analog-output analog-output-lineout analog-output-speaker analog-output-headphones analog-output-headphones-2
+paths-input = analog-input-front-mic analog-input-rear-mic analog-input-internal-mic analog-input-dock-mic analog-input analog-input-mic analog-input-linein analog-input-aux analog-input-video analog-input-tvtuner analog-input-fm analog-input-mic-line analog-input-headphone-mic analog-input-headset-mic
+priority = 15
+
+[Mapping hdmi-surround]
+description = Digital Surround 5.1 (HDMI)
+device-strings = hdmi:%f
+paths-output = hdmi-output-0
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround-extra1]
+description = Digital Surround 5.1 (HDMI 2)
+device-strings = hdmi:%f,1
+paths-output = hdmi-output-1
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 8
+direction = output
+
+[Mapping hdmi-surround-extra2]
+description = Digital Surround 5.1 (HDMI 3)
+device-strings = hdmi:%f,2
+paths-output = hdmi-output-2
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Profile speaker+hdmi-surround71]
+description = Speaker + HDMI 7.1
+output-mappings = analog-stereo hdmi-surround71 hdmi-surround71-extra1 hdmi-surround71-extra2
+input-mappings = analog-stereo
+
+[Mapping analog-stereo]
+device-strings = front:%f
+channel-map = left,right
+paths-output = analog-output analog-output-lineout analog-output-speaker analog-output-headphones analog-output-headphones-2
+paths-input = analog-input-front-mic analog-input-rear-mic analog-input-internal-mic analog-input-dock-mic analog-input analog-input-mic analog-input-linein analog-input-aux analog-input-video analog-input-tvtuner analog-input-fm analog-input-mic-line analog-input-headphone-mic analog-input-headset-mic
+priority = 15
+
+[Mapping hdmi-surround71]
+description = Digital Surround 7.1 (HDMI)
+device-strings = hdmi:%f
+paths-output = hdmi-output-0
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra1]
+description = Digital Surround 7.1 (HDMI 2)
+device-strings = hdmi:%f,1
+paths-output = hdmi-output-1
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 8
+direction = output
+
+[Mapping hdmi-surround71-extra2]
+description = Digital Surround 7.1 (HDMI 3)
+device-strings = hdmi:%f,2
+paths-output = hdmi-output-2
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
+direction = output


### PR DESCRIPTION
This fixes the pulseaudio profiles of the Thinkpad T490.
The laptop contains a single audio card with 5 sub-devices. Default pulseaudio only offers a single sink which can only be switched between speaker/HDMI via a manual profile change.
This configures a profile set for pulseaudio which offers multiple sinks corresponding to the speaker + 4 HDMI ports. This allows the user to play audio streams on the speaker and any of the 4 HDMI/USB-C ports at the same time.