### PR TITLE
lenovo/thinkpad/x260: use services.tlp.settings

### DIFF
--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -6,7 +6,7 @@
   ];
 
   # https://wiki.archlinux.org/index.php/TLP#Btrfs
-  services.tlp.extraConfig = ''
-    SATA_LINKPWR_ON_BAT=med_power_with_dipm
-  '';
+  services.tlp.settings = {
+    SATA_LINKPWR_ON_BAT = "med_power_with_dipm";
+  };
 }


### PR DESCRIPTION
With switching from NixOS 20.03 to 20.09, the `services.tlp.extraConfig` option became deprecated and was replaced by `services.tlp.settings`.

The ThinkPad X260 is only device within `nixos-hardware` which makes use of this configuration.