### PR TITLE
pc/laptop: remove redundant cpuFreqGovernor setting

### DIFF
--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -3,11 +3,5 @@
 {
   imports = [ ../. ];
 
-  # TODO: fix in NixOS/nixpkgs
-  # Disable governor set in hardware-configuration.nix,
-  # required when services.tlp.enable is true:
-  powerManagement.cpuFreqGovernor =
-    lib.mkIf config.services.tlp.enable (lib.mkForce null);
-
   services.tlp.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
This setting has been part of NixOS since version 16.09.

It's defined in [services/hardware/tlp.nix](https://github.com/NixOS/nixpkgs/blob/82b5f87fcc710a99c47c5ffe441589807a8202af/nixos/modules/services/hardware/tlp.nix#L59).