### PR TITLE
Add support for System76 hardware, specifically the Darter Pro 6

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,4 @@ lenovo/thinkpad/x230 @makefu @yegortimoshenko
 lenovo/thinkpad/x250 @Mic92
 pcengines/apu @yegortimoshenko
 purism/librem/13v3 @yegortimoshenko
+system76/darp6 @khumba

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ See code for all available configurations.
 | [Purism Librem 15v3][]            | `<nixos-hardware/purism/librem/15v3>`              |
 | Supermicro A1SRi-2758F            | `<nixos-hardware/supermicro/a1sri-2758f>`          |
 | Supermicro X10SLL-F               | `<nixos-hardware/supermicro/x10sll-f>`             |
+| [System76 (generic)][]            | `<nixos-hardware/system76>`                        |
+| [System76 Darter Pro 6][]         | `<nixos-hardware/system76/darp6>`                  |
 | [Toshiba Chromebook 2 `swanky`][] | `<nixos-hardware/toshiba/swanky>`                  |
 | [Tuxedo InfinityBook v4][]        | `<nixos-hardware/tuxedo/infinitybook/v4>`          |
 
@@ -151,6 +153,8 @@ See code for all available configurations.
 [Microsoft Surface Pro 3]: microsoft/surface-pro/3
 [Raspberry Pi 2]: raspberry-pi/2
 [Samsung Series 9 NP900X3C]: samsung/np900x3c
+[System76 (generic)]: system76
+[System76 Darter Pro 6]: system76/darp6
 [Purism Librem 13v3]: purism/librem/13v3
 [Purism Librem 15v5]: purism/librem/15v5
 [Toshiba Chromebook 2 `swanky`]: toshiba/swanky

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
       pcengines-apu = import ./pcengines/apu;
       raspberry-pi-2 = import ./raspberry-pi/2;
       samsung-np900x3c = import ./samsung/np900x3c;
+      system76 = import ./system76;
+      system76-darp6 = import ./system76/darp6;
       purism-librem-13v3 = import ./purism/librem/13v3;
       purism-librem-15v3 = import ./purism/librem/15v3;
       supermicro-a1sri-2758f = import ./supermicro/a1sri-2758f;

--- a/system76/darp6/default.nix
+++ b/system76/darp6/default.nix
@@ -2,8 +2,20 @@
 #
 # https://system76.com/laptops/darter
 
-{ config, ... }:
+{ config, lib, options, pkgs, ... }:
 let
+  cfg = config.hardware.system76.darp6;
+
+  # Allow silencing the warning about these options if either is defined.
+  soundSettingsDefined =
+    options.hardware.system76.darp6.soundVendorId.isDefined ||
+    options.hardware.system76.darp6.soundSubsystemId.isDefined;
+
+  # We neeed both options non-null to be able to apply the headset fixup though.
+  soundSettingsAvailable =
+    soundSettingsDefined &&
+    (cfg.soundVendorId != null && cfg.soundSubsystemId != null);
+
   # darp6 needs system76-acpi-dkms, not system76-dkms:
   #
   # [1] https://github.com/pop-os/system76-dkms/issues/39
@@ -19,9 +31,73 @@ in
     ../../common/pc/laptop/ssd
   ];
 
-  boot.extraModulePackages = packages;
+  options.hardware.system76.darp6 = {
+    soundVendorId = lib.mkOption {
+      type = with lib.types; nullOr (strMatching "0x[0-9a-f]{8}");
+      description = ''
+        The vendor ID of the sound card PCI device, for applying the headset fixup.
+        This should be set to the value of the following file on your Darter Pro:
+            /sys/class/sound/hwC0D0/vendor_id
+        If this option has the default null value, then the headset fixup will
+        not be applied.
+      '';
+    };
+    soundSubsystemId = lib.mkOption {
+      type = with lib.types; nullOr (strMatching "0x[0-9a-f]{8}");
+      description = ''
+        The subsystem ID of the sound card PCI device, for applying the headset fixup.
+        This should be set to the value of the following file on your Darter Pro:
+            /sys/class/sound/hwC0D0/subsystem_id
+        If this option has the default null value, then the headset fixup will
+        not be applied.
+      '';
+    };
+  };
 
-  # system76_acpi automatically loads on darp6, but system76_io does not.
-  # Explicitly list all modules to be loaded, for consistency.
-  boot.kernelModules = map (drv: drv.moduleName) packages;
+  config = lib.mkMerge [
+    {
+      boot.extraModulePackages = packages;
+
+      # system76_acpi automatically loads on darp6, but system76_io does not.
+      # Explicitly list all modules to be loaded, for consistency.
+      boot.kernelModules = map (drv: drv.moduleName) packages;
+
+      warnings = lib.optional (!soundSettingsDefined) ''
+        For full Darter Pro support, set the options:
+        - hardware.system76.darp76.soundVendorId
+        - hardware.system76.darp76.soundSubsystemId
+        You can copy these values directly from:
+        - /sys/class/sound/hwC0D0/vendor_id
+        - /sys/class/sound/hwC0D0/subsystem_id
+        The headset audio fixup will not be applied without these values.
+        Set these options to null to silence this warning.
+      '';
+    }
+
+    # Apply the headset fixup patch from system76-driver, if the necessary
+    # options have been provided.
+    #
+    # See occurrences of "darp" in:
+    # https://github.com/pop-os/system76-driver/blob/master/system76driver/actions.py
+    # https://github.com/pop-os/system76-driver/blob/master/system76driver/products.py
+    (lib.mkIf soundSettingsAvailable {
+      boot.extraModprobeConfig = ''
+        options snd-hda-intel model=headset-mode-no-hp-mic patch=system76-audio-patch
+      '';
+
+      hardware.firmware = [
+        (pkgs.writeTextFile {
+          name = "system76-audio-patch";
+          destination = "/lib/firmware/system76-audio-patch";
+          text = ''
+            [codec]
+            ${cfg.soundVendorId} ${cfg.soundSubsystemId} 0
+
+            [pincfg]
+            0x1a 0x01a1913c
+          '';
+        })
+      ];
+    })
+  ];
 }

--- a/system76/darp6/default.nix
+++ b/system76/darp6/default.nix
@@ -1,0 +1,27 @@
+# Hardware profile for the Darter Pro 6 laptop by System76.
+#
+# https://system76.com/laptops/darter
+
+{ config, ... }:
+let
+  # darp6 needs system76-acpi-dkms, not system76-dkms:
+  #
+  # [1] https://github.com/pop-os/system76-dkms/issues/39
+  # jackpot51> system76-acpi-dkms is the correct driver to use on the darp6
+  #
+  # system76-io-dkms also appears to be loaded on darp6 with Pop!_OS, and
+  # system76-dkms does not, and in fact refuses to load.
+  packages = with config.boot.kernelPackages; [ system76-acpi system76-io ];
+in
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+  ];
+
+  boot.extraModulePackages = packages;
+
+  # system76_acpi automatically loads on darp6, but system76_io does not.
+  # Explicitly list all modules to be loaded, for consistency.
+  boot.kernelModules = map (drv: drv.moduleName) packages;
+}

--- a/system76/darp6/default.nix
+++ b/system76/darp6/default.nix
@@ -1,6 +1,14 @@
 # Hardware profile for the Darter Pro 6 laptop by System76.
 #
 # https://system76.com/laptops/darter
+#
+# Regarding kernel modules, darp6 needs system76-acpi-dkms, not system76-dkms:
+#
+# [1] https://github.com/pop-os/system76-dkms/issues/39
+# jackpot51> system76-acpi-dkms is the correct driver to use on the darp6
+#
+# system76-io-dkms also appears to be loaded on darp6 with Pop!_OS, and
+# system76-dkms does not, and in fact refuses to load.
 
 { config, lib, options, pkgs, ... }:
 let
@@ -15,18 +23,10 @@ let
   soundSettingsAvailable =
     soundSettingsDefined &&
     (cfg.soundVendorId != null && cfg.soundSubsystemId != null);
-
-  # darp6 needs system76-acpi-dkms, not system76-dkms:
-  #
-  # [1] https://github.com/pop-os/system76-dkms/issues/39
-  # jackpot51> system76-acpi-dkms is the correct driver to use on the darp6
-  #
-  # system76-io-dkms also appears to be loaded on darp6 with Pop!_OS, and
-  # system76-dkms does not, and in fact refuses to load.
-  packages = with config.boot.kernelPackages; [ system76-acpi system76-io ];
 in
 {
   imports = [
+    ../.
     ../../common/pc/laptop
     ../../common/pc/laptop/ssd
   ];
@@ -56,12 +56,6 @@ in
 
   config = lib.mkMerge [
     {
-      boot.extraModulePackages = packages;
-
-      # system76_acpi automatically loads on darp6, but system76_io does not.
-      # Explicitly list all modules to be loaded, for consistency.
-      boot.kernelModules = map (drv: drv.moduleName) packages;
-
       warnings = lib.optional (!soundSettingsDefined) ''
         For full Darter Pro support, set the options:
         - hardware.system76.darp76.soundVendorId

--- a/system76/default.nix
+++ b/system76/default.nix
@@ -2,21 +2,12 @@
 #
 # https://system76.com/
 
-{ config, ... }:
-let
-  # Try loading all system76 modules.  The ones not relevant to specific
-  # hardware won't be loaded.
-  packages = with config.boot.kernelPackages; [ system76 system76-acpi system76-io ];
-in
+{ config, lib, ... }:
 {
   imports = [ ../common/pc ];
 
   # This seems to be required for system76-driver.
   boot.kernelParams = [ "ec_sys.write_support=1" ];
 
-  boot.extraModulePackages = packages;
-
-  # Explicitly attempt to load all available system76 modules.  Some do
-  # (system76-acpi), some don't (system76-io).
-  boot.kernelModules = map (drv: drv.moduleName) packages;
+  hardware.system76.enableAll = lib.mkDefault true;
 }

--- a/system76/default.nix
+++ b/system76/default.nix
@@ -1,0 +1,22 @@
+# Implementation of support for general System76 hardware.
+#
+# https://system76.com/
+
+{ config, ... }:
+let
+  # Try loading all system76 modules.  The ones not relevant to specific
+  # hardware won't be loaded.
+  packages = with config.boot.kernelPackages; [ system76 system76-acpi system76-io ];
+in
+{
+  imports = [ ../common/pc ];
+
+  # This seems to be required for system76-driver.
+  boot.kernelParams = [ "ec_sys.write_support=1" ];
+
+  boot.extraModulePackages = packages;
+
+  # Explicitly attempt to load all available system76 modules.  Some do
+  # (system76-acpi), some don't (system76-io).
+  boot.kernelModules = map (drv: drv.moduleName) packages;
+}

--- a/system76/default.nix
+++ b/system76/default.nix
@@ -6,8 +6,5 @@
 {
   imports = [ ../common/pc ];
 
-  # This seems to be required for system76-driver.
-  boot.kernelParams = [ "ec_sys.write_support=1" ];
-
   hardware.system76.enableAll = lib.mkDefault true;
 }


### PR DESCRIPTION
This integrates the System76 hardware support at https://github.com/stites/system76-nixos into this repo.  @stites did the bulk of the work in that repo, and I added support for the Darter Pro.

This PR *only* includes the kernel modules for now, along with some NixOS options for controlling which modules are enabled.  These kernel modules are needed for multimedia keys and keyboard backlights to work on System76's laptops.  System76 provides also some daemons and tools for hardware management, and some of these are included in the other repo, but I haven't had the time/need/interest use them yet.

I have the darp6 and all hardware works, with the two `system76-acpi` and `system76-io` modules.  I can't personally test the `system76` module as my laptop doesn't need it, but I'm including it with minimal changes from @stites's repo on the assumption that it still works fine (though I'm bumping the version from 1.0.6 to 1.0.9, and dropping the initramfs-tools files from all of the kernel module packages, since they appear unused).

@stites: The license on your repo is BSD-3, and the license on this repo is CC0.  Are you okay with including your code here?  I see that your readme says that you intend to move things over, but we should get an explicit ACK from you on the license change before merging this.

Thanks!