### PR TITLE
macbook: added option for swapped cmd and opt

### DIFF
--- a/apple/README.md
+++ b/apple/README.md
@@ -1,0 +1,11 @@
+## Switching Cmd and Alt/AltGr
+
+This will switch the left Alt and Cmd key as well as the right Alt/AltGr and Cmd key. 
+
+```nix
+boot.kernelParams = [
+  "hid_apple.swap_opt_cmd=1"
+];
+```
+
+Reference: https://wiki.archlinux.org/index.php/Apple_Keyboard#Switching_Cmd_and_Alt/AltGr

--- a/apple/default.nix
+++ b/apple/default.nix
@@ -2,6 +2,7 @@
 
 {
   boot.kernelParams = [
+    "hid_apple.swap_opt_cmd=1"
     "hid_apple.iso_layout=0"
   ];
 

--- a/apple/default.nix
+++ b/apple/default.nix
@@ -2,7 +2,6 @@
 
 {
   boot.kernelParams = [
-    "hid_apple.swap_opt_cmd=1"
     "hid_apple.iso_layout=0"
   ];
 


### PR DESCRIPTION
not 100% sure it should be default, as technically cmd is a super key, but being accustomed to PC keyboard layout I think it might easily be default.

ref: https://wiki.archlinux.org/index.php/Apple_Keyboard#Switching_Cmd_and_Alt/AltGr

