### PR TITLE
lenovo/thinkpad/t495: init from e495.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See code for all available configurations.
 | Lenovo ThinkPad T470s             | `<nixos-hardware/lenovo/thinkpad/t470s>`           |
 | Lenovo ThinkPad T480s             | `<nixos-hardware/lenovo/thinkpad/t480s>`           |
 | Lenovo ThinkPad T490              | `<nixos-hardware/lenovo/thinkpad/t490>`            |
+| Lenovo ThinkPad T495              | `<nixos-hardware/lenovo/thinkpad/t495>`            |
 | Lenovo ThinkPad X140e             | `<nixos-hardware/lenovo/thinkpad/x140e>`           |
 | Lenovo ThinkPad X220              | `<nixos-hardware/lenovo/thinkpad/x220>`            |
 | Lenovo ThinkPad X230              | `<nixos-hardware/lenovo/thinkpad/x230>`            |

--- a/lenovo/thinkpad/t495/default.nix
+++ b/lenovo/thinkpad/t495/default.nix
@@ -1,0 +1,11 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../common/cpu/amd
+  ];
+
+  # see https://github.com/NixOS/nixpkgs/issues/69289
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.2") pkgs.linuxPackages_latest;
+}


### PR DESCRIPTION
The E495 and T495 are based on the same core Ryzen platform, so the
E495 tweaks apply similarly to the T495.

Tested on my own T495, works well.