### PR TITLE
Adding Dell XPS 15 9560

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ See code for all available configurations.
 | [Dell XPS 13 9380][]              | `<nixos-hardware/dell/xps/13-9380>`                |
 | [Dell XPS 15 7590][]              | `<nixos-hardware/dell/xps/15-7590>`                |
 | [Dell XPS 15 9550][]              | `<nixos-hardware/dell/xps/15-9550>`                |
+| [Dell XPS 15 9560][]              | `<nixos-hardware/dell/xps/15-9560>`                |
+| [Dell XPS 15 9560, intel only][]  | `<nixos-hardware/dell/xps/15-9560/intel>`          |
+| [Dell XPS 15 9560, nvidia only][] | `<nixos-hardware/dell/xps/15-9560/nvidia>`         |
 | [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`           |
 | Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`             |
 | Lenovo ThinkPad E495              | `<nixos-hardware/lenovo/thinkpad/e495>`            |
@@ -83,6 +86,9 @@ See code for all available configurations.
 [Dell XPS 13 9380]: dell/xps/13-9380
 [Dell XPS 15 7590]: dell/xps/15-7590
 [Dell XPS 15 9550]: dell/xps/15-9550
+[Dell XPS 15 9560]: dell/xps/15-9560
+[Dell XPS 15 9560, intel only]: dell/xps/15-9560/intel
+[Dell XPS 15 9560, nvidia only]: dell/xps/15-9560/nvidia
 [Inverse Path USB armory]: inversepath/usbarmory
 [Lenovo ThinkPad X1 (6th Gen)]: lenovo/thinkpad/x1/6th-gen
 [Lenovo ThinkPad X260]: lenovo/thinkpad/x260

--- a/dell/xps/15-9560/README.wiki
+++ b/dell/xps/15-9560/README.wiki
@@ -1,0 +1,54 @@
+= Dell XPS 15 9560 =
+
+== Tested Hardware ==
+
+* CPU: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
+* RAM: 16 GB
+* HDD: 512 GiB SSD
+* Screen: 15.6" FHD(1920x1080) InfinityEdge
+* Graphics: NVIDIA Corporation GTX1050 4GB GDDR5, with Intel Graphics too.
+* Input: trackpad
+
+
+== Firmware Configuration ==
+
+Not much tweaking of NixOS itself was needed. But we currently cannot automate the firmware setup, so this must be done by hand.
+
+=== Before installation ===
+
+These settings are needed both for booting the final install, and installer itself. Therefore, they must be done first.
+
+* ''Disable Secure Boot (but keep UEFI Boot).'' Thakfully doing so is as easy as changing any other simple setting.
+
+* ''Disable Intel hardware RAID and use AHCI instead.'' Intel doesn't seem to provide a working linux driver for this.  (If you just have SSD it's pointless and just slows things down needlessly anyways.)
+
+
+=== After installation ===
+
+* ''Add systemd-boot to UEFI boot list.'' The (uneditable anyways) settings mapping drive UUIDs to HD* work fine.
+
+=== Optional ===
+
+* ''Disable C-States.'' This is a processor idling thing. It seems to cause random crashes (Blank screen, no normal panic debug dump). Unfortunately, without it, the computer cannot be suspended. On the other hand, it doesn't seem to affect acpi's estimation of battery life when the computer is running with minimal load, but I haven't tested battery life in practice. I list it as optional as there's a tradeoff, and the crashes are rare enough one can probably get through installation just fine.
+
+* ''Update BIOS.'' According to Reddit, this helps with battery life.
+
+* ''Update Intel's Thunderbolt firmware.'' Without this, the Thunderbolt port will only work as power source, and not transfer data.
+
+=== Troubleshooting ===
+
+==== rcu_sched freezing problems ====
+
+After a recent update my machine became unstable. X couldn't start and even running `lspci` would lock the machine. I'm not sure what the root cause was, but I found the fix here: https://wiki.archlinux.org/index.php/Dell_XPS_15_9560#Troubleshooting
+
+TL;DR I added this line:
+  I am leaving these params here, I haven't test these so use on your own risk.
+  I am using different method to disable nvidia.
+  ("acpi_rev_override=1" param is save and I have been using it for a while now,
+  no crashes.)
+
+```
+boot.kernelParams = [ "acpi_rev_override=1" "pcie_aspm=off" "nouveau.modeset=0" ];
+```
+
+Some more detail about the problem can be found here: https://bbs.archlinux.org/viewtopic.php?id=223056

--- a/dell/xps/15-9560/default.nix
+++ b/dell/xps/15-9560/default.nix
@@ -1,0 +1,24 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ./xps-common.nix
+  ];
+
+  # This configuration makes intel default and optionaly applications could run nvidia with optirun.
+  # To Optimize for your use case import intel or nvidia only configuration instead
+  # xps-9560/intel
+  # or
+  # xps-9560/nvidia
+
+
+ ##### bumblebee working, needs reboot to take affect and to use it run: optirun "<application>"
+ services.xserver.videoDrivers = lib.mkDefault [ "intel" "nvidia" ];
+ boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "bbswitch" ];
+ boot.extraModulePackages = lib.mkDefault [ pkgs.linuxPackages.nvidia_x11 ];
+ hardware.bumblebee.enable = lib.mkDefault true;
+ hardware.bumblebee.pmMethod = lib.mkDefault "none";
+
+}

--- a/dell/xps/15-9560/intel/default.nix
+++ b/dell/xps/15-9560/intel/default.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../../common/cpu/intel
+    ../../../../common/pc/laptop
+    ../xps-common.nix
+  ];
+
+
+  # This runs only Intel and nvidia does not drain power.
+
+  ##### disable nvidia, very nice battery life.
+  hardware.nvidiaOptimus.disable = lib.mkDefault true;
+  boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" ];
+  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
+
+}

--- a/dell/xps/15-9560/nvidia/default.nix
+++ b/dell/xps/15-9560/nvidia/default.nix
@@ -1,0 +1,20 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../../common/cpu/intel
+    ../../../../common/pc/laptop
+    ../xps-common.nix
+  ];
+
+
+  # This runs only nvidia, great for games or heavy use of render applications
+
+  ##### disable intel, run nvidia only and as default
+  services.xserver.videoDrivers = lib.mkDefault ["nvidia"];
+  hardware.nvidia.modesetting.enable = lib.mkDefault true;
+  hardware.nvidia.optimus_prime.enable = lib.mkDefault true;
+  hardware.nvidia.optimus_prime.nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  hardware.nvidia.optimus_prime.intelBusId = lib.mkDefault "PCI:0:2:0";
+
+}

--- a/dell/xps/15-9560/xps-common.nix
+++ b/dell/xps/15-9560/xps-common.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+
+{
+
+  # Boot loader
+  boot.loader.systemd-boot.enable = lib.mkDefault true;
+  boot.loader.efi.canTouchEfiVariables = lib.mkDefault true;
+  boot.kernelParams = lib.mkDefault [ "acpi_rev_override" ];
+
+  # This will save you money and possibly your life!
+  services.thermald.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
 Add xps 9560 with its own quirks, I added versions:

1 default one, with nvidia working and intel working, needs optirun to
run application with nvidia
2 intel only, I am using this as my daily driver for long time, only
intel is turned on and nvidia is turned off and doesn't drain any
power.
3 nvidia only, intel is dissabled and nvidia is picked as default gpu,
no need to fiddle with optirun etc, good for gpu heavy application.

All these settings needs to reboot to work properly.


