### PR TITLE
lenovo/thinkpad/l14/amd: update iommu comment

### DIFF
--- a/lenovo/thinkpad/l14/amd/default.nix
+++ b/lenovo/thinkpad/l14/amd/default.nix
@@ -10,6 +10,10 @@
     # With BIOS version 1.12 and the IOMMU enabled, the amdgpu driver
     # either crashes or is not able to attach to the GPU depending on
     # the kernel version. I've seen no issues with the IOMMU disabled.
+    #
+    # BIOS version 1.13 claims to fix IOMMU issues, but we leave the
+    # IOMMU off to avoid a sad experience for those people that drew
+    # the short straw when they bought their laptop.
     "iommu=off"
   ];
 


### PR DESCRIPTION
I've updated the comment about disabling the IOMMU to refer to the new BIOS version that claims to fix issues. There is no functional change here, but the comment should guide people to the right place if they really want the IOMMU to be enabled.