### PR TITLE
match specifically on the sound chip

### DIFF
--- a/lenovo/thinkpad/t490/default.nix
+++ b/lenovo/thinkpad/t490/default.nix
@@ -22,7 +22,7 @@
     KERNEL!="card*", GOTO="pulseaudio_end"
 
     # Lenovo T490
-    ATTRS{subsystem_vendor}=="0x17aa", ATTRS{subsystem_device}=="0x2279", ENV{PULSE_PROFILE_SET}="${t490ProfileSet}"
+    ATTRS{vendor}=="0x8086" ATTRS{device}=="0x9dc8" ATTRS{subsystem_vendor}=="0x17aa", ATTRS{subsystem_device}=="0x2279", ENV{PULSE_PROFILE_SET}="${t490ProfileSet}"
 
     LABEL="pulseaudio_end"
     '';


### PR DESCRIPTION
The previous matcher was overly broad, which caused it to disable newly found usb audio chips.