### PR TITLE
microsoft-surface: add surface-control

### DIFF
--- a/microsoft/surface/README.md
+++ b/microsoft/surface/README.md
@@ -42,7 +42,11 @@ kernel-space driver into events for the HID / input sub-system.
 
 ### DTX, `surface-control`
 
-*TODO*
+#### surface-control
+
+For controlling the performance modes and other aspects of the device, the [`surface-control`](https://github.com/linux-surface/surface-control) tool is included.
+
+To be able to control the performance mode without using `sudo`, add your user to the `surface-control` group.
 
 # ToDo's Not Done
 

--- a/microsoft/surface/default.nix
+++ b/microsoft/surface/default.nix
@@ -1,5 +1,6 @@
 { config, lib, pkgs, ... }: {
-  imports = [ ./kernel ./firmware ./hardware_configuration.nix ];
+  imports =
+    [ ./kernel ./hardware_configuration.nix ./firmware/surface-go/ath10k ];
 
   environment.systemPackages = with pkgs; [ surface-control ];
   users.groups.surface-control = { };

--- a/microsoft/surface/default.nix
+++ b/microsoft/surface/default.nix
@@ -1,8 +1,7 @@
-{ config, lib, pkgs, ... }:
-{
-  imports = [
-    ./kernel
-    ./firmware
-    ./hardware_configuration.nix
-  ];
+{ config, lib, pkgs, ... }: {
+  imports = [ ./kernel ./firmware ./hardware_configuration.nix ];
+
+  environment.systemPackages = with pkgs; [ surface-control ];
+  users.groups.surface-control = {};
+  services.udev.packages = [ pkgs.surface-control ];
 }

--- a/microsoft/surface/default.nix
+++ b/microsoft/surface/default.nix
@@ -2,6 +2,6 @@
   imports = [ ./kernel ./firmware ./hardware_configuration.nix ];
 
   environment.systemPackages = with pkgs; [ surface-control ];
-  users.groups.surface-control = {};
+  users.groups.surface-control = { };
   services.udev.packages = [ pkgs.surface-control ];
 }


### PR DESCRIPTION
This adds [surface-control](https://github.com/linux-surface/surface-control), a command line tool to control various aspects of the Microsoft Surface line of devices from the command line.

This PR depends on https://github.com/NixOS/nixpkgs/pull/111690, and is a draft until it is merged.