### PR TITLE
Add profiles for AMD GPUs

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+{
+  boot.initrd.kernelModules = [ "amdgpu" ];
+  services.xserver.videoDrivers = [ "amdgpu" ];
+  
+  hardware.opengl.extraPackages = with pkgs; [
+    rocm-opencl-icd
+    rocm-opencl-runtime
+    amdvlk
+  ];
+
+  hardware.opengl = {
+    driSupport = lib.mkDefault true;
+    driSupport32Bit = lib.mkDefault true;
+  };
+} 

--- a/common/gpu/amd/sea-islands/default.nix
+++ b/common/gpu/amd/sea-islands/default.nix
@@ -1,4 +1,5 @@
 {
   imports = [ ../. ];
+  # Explicitly set amdgpu support in place of radeon
   boot.kernelParams = [ "radeon.cik_support=0" "amdgpu.cik_support=1" ];
 }

--- a/common/gpu/amd/sea-islands/default.nix
+++ b/common/gpu/amd/sea-islands/default.nix
@@ -1,0 +1,4 @@
+{
+  imports = [ ../. ];
+  boot.kernelParams = [ "radeon.cik_support=0" "amdgpu.cik_support=1" ];
+}

--- a/common/gpu/amd/southern-islands/default.nix
+++ b/common/gpu/amd/southern-islands/default.nix
@@ -1,4 +1,5 @@
 {
   imports = [ ../. ];
+  # Explicitly set amdgpu support in place of radeon
   boot.kernelParams = [ "radeon.si_support=0" "amdgpu.si_support=1" ];
 }

--- a/common/gpu/amd/southern-islands/default.nix
+++ b/common/gpu/amd/southern-islands/default.nix
@@ -1,0 +1,4 @@
+{
+  imports = [ ../. ];
+  boot.kernelParams = [ "radeon.si_support=0" "amdgpu.si_support=1" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,9 @@
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;
       common-gpu-nvidia = import ./common/gpu/nvidia.nix;
       common-gpu-nvidia-disable = import ./common/gpu/nvidia-disable.nix;
+      common-gpu-amd = import ./common/gpu/amd;
+      common-gpu-amd-sea-islands = import ./common/gpu/amd/sea-islands;
+      common-gpu-amd-southern-islands = import ./common/gpu/amd/southern-islands;
       common-pc-hdd = import ./common/pc/hdd;
       common-pc-laptop-hdd = import ./common/pc/laptop/hdd;
       common-pc-laptop-ssd = import ./common/pc/ssd;


### PR DESCRIPTION
Inspired by [https://github.com/NixOS/nixpkgs/issues/116619](https://github.com/NixOS/nixpkgs/issues/116619), I decided to create basic profiles for AMD GPUs according to the NixOS Wiki [article](https://nixos.wiki/wiki/AMD_GPU).

The profile for Sea Islands works fine on my machine (R9 290X), I expect the one for Southern Islands to work equally well.