### PR TITLE
thinkpad/x250: add acpi_call

### DIFF
--- a/lenovo/thinkpad/x250/default.nix
+++ b/lenovo/thinkpad/x250/default.nix
@@ -2,5 +2,6 @@
   imports = [
     ../.
     ../../../common/cpu/intel
+    ../../../common/pc/laptop/acpi_call.nix
   ];
 }


### PR DESCRIPTION
This kernel module is needed to, for example, support tlp's

  - `START_CHARGE_THRESH_BAT?` and
  - `STOP_CHARGE_THRESH_BAT?`

options.