### PR TITLE
apple/macbook-pro/12-1/default.nix: Fixed impure <nixpkgs> import.

### DIFF
--- a/apple/macbook-pro/12-1/default.nix
+++ b/apple/macbook-pro/12-1/default.nix
@@ -1,10 +1,10 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, modulesPath, ... }:
 
 {
   imports = [
     ../.
     ../../../common/pc/laptop/ssd
-    <nixpkgs/nixos/modules/hardware/network/broadcom-43xx.nix>
+    "${modulesPath}/hardware/network/broadcom-43xx.nix"
   ];
 
   powerManagement = {


### PR DESCRIPTION
Fixes #255