### PR TITLE
thinkpad/t495: fix backlight save/load and and battery conditioning.

### DIFF
--- a/lenovo/thinkpad/t495/default.nix
+++ b/lenovo/thinkpad/t495/default.nix
@@ -4,7 +4,12 @@
   imports = [
     ../.
     ../../../common/cpu/amd
+    ../../../common/pc/laptop/acpi_call.nix
   ];
+
+  # Force use of the thinkpad_acpi driver for backlight control.
+  # This allows the backlight save/load systemd service to work.
+  boot.kernelParams = [ "acpi_backlight=native" ];
 
   # see https://github.com/NixOS/nixpkgs/issues/69289
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.2") pkgs.linuxPackages_latest;


### PR DESCRIPTION
Saving/loading the backlight state requires the acpi_backlight=native
kernel parameter.

acpi_call is required by TLP to get access to battery conditioning
information from the firmware.

Signed-off-by: David Anderson <dave@natulte.net>