### PR TITLE
Add a shared HiDPI Configuration, use it.

### DIFF
--- a/common/pc/display/hidpi.nix
+++ b/common/pc/display/hidpi.nix
@@ -1,13 +1,17 @@
-# Shared configuration which most (if not all) HiDPI setups should have.
-{ config, lib, pkgs, ... }:
+{ pkgs, lib, ... }: {
+  console.font = lib.mkDefault
+    "${pkgs.terminus_font}/share/consolefonts/ter-u28n.psf.gz";
 
-{
+  # Needed when doing cryptsetup
+  console.earlySetup = lib.mkDefault true;
+  boot.loader.systemd-boot.consoleMode = lib.mkDefault "max";
+
   services.xserver.dpi = lib.mkDefault 196;
   fonts.fontconfig.dpi = lib.mkDefault 196;
+  environment.variables = lib.mkDefault {
+    GDK_SCALE = "2";
+    GDK_DPI_SCALE = "0.5";
+    _JAVA_OPTIONS = "-Dsun.java2d.uiScale=2";
 
-  # Fix sizes of GTK/GNOME ui elements
-  environment.variables = {
-    GDK_SCALE = lib.mkDefault "2";
-    GDK_DPI_SCALE= lib.mkDefault "0.5";
   };
 }

--- a/common/pc/display/hidpi.nix
+++ b/common/pc/display/hidpi.nix
@@ -1,0 +1,13 @@
+# Shared configuration which most (if not all) HiDPI setups should have.
+{ config, lib, pkgs, ... }:
+
+{
+  services.xserver.dpi = lib.mkDefault 196;
+  fonts.fontconfig.dpi = lib.mkDefault 196;
+
+  # Fix sizes of GTK/GNOME ui elements
+  environment.variables = {
+    GDK_SCALE = lib.mkDefault "2";
+    GDK_DPI_SCALE= lib.mkDefault "0.5";
+  };
+}

--- a/lenovo/thinkpad/x1-extreme/gen2/default.nix
+++ b/lenovo/thinkpad/x1-extreme/gen2/default.nix
@@ -5,6 +5,7 @@ with lib;
 {
   imports = [
     ../.
+    ../../../../common/pc/display/hidpi.nix
   ];
 
   # Fixes an issue with incorrect battery reporting. See


### PR DESCRIPTION
I've noticed other laptops with HiDPI displays have this configuration set  and my laptop didn't, so I thought it might be worth adding a common configuration for basic HiDPI display settings which seem quite universal.

