### PR TITLE
intel: add intel-media-driver

### DIFF
--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -10,5 +10,6 @@
     vaapiIntel
     vaapiVdpau
     libvdpau-va-gl
+    intel-media-driver
   ];
 }


### PR DESCRIPTION
Provides hardware accelerated video playback from Broadwell onwards.

Older boards (e.g. Sandy Bridge) are not supported. I'm not sure if they should specifically be excluded.

More info:

* https://github.com/intel/media-driver#supported-platforms
* https://wiki.archlinux.org/index.php/Hardware_video_acceleration#Intel

Closes #99.