### PR TITLE
Support NixOS 19.09 for <dell/xps/15-7590>

### DIFF
--- a/dell/xps/15-7590/default.nix
+++ b/dell/xps/15-7590/default.nix
@@ -1,6 +1,13 @@
 { lib, ... }:
-
-{
+# Earlier font-size setup.
+# Virtual console options were renamed in 20.03; use the right option depending
+# on the OS version; keep this here at least until 20.03 is stable.
+lib.recursiveUpdate
+(if lib.versionAtLeast (lib.versions.majorMinor lib.version) "20.03" then {
+  console.earlySetup = true;
+} else {
+  boot.earlyVconsoleSetup = true;
+}) {
   imports = [
     ../../../common/cpu/intel
     ../../../common/pc/laptop
@@ -9,9 +16,6 @@
 
   # Set to true for just the first run, then disable it.
   # boot.loader.efi.canTouchEfiVariables = lib.mkDefault true;
-
-  # Earlier font-size setup
-  console.earlySetup = true;
 
   # Prevent small EFI partiion from filling up
   boot.loader.grub.configurationLimit = 10;
@@ -23,8 +27,9 @@
     overlays = [
       (self: super: {
         firmwareLinuxNonfree = super.firmwareLinuxNonfree.overrideAttrs (old: {
-          src = super.fetchgit{
-            url = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
+          src = super.fetchgit {
+            url =
+              "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
             rev = "bf13a71b18af229b4c900b321ef1f8443028ded8";
             sha256 = "1dcaqdqyffxiadx420pg20157wqidz0c0ca5mrgyfxgrbh6a4mdj";
           };


### PR DESCRIPTION
Virtual console options were renamed in 20.03; use `console.earlySetup` or `boot.earlyVconsoleSetup` depending on OS version.

Follows discussion in https://github.com/NixOS/nixos-hardware/pull/114#discussion_r374953204