### PR TITLE
t14s: fix minimum kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ See code for all available configurations.
 | Lenovo ThinkPad L14 (AMD)         | `<nixos-hardware/lenovo/thinkpad/l14/amd>          |
 | Lenovo ThinkPad P53               | `<nixos-hardware/lenovo/thinkpad/p53>`             |
 | Lenovo ThinkPad T14s              | `<nixos-hardware/lenovo/thinkpad/t14s>`            |
+| Lenovo ThinkPad T14s AMD Gen 1    | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`   |
 | Lenovo ThinkPad T410              | `<nixos-hardware/lenovo/thinkpad/t410>`            |
 | Lenovo ThinkPad T420              | `<nixos-hardware/lenovo/thinkpad/t420>`            |
 | Lenovo ThinkPad T430              | `<nixos-hardware/lenovo/thinkpad/t430>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
       lenovo-thinkpad-l14-amd = import ./lenovo/thinkpad/l14/amd;
       lenovo-thinkpad-p53 = import ./lenovo/thinkpad/p53;
       lenovo-thinkpad-t14s = import ./lenovo/thinkpad/t14s;
+      lenovo-thinkpad-t14s-amd-gen1 = import ./lenovo/thinkpad/t14s/amd/gen1;
       lenovo-thinkpad-t410 = import ./lenovo/thinkpad/t410;
       lenovo-thinkpad-t420 = import ./lenovo/thinkpad/t420;
       lenovo-thinkpad-t430 = import ./lenovo/thinkpad/t430;

--- a/lenovo/thinkpad/t14s/amd/default.nix
+++ b/lenovo/thinkpad/t14s/amd/default.nix
@@ -1,0 +1,11 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../common/cpu/amd
+  ];
+
+  # For support of newer AMD GPUs, backlight and internal microphone
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.8") pkgs.linuxPackages_latest;
+}

--- a/lenovo/thinkpad/t14s/amd/gen1/default.nix
+++ b/lenovo/thinkpad/t14s/amd/gen1/default.nix
@@ -1,0 +1,8 @@
+
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+  ];
+}

--- a/lenovo/thinkpad/t14s/default.nix
+++ b/lenovo/thinkpad/t14s/default.nix
@@ -7,6 +7,11 @@
     ../../../common/pc/laptop/acpi_call.nix
   ];
 
+  # For suspending to RAM to work, set Config -> Power -> Sleep State to "Linux" in EFI.
+  # See https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X1_Carbon_(Gen_6)#Suspend_issues
+
+  # Fingerprint sensor requires a firmware-update to work.
+
   # Force use of the thinkpad_acpi driver for backlight control.
   # This allows the backlight save/load systemd service to work.
   boot.kernelParams = [ "acpi_backlight=native" ];

--- a/lenovo/thinkpad/t14s/default.nix
+++ b/lenovo/thinkpad/t14s/default.nix
@@ -3,7 +3,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/amd
     ../../../common/pc/laptop/acpi_call.nix
   ];
 


### PR DESCRIPTION
Adds special settings for AMD models. linuxPackages 5.8 is currently only available in 20.09, but is required for backlight and microphone to work. The graphics chipset should work with older kernels (reportedly also 5.4), but this is untested.

There is some manual work required to get suspend and the fingerprint sensor to work, so I left a comment, in the hopes that it may be found. It's probably infeasible to put a warning, since the firmware version and UEFI settings are hard to detect from nix.