### PR TITLE
Add support for Macbook(2,1)

### DIFF
--- a/apple/macbook-pro/2-2/README.md
+++ b/apple/macbook-pro/2-2/README.md
@@ -1,0 +1,46 @@
+# Apple MacBook Pro 2,2
+
+This hardware has some challenging quirks requiring workarounds documented below. Before you get started, have a look over Andreas Baumann's detailed post [Archlinux on a MacBook Pro 15'' Model A1211](http://www.andreasbaumann.cc/blog/archlinux-macbook-a1211/) to get a sense of what is involved.
+
+This guide assumes you want a 64-bit OS booted via UEFI, but the 32 bit EFI is only a problem for 64-bit OSes, and the Radeon vBIOS is only missing in EFI mode, so if you are willing to settle for 32 bit and MBR you can avoid those issues. Just be aware that attempting to set a graphical mode during install will still crash due to mising vbios because you will be booted in EFI mode. Use a text-only install method.
+
+## 32 Bit UEFI
+
+Apple's late-2006 machines run a 32-bit EFI firmware which won't boot 64-bit EFI programs. You will need to modify your install image to boot BIOS-only, and make sure to install a 32bit EFI bootloader (which this include does). See [/common/pc/uefi32](../../../common/pc/uefi32/README.md).
+
+## Blessing the boot partition
+
+If you created your own boot partition (for example, after wiping your hard disk), you will notice an extra 30 second delay before GRUB. To speed up boot, you need to "bless" the boot partition.
+
+Boot Mac OS (recovery or install media works) and run:
+
+``` sh
+bless --device /dev/<your boot partion> --setBoot --verbose
+```
+
+Use `diskutil list` to locate your boot partition. If you followed [the manual](https://nixos.org/manual/nixos/stable/index.html#sec-installation-partitioning-UEFI) so that the third partition is boot, it would be `disk0s3`
+
+For more details, read [reducing the 30 second delay when starting 64-bit Ubuntu in BIOS mode on the old 32-bit EFI Macs | mattgadient.com](https://mattgadient.com/reducing-the-30-second-delay-when-starting-64-bit-ubuntu-in-bios-mode-on-the-old-32-bit-efi-macs/) (although note that you should leave off the `--legacy` flag since we are booting in EFI mode).
+
+## Missing radeon vbios in UEFI mode
+
+You will find that the system locks hard when Linux attempts to set a display mode via KMS. 
+
+This is because in EFI mode, on this model and many other Apple machines, the Radeon vbios firmware is loaded by Apple's OS via a proprietary method early in the EFI boot process rather than being made available via a standard ACPI table.
+
+To work around this, you need:
+
+ - A kernel with a patched radeon module capable of loading vbios from a file (already taken care of here)
+ - A dump of your model's vbios
+  - Since it is readable via ACPI in BIOS mod, it can be obtained by booting Linux in BIOS mode using a specially crafted BIOS-only optical disk or hard drive (USB-booting into BIOS isn't supported in this model). 
+
+### More info
+
+ - TL;DR steps in Andreas Baumann's post: [Load custom Radeon firmware for Macbook Pro / Kernel & Hardware / Arch Linux Forums](https://bbs.archlinux.org/viewtopic.php?pid=1810437#p1810437)
+ - The bug where this was figured out and the radeon patch is attached: [26891 – Radeon KMS fails with inaccessible AtomBIOS on systems with (U)EFI boot](https://bugs.freedesktop.org/show_bug.cgi?id=26891#c3)
+
+## iSight Camera Firmware
+
+## Quick reference
+
+* [Mac startup key combinations - Apple Support](https://support.apple.com/en-us/HT201255)

--- a/apple/macbook-pro/2-2/default.nix
+++ b/apple/macbook-pro/2-2/default.nix
@@ -8,8 +8,12 @@
   ];
 
   # TODO:
+  #  - [ ] Pin kernel to ensure patch succeeds
+  #  - [ ] Find how to get source dir
   #  - [ ] build kernel with radeon vbios loading support
+  #        https://discourse.nixos.org/t/how-to-install-a-linux-kernel-patch/6889
   #  - [ ] put firmware in the right place
-  #  [[https://bbs.archlinux.org/viewtopic.php?pid=1810437#p1810437][Load custom Radeon firmware for Macbook Pro / Kernel & Hardware / Arch Linux Forums]]
+  #        - Load custom Radeon firmware for Macbook Pro / Kernel & Hardware / Arch Linux Forums https://bbs.archlinux.org/viewtopic.php?pid=1810437#p1810437
+  #        - https://discourse.nixos.org/t/trying-to-include-custom-firmware-but-it-doesnt-appear-under-run-current-system/3044
   boot.kernelParams = ["nomodeset"];
 }

--- a/apple/macbook-pro/2-2/default.nix
+++ b/apple/macbook-pro/2-2/default.nix
@@ -1,0 +1,15 @@
+{ lib, config, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../common/pc/laptop/hdd
+    ../../../common/pc/uefi32
+  ];
+
+  # TODO:
+  #  - [ ] build kernel with radeon vbios loading support
+  #  - [ ] put firmware in the right place
+  #  [[https://bbs.archlinux.org/viewtopic.php?pid=1810437#p1810437][Load custom Radeon firmware for Macbook Pro / Kernel & Hardware / Arch Linux Forums]]
+  boot.kernelParams = ["nomodeset"];
+}

--- a/apple/macbook-pro/2-2/default.nix
+++ b/apple/macbook-pro/2-2/default.nix
@@ -1,5 +1,4 @@
 { lib, config, pkgs, ... }:
-
 {
   imports = [
     ../.
@@ -16,4 +15,10 @@
   #        - Load custom Radeon firmware for Macbook Pro / Kernel & Hardware / Arch Linux Forums https://bbs.archlinux.org/viewtopic.php?pid=1810437#p1810437
   #        - https://discourse.nixos.org/t/trying-to-include-custom-firmware-but-it-doesnt-appear-under-run-current-system/3044
   boot.kernelParams = ["nomodeset"];
+ 
+      boot.kernelPatches = [
+        { name = "radeon-vbios-from-dump";
+          patch = ./radeon_bios.patch ;
+        }
+      ];
 }

--- a/apple/macbook-pro/2-2/radeon_bios.patch
+++ b/apple/macbook-pro/2-2/radeon_bios.patch
@@ -1,0 +1,82 @@
+--- linux-5.4.105/drivers/gpu/drm/radeon/radeon_bios.c.orig	2021-03-20 14:13:04.224874027 -0700
++++ linux-5.4.105/drivers/gpu/drm/radeon/radeon_bios.c	2021-03-20 14:58:15.568629971 -0700
+@@ -33,6 +33,7 @@
+ #include <drm/drm_pci.h>
+ 
+ #include "atom.h"
++#include <linux/firmware.h>
+ #include "radeon.h"
+ #include "radeon_reg.h"
+ 
+@@ -60,15 +61,18 @@
+ 	vram_base = pci_resource_start(rdev->pdev, 0);
+ 	bios = ioremap(vram_base, size);
+ 	if (!bios) {
++	     DRM_ERROR("No bios\n");
+ 		return false;
+ 	}
+ 
+ 	if (size == 0 || bios[0] != 0x55 || bios[1] != 0xaa) {
++	     DRM_ERROR("Invalid bios\n");
+ 		iounmap(bios);
+ 		return false;
+ 	}
+ 	rdev->bios = kmalloc(size, GFP_KERNEL);
+ 	if (rdev->bios == NULL) {
++		DRM_ERROR("alloc fail\n");
+ 		iounmap(bios);
+ 		return false;
+ 	}
+@@ -77,6 +81,41 @@
+ 	return true;
+ }
+ 
++static bool radeon_read_bios_from_firmware(struct radeon_device *rdev)
++{
++	const uint8_t __iomem *bios;
++	resource_size_t size;
++	const struct firmware *fw = NULL;
++
++	request_firmware(&fw, "radeon/vbios.bin", rdev->dev);
++	if (!fw) {
++		DRM_ERROR("No bios\n");
++		return false;
++	}
++	size = fw->size;
++	bios = fw->data;
++
++	if (!bios) {
++		DRM_ERROR("No bios\n");
++		return false;
++	}
++
++	if (size == 0 || bios[0] != 0x55 || bios[1] != 0xaa) {
++		DRM_ERROR("wrong sig\n");
++		release_firmware(fw);
++		return false;
++	}
++	rdev->bios = kmalloc(size, GFP_KERNEL);
++	if (rdev->bios == NULL) {
++		DRM_ERROR("alloc fail\n");
++		release_firmware(fw);
++		return false;
++	}
++	memcpy(rdev->bios, bios, size);
++	release_firmware(fw);
++	return true;
++}
++
+ static bool radeon_read_bios(struct radeon_device *rdev)
+ {
+ 	uint8_t __iomem *bios, val1, val2;
+@@ -671,7 +710,9 @@
+ 	bool r;
+ 	uint16_t tmp;
+ 
+-	r = radeon_atrm_get_bios(rdev);
++	r = radeon_read_bios_from_firmware(rdev);
++	if (r == false)
++		r = radeon_atrm_get_bios(rdev);
+ 	if (r == false)
+ 		r = radeon_acpi_vfct_bios(rdev);
+ 	if (r == false)

--- a/common/pc/uefi32/README.md
+++ b/common/pc/uefi32/README.md
@@ -1,0 +1,12 @@
+# 32 Bit UEFI
+
+This module forces use of a 32bit EFI GRUB, needed to boot 64bit OSes on systems with a 64-bit CPU but 32-bit EFI firmware, such as Apple's ["Late 2006"](http://refit.sourceforge.net/info/apple_efi.html) hardware.
+
+## Booting 64-bit install media
+Before you can utilize this module, you will need to somehow boot your 64-bit install media, which as-is will fail since firmware will prefer the EFI program over MBR, but it will fail to load because it is 64bit. 
+
+I'm aware of three options:
+
+ - First install a 32-bit OS with a 32-bit EFI bootloader (GRUB) then manually type the boot params for your 64-bit installer into GRUB's console. This is detailed at [Bootloader#Installing x86_64 NixOS on IA-32 UEFI](Installing x86_64 NixOS on IA-32 UEFI)). Importing this module should be sufficient for configuring GRUB correctly on both the initial 32-bit system and the bootstrapped 64-bit one.
+ - Modify your 64-bit install image to force it to boot in BIOS/MBR mode. This is what I did. TODO: link
+ - Modify your install image to have a 32-bit EFI bootloader (like this module does but for the install media). This seems cleanest but is theoretical and untested.

--- a/common/pc/uefi32/default.nix
+++ b/common/pc/uefi32/default.nix
@@ -1,0 +1,17 @@
+{ lib, config, pkgs, ... }:
+
+{
+  # Grub to work around 32 bit efi
+  # https://nixos.wiki/wiki/Bootloader#Installing_x86_64_NixOS_on_IA-32_UEFI
+  boot.loader = {
+    efi = {
+      canTouchEfiVariables = false;
+    };
+    grub = {
+      efiSupport = true;
+      efiInstallAsRemovable = true;
+      device = "nodev";
+      forcei686 = true;
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       apple-macbook-air-3 = import ./apple/macbook-air/3;
       apple-macbook-air-4 = import apple/macbook-air/4;
       apple-macbook-air-6 = import apple/macbook-air/6;
-      apple-macbook-pro-2-1 = import ./apple/macbook-pro/2-1;
+      apple-macbook-pro-2-2 = import ./apple/macbook-pro/2-2;
       apple-macbook-pro-10-1 = import ./apple/macbook-pro/10-1;
       apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
       apple-macbook-air-3 = import ./apple/macbook-air/3;
       apple-macbook-air-4 = import apple/macbook-air/4;
       apple-macbook-air-6 = import apple/macbook-air/6;
+      apple-macbook-pro-2-1 = import ./apple/macbook-pro/2-1;
       apple-macbook-pro-10-1 = import ./apple/macbook-pro/10-1;
       apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;


### PR DESCRIPTION
I'm bringing up this old MBP from my bottom drawer. I think it was my second laptop.. It is weird in these ways:

 - 32bit UEFI on a 64bit machine
 - In UEFI mode, Radeon vbios isn't available to the OS (apple grabs it somehow in bootloader)

Tasks:
 - [x] Point to process to bootstrap 64bit OS
 - [x] Install 32bit grub
 - [ ] Build kernel with patch to load vbios in radeon module
 - [ ] Point to process for dumping vbios or otherwise obtaining it.

The vbios thing applies to a bunch of models. The 32 bit uefi is only up to 2007 AFAIK but still several models.