### PR TITLE
add xps 13 (9343)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See code for all available configurations.
 | Dell Latitude 3480                | `<nixos-hardware/dell/latitude/3480>`              |
 | [Dell XPS E7240][]                | `<nixos-hardware/dell/e7240>`                      |
 | [Dell XPS 13 7390][]              | `<nixos-hardware/dell/xps/13-7390>`                |
+| [Dell XPS 13 9343][]              | `<nixos-hardware/dell/xps/13-9343>`                |
 | [Dell XPS 13 9360][]              | `<nixos-hardware/dell/xps/13-9360>`                |
 | [Dell XPS 13 9370][]              | `<nixos-hardware/dell/xps/13-9370>`                |
 | [Dell XPS 13 9380][]              | `<nixos-hardware/dell/xps/13-9380>`                |
@@ -87,6 +88,7 @@ See code for all available configurations.
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1
 [Dell XPS E7240]: dell/e7240
 [Dell XPS 13 7390]: dell/xps/13-7390
+[Dell XPS 13 9343]: dell/xps/13-9343
 [Dell XPS 13 9360]: dell/xps/13-9360
 [Dell XPS 13 9370]: dell/xps/13-9370
 [Dell XPS 13 9380]: dell/xps/13-9380

--- a/dell/xps/13-9343/default.nix
+++ b/dell/xps/13-9343/default.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # This will save you money and possibly your life!
+  services.thermald.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
I have no idea if `throttled` and `thermald` are needed since `common/pc/laptop` has `tlp`. I copied them from another profile.

Also I wonder if `boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];` should be in the profile since `hardware-configuration.nix` already has it. I wonder if it could help people figure out that they need to make a custom iso with that driver to be able to install with the wifi. Maybe it could be noted in a README.

> With kernel 4.6.5 and tlp, the idle power usage can reach ~2.3 W with the kernel parameter pcie_aspm=force enabled. 

https://wiki.archlinux.org/index.php/Dell_XPS_13_(9343)#Powersaving
I also wonder if this should be included or only noted in a README. If included I'm not sure how the user could disable it.