### PR TITLE
lenovo/thinkpad/x260: i915.enable_psr=0 parameter

### DIFF
--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -5,6 +5,11 @@
     ../../../common/pc/laptop/acpi_call.nix
   ];
 
+  boot.kernelParams = [
+    # https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X260#Thinkpad_X260
+    "i915.enable_psr=0"
+  ];
+
   # https://wiki.archlinux.org/index.php/TLP#Btrfs
   services.tlp.extraConfig = ''
     SATA_LINKPWR_ON_BAT=med_power_with_dipm


### PR DESCRIPTION
The video driver causes short freezes from time to time, especially if an external monitor is attached. Adding the `i915.enable_psr=0` kernel parameter mitigates those freezes.

This is a known problem for the X260, as mentioned in the [Arch Wiki](https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X260#Thinkpad_X260). It occurred mainly after switching to kernel version five.