### PR TITLE
permit to access config in common/ via the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,18 @@
       supermicro-x10sll-f = import ./supermicro/x10sll-f;
       thoshiba-swanky = import ./toshiba/swanky;
       tuxedo-infinitybook-v4 = import ./tuxedo/infinitybook/v4;
+      common-cpu-amd = import ./common/cpu/amd;
+      common-cpu-intel = import ./common/cpu/intel;
+      common-cpu-intel-kaby-lake = import ./common/cpu/intel/kaby-lake;
+      common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;
+      common-gpu-nvidia = import ./common/gpu/nvidia.nix;
+      common-pc-hdd = import ./common/pc/hdd;
+      common-pc-laptop-hdd = import ./common/pc/laptop/hdd;
+      common-pc-laptop-ssd = import ./common/pc/ssd;
+      common-pc-laptop-acpi_call = import ./common/pc/laptop/acpi_call.nix;
+      common-pc-laptop = import ./common/pc/laptop;
+      common-pc-ssd = import ./common/pc/ssd;
+      common-pc = import ./common/pc;
     };
   };
 }


### PR DESCRIPTION
I wished to simplify my nix expression of my system, and I wanted to be able to do this quickly (without having to make change in this repo, as I mainly wanted the common/gpu/nvidia option to replace the code I copied from the nixos wiki). I decided to use flake, but I couldn't find a way to call the common/gpu/nvidia.nix file. I decided to add the other module in common/ too, for those who are interested by that. I will probably add a module for my laptop soon, btw.