### PR TITLE
ThinkPad X270: Disable Panel Self Refresh

### DIFF
--- a/lenovo/thinkpad/x270/default.nix
+++ b/lenovo/thinkpad/x270/default.nix
@@ -3,4 +3,9 @@
     ../.
     ../../../common/cpu/intel
   ];
+
+  boot.kernelParams = [
+    # Disable "Panel Self Refresh".  Fix random freezes.
+    "i915.enable_psr=0"
+  ];
 }


### PR DESCRIPTION
Disable "Panel Self Refresh" for ThinkPad X270.  Fix random screen freezes.

I own a ThinkPad X270.  This has been verified on my device.