### PR TITLE
Added profile for Thinkpad E495

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See code for all available configurations.
 | [Dell XPS 15 9550][]              | `<nixos-hardware/dell/xps/15-9550>`                |
 | [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`           |
 | Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`             |
+| Lenovo ThinkPad E495              | `<nixos-hardware/lenovo/thinkpad/e495>`            |
 | Lenovo ThinkPad L13               | `<nixos-hardware/lenovo/thinkpad/l13>`             |
 | Lenovo ThinkPad P53               | `<nixos-hardware/lenovo/thinkpad/p53>`             |
 | Lenovo ThinkPad T410              | `<nixos-hardware/lenovo/thinkpad/t410>`            |

--- a/lenovo/thinkpad/e495/default.nix
+++ b/lenovo/thinkpad/e495/default.nix
@@ -1,0 +1,11 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../common/cpu/amd
+  ];
+
+  # see https://github.com/NixOS/nixpkgs/issues/69289
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.2") pkgs.linuxPackages_latest;
+}


### PR DESCRIPTION
@Mic92 Sorry you were too fast in merging ^^ 
The version you merged does not work there is a 'pkgs' prefix missing. I clicked on the button to merge your changes into mine. This is now a rebased commit with only one commit message and the profile is tested and working.


https://github.com/NixOS/nixos-hardware/pull/144