### PR TITLE
t14s: removed amd import for general profile

### DIFF
--- a/lenovo/thinkpad/t14s/default.nix
+++ b/lenovo/thinkpad/t14s/default.nix
@@ -3,7 +3,6 @@
 {
   imports = [
     ../.
-    ../../../common/cpu/amd
     ../../../common/pc/laptop/acpi_call.nix
   ];
 


### PR DESCRIPTION
t14s are coming in intel and amd, i guess there should split like in here:

https://github.com/NixOS/nixos-hardware/tree/master/lenovo/thinkpad/l14