### PR TITLE
Add Asus TUF FX504GD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-NixOS profiles covering hardware quirks.
+NixOS profiles to optimize settings for different hardware.
 
 ## Setup
+
+### Using channels
 
 Add and update `nixos-hardware` channel:
 
@@ -20,7 +22,46 @@ imports = [
 ];
 ```
 
-## Incomplete list of Profiles
+New updates to the expressions here will be fetched when you update the channel.
+
+## Using nix flakes support
+
+There is also experimental flake support. In your `/etc/nixos/flake.nix` add the following:
+
+```nix
+{
+  description = "NixOS configuration with flakes";
+  inputs.nixos-hardware.url = github:NixOS/nixos-hardware/master;
+
+  outputs = { self, nixpkgs, nixos-hardware }: {
+    # replace <your-hostname> with your actual hostname
+    nixosConfigurations.<your-hostname> = nixpkgs.lib.nixosSystem {
+      # ...
+      modules = [
+        # ...
+        # add your model from this list: https://github.com/NixOS/nixos-hardware/blob/flakes/flake.nix
+        nixos-hardware.nixosModules.dell-xps-13-9380
+      ];
+    };
+  };
+}
+```
+
+
+### Using fetchgit
+
+You can fetch the git repository directly:
+
+```nix
+imports = [ 
+  "${builtins.fetchgit { url = "https://github.com/NixOS/nixos-hardware.git"; }}/lenovo/thinkpad/x220"
+];
+```
+
+Unlike the channel, this will update the git repository on a rebuild. However, 
+you can easily pin to a particular revision if you desire more stability.
+
+## List of Profiles
 
 See code for all available configurations.
 
@@ -33,10 +74,12 @@ See code for all available configurations.
 | Apple MacBook Air 6,X             | `<nixos-hardware/apple/macbook-air/6>`             |
 | [Apple MacBook Pro 10,1][]        | `<nixos-hardware/apple/macbook-pro/10-1>`          |
 | Apple MacBook Pro 12,1            | `<nixos-hardware/apple/macbook-pro/12-1>`          |
+| Asus TUF FX504GD                  | `<nixos-hardware/asus/fx504gd>`                    |
 | BeagleBoard PocketBeagle          | `<nixos-hardware/beagleboard/pocketbeagle>`        |
 | Dell Latitude 3480                | `<nixos-hardware/dell/latitude/3480>`              |
 | [Dell XPS E7240][]                | `<nixos-hardware/dell/e7240>`                      |
 | [Dell XPS 13 7390][]              | `<nixos-hardware/dell/xps/13-7390>`                |
+| [Dell XPS 13 9343][]              | `<nixos-hardware/dell/xps/13-9343>`                |
 | [Dell XPS 13 9360][]              | `<nixos-hardware/dell/xps/13-9360>`                |
 | [Dell XPS 13 9370][]              | `<nixos-hardware/dell/xps/13-9370>`                |
 | [Dell XPS 13 9380][]              | `<nixos-hardware/dell/xps/13-9380>`                |
@@ -45,6 +88,8 @@ See code for all available configurations.
 | [Dell XPS 15 9560][]              | `<nixos-hardware/dell/xps/15-9560>`                |
 | [Dell XPS 15 9560, intel only][]  | `<nixos-hardware/dell/xps/15-9560/intel>`          |
 | [Dell XPS 15 9560, nvidia only][] | `<nixos-hardware/dell/xps/15-9560/nvidia>`         |
+| [Dell XPS 15 9500][]              | `<nixos-hardware/dell/xps/15-9500>`                |
+| [Dell XPS 15 9500, nvidia][]      | `<nixos-hardware/dell/xps/15-9500/nvidia>`         |
 | [Google Pixelbook][]              | `<nixos-hardware/google/pixelbook>`                |
 | [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`           |
 | Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`             |
@@ -84,9 +129,11 @@ See code for all available configurations.
 | [Tuxedo InfinityBook v4][]        | `<nixos-hardware/tuxedo/infinitybook/v4>`          |
 
 [Acer Aspire 4810T]: acer/aspire/4810t
+[Asus TUF FX504GD]: asus/fx504gd
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1
 [Dell XPS E7240]: dell/e7240
 [Dell XPS 13 7390]: dell/xps/13-7390
+[Dell XPS 13 9343]: dell/xps/13-9343
 [Dell XPS 13 9360]: dell/xps/13-9360
 [Dell XPS 13 9370]: dell/xps/13-9370
 [Dell XPS 13 9380]: dell/xps/13-9380
@@ -104,7 +151,7 @@ See code for all available configurations.
 [Raspberry Pi 2]: raspberry-pi/2
 [Samsung Series 9 NP900X3C]: samsung/np900x3c
 [Purism Librem 13v3]: purism/librem/13v3
-[Purism Librem 13v5]: purism/librem/13v5
+[Purism Librem 15v5]: purism/librem/15v5
 [Toshiba Chromebook 2 `swanky`]: toshiba/swanky
 [Tuxedo InfinityBook v4]: nixos-hardware/tuxedo/infinitybook/v4
 

--- a/asus/fx504gd/default.nix
+++ b/asus/fx504gd/default.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  imports = [
+    ../../common/cpu/intel
+    ../../common/pc/laptop   
+  ];
+
+  #Nouveau doesn't work at all on this model.
+  boot.kernelParams = [ "nouveau.modeset=0" ];
+}

--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -3,11 +3,5 @@
 {
   imports = [ ../. ];
 
-  # TODO: fix in NixOS/nixpkgs
-  # Disable governor set in hardware-configuration.nix,
-  # required when services.tlp.enable is true:
-  powerManagement.cpuFreqGovernor =
-    lib.mkIf config.services.tlp.enable (lib.mkForce null);
-
   services.tlp.enable = lib.mkDefault true;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "nixos-hardware";
+
+  outputs = { self }: {
+    nixosModules = {
+      dell-aspire-4810t = import ./acer/aspire/4810t;
+      apple-macbook-air-3 = import ./apple/macbook-air/3;
+      apple-macbook-air-4 = import apple/macbook-air/4;
+      apple-macbook-air-6 = import apple/macbook-air/6;
+      apple-macbook-air-10-1 = import ./apple/macbook-pro/10-1;
+      apple-macbook-air-12-1 = import ./apple/macbook-pro/12-1;
+      asus-fx504gd = import ./asus/fx504gd;
+      beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
+      dell-latitude-3480 = import ./dell/latitude/3480;
+      dell-e7240 = import ./dell/e7240;
+      dell-xps-13-7390 = import ./dell/xps/13-7390;
+      dell-xps-13-9360 = import ./dell/xps/13-9360;
+      dell-xps-13-9370 = import ./dell/xps/13-9370;
+      dell-xps-13-9380 = import ./dell/xps/13-9380;
+      dell-xps-15-7590 = import ./dell/xps/15-7590;
+      dell-xps-15-9550 = import ./dell/xps/15-9550;
+      dell-xps-15-9560 = import ./dell/xps/15-9560;
+      dell-xps-15-9560-intel = import ./dell/xps/15-9560/intel;
+      dell-xps-15-9560-nvidia = import ./dell/xps/15-9560/nvidia;
+      dell-xps-15-9500 = import ./dell/xps/15-9500;
+      dell-xps-15-9500-nvidia = import ./dell/xps/15-9500/nvidia;
+      google-pixelbook = import ./google/pixelbook;
+      inversepath-usbarmory = import ./inversepath/usbarmory;
+      lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;
+      lenovo-thinkpad-e495 = import ./lenovo/thinkpad/e495;
+      lenovo-thinkpad-l13 = import ./lenovo/thinkpad/l13;
+      lenovo-thinkpad-p53 = import ./lenovo/thinkpad/p53;
+      lenovo-thinkpad-t410 = import ./lenovo/thinkpad/t410;
+      lenovo-thinkpad-t420 = import ./lenovo/thinkpad/t420;
+      lenovo-thinkpad-t430 = import ./lenovo/thinkpad/t430;
+      lenovo-thinkpad-t440s = import ./lenovo/thinkpad/t440s;
+      lenovo-thinkpad-t440p = import ./lenovo/thinkpad/t440p;
+      lenovo-thinkpad-t450s = import ./lenovo/thinkpad/t450s;
+      lenovo-thinkpad-t460s = import ./lenovo/thinkpad/t460s;
+      lenovo-thinkpad-t470s = import ./lenovo/thinkpad/t470s;
+      lenovo-thinkpad-t480s = import ./lenovo/thinkpad/t480s;
+      lenovo-thinkpad-t490 = import ./lenovo/thinkpad/t490;
+      lenovo-thinkpad-t495 = import ./lenovo/thinkpad/t495;
+      lenovo-thinkpad-x140e = import ./lenovo/thinkpad/x140e;
+      lenovo-thinkpad-x220 = import ./lenovo/thinkpad/x220;
+      lenovo-thinkpad-x230 = import ./lenovo/thinkpad/x230;
+      lenovo-thinkpad-x250 = import ./lenovo/thinkpad/x250;
+      lenovo-thinkpad-x260 = import ./lenovo/thinkpad/x260;
+      lenovo-thinkpad-x270 = import ./lenovo/thinkpad/x270;
+      lenovo-thinkpad-x280 = import ./lenovo/thinkpad/x280;
+      lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
+      lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
+      lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
+      microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
+      pcengines-apu = import ./pcengines/apu;
+      raspberry-pi-2 = import ./raspberry-pi/2;
+      samsung-np900x3c = import ./samsung/np900x3c;
+      purism-librem-13v3 = import ./purism/librem/13v3;
+      purism-librem-15v3 = import ./purism/librem/15v3;
+      supermicro-a1sri-2758f = import ./supermicro/a1sri-2758f;
+      supermicro-x10sll-f = import ./supermicro/x10sll-f;
+      thoshiba-swanky = import ./toshiba/swanky;
+      tuxedo-infinitybook-v4 = import ./tuxedo/infinitybook/v4;
+    };
+  };
+}


### PR DESCRIPTION
Request to add Asus TUF FX504GD to nixos-hardware channel.
Nouveau doesn't work at all on this laptop, so I add nouveau.modeset=0 as a kernel param.