### PR TITLE
Change TLP charge thresholds

### DIFF
--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -16,4 +16,10 @@
   services.xserver.deviceSection = lib.mkDefault ''
     Option "TearFree" "true"
   '';
+
+  services.tlp.extraConfig = lib.mkDefault ''
+    START_CHARGE_THRESH_BAT0=67
+    STOP_CHARGE_THRESH_BAT0=100
+  '';
+
 }


### PR DESCRIPTION
Set TLP charging thresholds to values recommended by the TLP developer on [ThinkPad-Forum.de](https://thinkpad-forum.de/threads/184510-elementary-OS-Thinkpad-X230-einrichten?p=1865345&viewfull=1#post1865345).