### PR TITLE
raspberry-2: remove console.extraTTYs

### DIFF
--- a/raspberry-pi/2/default.nix
+++ b/raspberry-pi/2/default.nix
@@ -1,8 +1,5 @@
 { lib, pkgs, ...}:
 
-let
-  hasConsoleExtraTTYs = lib.versionAtLeast (lib.versions.majorMinor lib.version) "21.03";
-in
 {
   boot = {
     consoleLogLevel = lib.mkDefault 7;
@@ -21,10 +18,7 @@ in
         version = lib.mkDefault 2;
       };
     };
-    extraTTYs = lib.mkIf (!hasConsoleExtraTTYs) [ "ttyAMA0" ];
   };
-
-  console.extraTTYs = lib.mkIf hasConsoleExtraTTYs [ "ttyAMA0" ];
 
   nix.buildCores = 4;
 


### PR DESCRIPTION
This option is no longer needed. Also remove boot.extraTTYs since
NixOS is older than 20.03 is no longer supported.