### PR TITLE
mpb15-1: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See code for all available configurations.
 | Apple MacBook Air 6,X             | `<nixos-hardware/apple/macbook-air/6>`             |
 | [Apple MacBook Pro 10,1][]        | `<nixos-hardware/apple/macbook-pro/10-1>`          |
 | Apple MacBook Pro 12,1            | `<nixos-hardware/apple/macbook-pro/12-1>`          |
+| Apple MacBook Pro 15,1            | `<nixos-hardware/apple/macbook-pro/15-1>`          |
 | Asus TUF FX504GD                  | `<nixos-hardware/asus/fx504gd>`                    |
 | BeagleBoard PocketBeagle          | `<nixos-hardware/beagleboard/pocketbeagle>`        |
 | [Dell G3 3779][]                  | `<nixos-hardware/dell/g3/3779>`                    |

--- a/apple/README.md
+++ b/apple/README.md
@@ -1,6 +1,61 @@
+## Macbooks with T2 chips (15 and later)
+
+# builtin wifi
+
+There's currently no existing firmware for Macbooks containing the new T2 chips.
+When installing NixOs you'll need to rely on 3rd party hardware (ex. usb-c -> ethernet unit).
+
+To get the builtin wifi running, make sure you store the firmware specific to your macbook
+as is described here: https://gist.github.com/TRPB/437f663b545d23cc8a2073253c774be3#wifi
+
+If you already formatted your osx partition (like I did), you can probably still access
+the wifi with trial and error using the firmware uploaded here https://packages.aunali1.com/apple/wifi-fw/18G2022/C-4364__s-B2
+
+To apply the firmware to your NixOs, I did the following which can be modified matching your machine and your firmware
+
+```nix
+{ stdenv,lib, fetchurl }:
+
+let clm_blob = fetchurl {
+      url = "https://packages.aunali1.com/apple/wifi-fw/18G2022/C-4364__s-B2/maui.clmb";
+      sha256 = "0c626zskm6yx3dxpvhx0q6j1hsvqwxdwm6nif3kkfahyfx69glny";
+    };
+    apple_txt = fetchurl {
+      url = "https://packages.aunali1.com/apple/wifi-fw/18G2022/C-4364__s-B2/P-midway-ID_M-HRPN_V-m__m-7.7.txt";
+      sha256 = "01nxmcds26aanvwmpjxwh0kk9i3l7v3gh25qrmy58cmw4mwxhsa5";
+    };
+
+in stdenv.mkDerivation {
+
+  name = "brcmfmac4364-firmware";
+
+  src = fetchurl {
+      url = "https://packages.aunali1.com/apple/wifi-fw/18G2022/C-4364__s-B2/maui.trx";
+      sha256 = "0n4jz3g5mxrn8vzyfb905gjpir9xdxglb33f0p68s4wm4szw04m3";
+    };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/lib/firmware/brcm
+    cp $src $out/lib/firmware/brcm/brcmfmac4364-pcie.bin
+    cp ${clm_blob} $out/lib/firmware/brcm/brcmfmac4364-pcie.clm_blob
+    cp ${apple_txt} $out/lib/firmware/brcm/brcmfmac4364-pcie.Apple\ Inc.-MacBookPro15,1.txt
+  '';
+
+}
+```
+
+then add it to your hardware configuration
+
+```nix
+hardware.firmware = [ (pkgs.callPackage ./brcmfmac4364.nix {}) ];
+```
+
+
 ## Switching Cmd and Alt/AltGr
 
-This will switch the left Alt and Cmd key as well as the right Alt/AltGr and Cmd key. 
+This will switch the left Alt and Cmd key as well as the right Alt/AltGr and Cmd key.
 
 ```nix
 boot.kernelParams = [
@@ -9,3 +64,25 @@ boot.kernelParams = [
 ```
 
 Reference: https://wiki.archlinux.org/index.php/Apple_Keyboard#Switching_Cmd_and_Alt/AltGr
+
+## Switching far-left fn with ctrl
+
+```nix
+boot.kernelParams = [
+  "hid_apple.swap_fn_leftctrl=1"
+];
+```
+
+## Making function keys default instead of media keys in TouchBar
+
+```nix
+boot.kernelParams = [
+  "hid_apple.fnmode=2"
+];
+```
+
+## Debugging hid_apple
+
+Depending on your kernel version and or patches, some kernel parameters may not work.
+See which parameters your system has with `ls /sys/module/hid_apple/parameters/`
+and if any problems related to those parameters appear in `# dmsg`.

--- a/apple/kernel-modules/bridge-drv.nix
+++ b/apple/kernel-modules/bridge-drv.nix
@@ -1,0 +1,40 @@
+{ pkgs, kernel }:
+
+pkgs.stdenv.mkDerivation rec {
+  name = "mbp-bridge";
+  version = "b43fcc069da73e051072fde24af4014c9c487286";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "MCMrARM";
+    repo = "mbp2018-bridge-drv";
+    rev = version;
+    sha256 = "0ac2l51ybfrvg8m36x67rsvgjqs1vwp7c89ssvbjkrcq3y4qdb53";
+  };
+
+  sourceRoot = "source";
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  postUnpack = ''
+    chmod -R +rw source
+  '';
+
+  buildPhase = ''
+    echo 'obj-m += bce.o
+bce-objs := pci.o mailbox.o queue.o queue_dma.o vhci/vhci.o vhci/queue.o vhci/transfer.o audio/audio.o audio/protocol.o audio/protocol_bce.o audio/pcm.o' > Makefile
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+      M=$(pwd) modules
+  '';
+
+  installPhase = ''
+   mkdir -p $out/lib/modules/${kernel.modDirVersion}
+   cp *.ko $out/lib/modules/${kernel.modDirVersion}
+  '';
+
+}

--- a/apple/macbook-pro/15-1/README.md
+++ b/apple/macbook-pro/15-1/README.md
@@ -1,0 +1,22 @@
+# Grub setup
+
+Here's a grub setup that worked for me.
+
+
+```nix
+  boot.loader = {
+    grub = {
+      device = "nodev";
+      gfxmodeEfi = "1024x768";
+      efiSupport = true;
+      efiInstallAsRemovable = true;
+    };
+    efi.efiSysMountPoint = "/boot";
+  };
+```
+
+For dual boot, you may be able to
+share darwin's bootloader under /boot/EFI as is
+shown here: https://github.com/gilescope/dotgiles/blob/b59280ca0056c8ad93ae8330241671a3ba15e0c8/configuration.nix
+But since it's an older mbp version with T1, the mbp15x(T2) may need to be
+configured differently.

--- a/apple/macbook-pro/15-1/default.nix
+++ b/apple/macbook-pro/15-1/default.nix
@@ -1,0 +1,46 @@
+{ lib, pkgs, ... }:
+
+let
+  bridge-drv = pkgs.callPackage ../../kernel-modules/bridge-drv.nix {
+    inherit pkgs;
+    kernel = pkgs.linuxPackages_latest.kernel;
+  };
+in
+
+{
+
+  # it is absolutely crucial that these are false
+  # otherwise the bootloader disfunctions
+  # causing kernel panic and infinite loop
+  boot.loader.systemd-boot.enable = false;
+  boot.loader.efi.canTouchEfiVariables = false;
+
+  # iwd is the only backend known to work
+  networking.wireless.iwd.enable = true;
+  networking.networkmanager.wifi.backend = "iwd";
+
+  # prevent false detection of built-in ethernet
+  # causing a 90 sec wait job on startup
+  networking.interfaces.enp2s0f1u1.useDHCP = false;
+
+  # if built-in wifi is set up, it should appear as wlan0
+  networking.interfaces.wlan0.useDHCP = true;
+
+  # required to get the keyboard working before startup
+  boot.initrd.kernelModules = [ "bce" ];
+
+  # prevent system being stuck on boot (not always needed?)
+  # https://gist.github.com/TRPB/437f663b545d23cc8a2073253c774be3#gistcomment-3055646
+  boot.blacklistedKernelModules = [ "thunderbolt" ];
+
+  # needed to get basic trackpad support
+  # adds the "bce" kernel module
+  boot.extraModulePackages = [ bridge-drv ];
+
+  # needed to get suspend working
+  boot.kernelParams = [
+    "pcie_ports=compat"
+    "acpi_mask_gpe=0x6e" # forgot why this was needed
+  ];
+
+}


### PR DESCRIPTION
This is my first PR to this repo, so I'm not sure what and what not to include. I also want to add that I'm still working on getting suspend and TouchBar working properly, I will follow up with those changes later, as well as a fix for mbpfan which needs a patch for the bus-id. I'll also add that later.

But important fact here I'm not including and I need an opinion about how to approach that. Which is that it's almost without exception, a requirement to use the archlinux's kernel patches https://github.com/aunali1/linux-mbp-arch, which I applied successfully like this. Note that I ignore 1 patch because it was merged upstream to the kernel (I expect most of these to be merged into the kernel, but I'm not 100% sure).


```nix
kernelPatches = (let
      src = (pkgs.fetchFromGitHub {
        owner = "aunali1";
        repo = "linux-mbp-arch";
        rev = "60cef373c14ba6a7b35d0af67d04dce7eb604f2e";
        sha256 = "11a75jiak14b2nyx283c39gry1xi57klsi6mjzljxliaih2agqqc";
       });
      items = with builtins;
      (filter (i:
        (match ".*\.patch$" i != null) &&
	# already merged https://github.com/torvalds/linux/commit/81a86e1bd8e7060ebba1718b284d54f1238e9bf9
        (match ".*0003-iwlwifi.*" i == null))
        (attrNames (readDir src)));
      patches = map (i: {name = i; patch = (pkgs.writeTextFile {name = i; text = builtins.readFile "${src}/${i}";});}) items;
      in (patches)
    );
    
```

One option would be to just document it. Or add it to nixpkgs, in which case I'd worry if these patches would cause problem for non mbp users.

Also the test is failing because of `boot.loader.systemd-boot.enable = false;` 

```
The option `boot.loader.systemd-boot.enable' has conflicting definition values:
- In `<unknown-file>': true
- In `/home/hlolli/nixos-hardware/apple/macbook-pro/15-1': false
```

Would it be ok to remove https://github.com/NixOS/nixos-hardware/blob/9c952961f1f1a643b8b8e5d4efab6717afec1bbe/tests/build-profile.nix#L5 (I think it's from there?).