### PR TITLE
Add support for the Lenovo Thinkpad L14 (AMD) laptop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ See code for all available configurations.
 | Lenovo ThinkPad E470              | `<nixos-hardware/lenovo/thinkpad/e470>`
 | Lenovo ThinkPad E495              | `<nixos-hardware/lenovo/thinkpad/e495>`            |
 | Lenovo ThinkPad L13               | `<nixos-hardware/lenovo/thinkpad/l13>`             |
+| Lenovo ThinkPad L14 (Intel)       | `<nixos-hardware/lenovo/thinkpad/l14/intel>        |
+| Lenovo ThinkPad L14 (AMD)         | `<nixos-hardware/lenovo/thinkpad/l14/amd>          |
 | Lenovo ThinkPad P53               | `<nixos-hardware/lenovo/thinkpad/p53>`             |
 | Lenovo ThinkPad T410              | `<nixos-hardware/lenovo/thinkpad/t410>`            |
 | Lenovo ThinkPad T420              | `<nixos-hardware/lenovo/thinkpad/t420>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
       lenovo-thinkpad-e470 = import ./lenovo/thinkpad/e470;
       lenovo-thinkpad-e495 = import ./lenovo/thinkpad/e495;
       lenovo-thinkpad-l13 = import ./lenovo/thinkpad/l13;
+      lenovo-thinkpad-l14-intel = import ./lenovo/thinkpad/l14/intel;
+      lenovo-thinkpad-l14-amd = import ./lenovo/thinkpad/l14/amd;
       lenovo-thinkpad-p53 = import ./lenovo/thinkpad/p53;
       lenovo-thinkpad-t410 = import ./lenovo/thinkpad/t410;
       lenovo-thinkpad-t420 = import ./lenovo/thinkpad/t420;

--- a/lenovo/thinkpad/l14/amd/default.nix
+++ b/lenovo/thinkpad/l14/amd/default.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../common/cpu/amd
+  ];
+
+  boot.kernelParams = [
+    # With BIOS version 1.12 and the IOMMU enabled, the amdgpu driver
+    # either crashes or is not able to attach to the GPU depending on
+    # the kernel version. I've seen no issues with the IOMMU disabled.
+    "iommu=off"
+  ];
+
+  # As of writing this, Linux 5.8 is the oldest kernel that is still
+  # supported and has decent Renoir support.
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.8") pkgs.linuxPackages_latest;
+}

--- a/lenovo/thinkpad/l14/default.nix
+++ b/lenovo/thinkpad/l14/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../common/pc/laptop/acpi_call.nix
+  ];
+
+  boot.kernelParams = [
+    # Force use of the thinkpad_acpi driver for backlight control.
+    # This allows the backlight save/load systemd service to work.
+    "acpi_backlight=native"
+  ];
+}

--- a/lenovo/thinkpad/l14/intel/default.nix
+++ b/lenovo/thinkpad/l14/intel/default.nix
@@ -1,0 +1,10 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../common/cpu/intel
+  ];
+
+  services.throttled.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
This PR adds support for the Lenovo Thinkpad L14 Gen 1 laptop with AMD Ryzen CPU (Renoir).

I'm not 100% sure where to put the module. If some one has a better idea than `l14-amd` I'm all ears. Should it be `l14/amd` instead?
