### PR TITLE
apple/macbook-pro/12-1: PM: set cpuFreqGovernor and power Up/Down commands

### DIFF
--- a/apple/macbook-pro/12-1/README.md
+++ b/apple/macbook-pro/12-1/README.md
@@ -1,0 +1,14 @@
+# MacBook Pro 12,1
+
+## Wireless won't get reconnected after resume/hibernate
+
+As an example similar code could be used to restart wireless interface:
+
+```nix
+powerManagement.powerUpCommands = ''
+  ${pkgs.systemd}/bin/systemctl restart wpa_supplicant.service
+'';
+};
+```
+
+You can apply this to your network management software of choice.

--- a/apple/macbook-pro/12-1/README.md
+++ b/apple/macbook-pro/12-1/README.md
@@ -2,7 +2,8 @@
 
 ## Wireless won't get reconnected after resume/hibernate
 
-As an example similar code could be used to restart wireless interface:
+The wifi driver is unloaded before suspend/hibernate to workaround driver issues.
+This means it might be required to restart your wifi deamon i.e. wpa_supplicant:
 
 ```nix
 powerManagement.powerUpCommands = ''

--- a/apple/macbook-pro/12-1/default.nix
+++ b/apple/macbook-pro/12-1/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 {
   imports = [
@@ -6,6 +6,17 @@
     ../../../common/pc/laptop/ssd
     <nixpkgs/nixos/modules/hardware/network/broadcom-43xx.nix>
   ];
+
+  powerManagement = {
+    # enable gradually increasing/decreasing CPU frequency, rather than using
+    # "powersave", which would keep CPU frequency at 0.8GHz.
+    cpuFreqGovernor = lib.mkDefault "conservative";
+
+    # brcmfmac being loaded during hibernation would not let a successful resume
+    # https://bugzilla.kernel.org/show_bug.cgi?id=101681#c116
+    powerUpCommands = lib.mkBefore "${pkgs.kmod}/bin/modprobe brcmfmac";
+    powerDownCommands = lib.mkBefore "${pkgs.kmod}/bin/rmmod brcmfmac";
+  };
 
   # USB subsystem wakes up MBP right after suspend unless we disable it.
   services.udev.extraRules = lib.mkDefault ''


### PR DESCRIPTION
fixes #211.
fixes #210.

Added default CPU governor "conservative" to enable gradually increasing/decreasing CPU freq, rather than using "powersave", which would keep CPU freq at 0.8Ghz.

 Added power Up/Down PM commands which will unload and load brcmfmac on state change. This is not elegant way, to say the least.