### PR TITLE
dell/g3/3779: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ See code for all available configurations.
 | Apple MacBook Pro 12,1            | `<nixos-hardware/apple/macbook-pro/12-1>`          |
 | Asus TUF FX504GD                  | `<nixos-hardware/asus/fx504gd>`                    |
 | BeagleBoard PocketBeagle          | `<nixos-hardware/beagleboard/pocketbeagle>`        |
+| [Dell G3 3779][]                  | `<nixos-hardware/dell/g3/3779>`                    |
 | Dell Latitude 3480                | `<nixos-hardware/dell/latitude/3480>`              |
 | Dell Precision 5530               | `<nixos-hardware/dell/precision/5530>`             |
 | [Dell XPS E7240][]                | `<nixos-hardware/dell/e7240>`                      |
@@ -139,6 +140,7 @@ See code for all available configurations.
 [Acer Aspire 4810T]: acer/aspire/4810t
 [Asus TUF FX504GD]: asus/fx504gd
 [Apple MacBook Pro 10,1]: apple/macbook-pro/10-1
+[Dell G3 3779]: dell/g3/3779
 [Dell XPS E7240]: dell/e7240
 [Dell XPS 13 7390]: dell/xps/13-7390
 [Dell XPS 13 9343]: dell/xps/13-9343

--- a/dell/g3/3779/default.nix
+++ b/dell/g3/3779/default.nix
@@ -1,0 +1,24 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # Specify bus id of Nvidia and Intel graphics
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+
+  # Cooling management
+  services.thermald.enable = lib.mkDefault true;
+
+  # Use same ACPI identifier as Dell Ubuntu
+  boot.kernelParams = [
+    "acpi_osi=Linux-Dell-Video"
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       apple-macbook-air-10-1 = import ./apple/macbook-pro/10-1;
       apple-macbook-air-12-1 = import ./apple/macbook-pro/12-1;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
+      dell-g3-3779 = import ./dell/g3/3779;
       dell-latitude-3480 = import ./dell/latitude/3480;
       dell-precision-5530 = import ./dell/precision/5530;
       dell-e7240 = import ./dell/e7240;


### PR DESCRIPTION
Add initial support for the Dell G3 3779.

This laptop runs NixOS fine with Nvidia PRIME offload.

Regards,