### PR TITLE
dell/xps/13-9360: conflicting font fix

### DIFF
--- a/dell/xps/13-9360/default.nix
+++ b/dell/xps/13-9360/default.nix
@@ -1,14 +1,10 @@
 { lib, pkgs, ... }:
 
-# TODO: move to general HiDPI profile
-# 4K screen, use bigger console font
-# i18n.consoleFont deprecated in >=20.03, choose option based on OS version
-lib.recursiveUpdate
-(if lib.versionAtLeast (lib.versions.majorMinor lib.version) "20.03" then {
-  console.font = lib.mkDefault "latarcyrheb-sun32";
-} else {
-  i18n.consoleFont = lib.mkDefault "latarcyrheb-sun32";
-}) {
+{
+  # 4K screen, use bigger console font
+  # i18n.consoleFont deprecated and obsolete in >=20.03
+  # hardware-configuration.nix generates console.font
+  i18n.consoleFont = lib.mkIf (lib.versionOlder (lib.versions.majorMinor lib.version) "20.03") (lib.mkDefault "latarcyrheb-sun32");
   imports = [
     ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop


### PR DESCRIPTION
Removed setting console.font for >= 20.03
because the auto generated `hardware-configuration.nix` now sets:
```
  # High-DPI console
  console.font = lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-u28n.psf.gz";
```
Which cause the following error when also importing `<nixos-hardware/dell/xps/13-9360>`:
```
The option `console.font' has conflicting definitions, in 
`/etc/nixos/hardware-configuration.nix' and 
`/nix/var/nix/profiles/per-user/root/channels/nixos-hardware/dell/xps/13-9360'.
```
Closes #177 
