### PR TITLE
x230: don't enable battery thresholds by default

### DIFF
--- a/lenovo/thinkpad/x230/default.nix
+++ b/lenovo/thinkpad/x230/default.nix
@@ -16,10 +16,4 @@
   services.xserver.deviceSection = lib.mkDefault ''
     Option "TearFree" "true"
   '';
-
-  services.tlp.extraConfig = lib.mkDefault ''
-    START_CHARGE_THRESH_BAT0=67
-    STOP_CHARGE_THRESH_BAT0=100
-  '';
-
 }


### PR DESCRIPTION
see https://github.com/NixOS/nixos-hardware/pull/154#issuecomment-617181517