### PR TITLE
Add default lenovo-thinkpad-x1 config to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
       lenovo-thinkpad-x260 = import ./lenovo/thinkpad/x260;
       lenovo-thinkpad-x270 = import ./lenovo/thinkpad/x270;
       lenovo-thinkpad-x280 = import ./lenovo/thinkpad/x280;
+      lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
       lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
       lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
       lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;


### PR DESCRIPTION
For computers like the Lenovo X1 Carbon Gen 2 no extra configuration is needed (as far as I'm aware), so the default x1 config can be used. However, this is not currently possible with flakes, since the configuration isn't exposed in flake.nix.

I suspect that the same argument could be had for other laptops. Would it be a good idea to expose all generic configurations, instead of only this one?