### PR TITLE
friendlyarm/nanopc-t4: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See code for all available configurations.
 | [Dell XPS 15 9560, nvidia only][] | `<nixos-hardware/dell/xps/15-9560/nvidia>`         |
 | [Dell XPS 15 9500][]              | `<nixos-hardware/dell/xps/15-9500>`                |
 | [Dell XPS 15 9500, nvidia][]      | `<nixos-hardware/dell/xps/15-9500/nvidia>`         |
+| FriendlyARM NanoPC-T4             | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [Google Pixelbook][]              | `<nixos-hardware/google/pixelbook>`                |
 | [Inverse Path USB armory][]       | `<nixos-hardware/inversepath/usbarmory>`           |
 | Lenovo IdeaPad Z510               | `<nixos-hardware/lenovo/ideapad/z510>`             |
@@ -113,7 +114,7 @@ See code for all available configurations.
 | Lenovo ThinkPad T440s             | `<nixos-hardware/lenovo/thinkpad/t440s>`           |
 | Lenovo ThinkPad T440p             | `<nixos-hardware/lenovo/thinkpad/t440p>`           |
 | Lenovo ThinkPad T450s             | `<nixos-hardware/lenovo/thinkpad/t450s>`           |
-| Lenovo ThinkPad T460              | `<nixos-hardware/lenovo/thinkpad/t460>`           |
+| Lenovo ThinkPad T460              | `<nixos-hardware/lenovo/thinkpad/t460>`            |
 | Lenovo ThinkPad T460s             | `<nixos-hardware/lenovo/thinkpad/t460s>`           |
 | Lenovo ThinkPad T470s             | `<nixos-hardware/lenovo/thinkpad/t470s>`           |
 | Lenovo ThinkPad T480s             | `<nixos-hardware/lenovo/thinkpad/t480s>`           |

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
       dell-xps-15-9560-nvidia = import ./dell/xps/15-9560/nvidia;
       dell-xps-15-9500 = import ./dell/xps/15-9500;
       dell-xps-15-9500-nvidia = import ./dell/xps/15-9500/nvidia;
+      friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
       google-pixelbook = import ./google/pixelbook;
       inversepath-usbarmory = import ./inversepath/usbarmory;
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;

--- a/friendlyarm/nanopc-t4/README.md
+++ b/friendlyarm/nanopc-t4/README.md
@@ -1,0 +1,91 @@
+# Description
+
+This document on how I configure [NixOS](https://nixos.org/) on [NanoPC-T4](https://wiki.friendlyarm.com/wiki/index.php/NanoPC-T4).
+
+# Installation
+
+To install NixOS on you can follow the [official instructions](https://nixos.wiki/wiki/NixOS_on_ARM/NanoPC-T4) and use the [pre-built images](https://github.com/tmountain/arch-nanopct4/tree/main/images/) from @tmountain. You can also build the U-Boot image yourself from `nixpkgs` based on changes added in [#111034](https://github.com/NixOS/nixpkgs/pull/111034).
+
+## NixOS on NVMe with ZFS
+
+It is possible to migrate the OS from the eMMC storage to the NVMe.
+
+In my case I migrated `/`, `/nix`, and `/home`, leaving `/boot` on the eMMC.
+
+Create the ZFS pool and three filesystems on the SSD:
+```sh
+zpool create -O xattr=sa -O acltype=posixacl -O mountpoint=none rpool /dev/nvme0n1
+for VOL in nix root home; do
+    zfs create -o mountpoint=legacy rpool/$VOL
+    mkdir /mnt/$VOL
+    mount.zfs rpool/$VOL /mnt/$VOL
+done
+```
+Then sync the original filesystem on eMMC to the new volumes:
+```sh
+rsync -rax /. /mnt/root
+rsync -rax /nix/. /mnt/nix
+rsync -rax /home/. /mnt/home
+rsync -rax /boot/. /
+```
+Afterwards create a configuration that looks like this:
+```nix
+{
+  # TODO: Make sure to update the eMMC device UUID!
+  fileSystems."/boot" = { device = "/dev/disk/by-uuid/1234-5678"; fsType = "ext4"; };
+  fileSystems."/" = { device = "rpool/root"; fsType = "zfs"; };
+  fileSystems."/nix" = { device = "rpool/nix"; fsType = "zfs"; };
+  fileSystems."/home" = { device = "rpool/home"; fsType = "zfs"; };
+}
+```
+And rebuild he system:
+```sh
+sudo nixos-rebuild boot
+```
+:warning: __IMPORTANT:__ After that it's necessary to run all the four `rsync` commands again to sync filesystems.
+
+Once everything is synced you can finally reboot.
+
+You should also clean up `/boot` afterwards.
+
+# UART Debug Console
+
+Device provides a Debug UART 4 Pin 2.54mm header connection, 3V level, 1500000bps.
+
+To connect to you will need a USB to UART converter/receiver that supports the speed of 1500000bps.
+
+The serial port parameters are [8-N-1](https://en.wikipedia.org/wiki/8-N-1).
+
+A reader using `CP2102` chip did not work but `FT232RL` works fine:
+
+![UART converter photo](https://github.com/NixOS/nixos-hardware/releases/download/not-a-release/FT232RL.jpg)
+
+You can use `minicom` or `picocom` to connect:
+```
+sudo minicom -b 1500000 -D /dev/ttyUSB0 
+sudo picocom -b 1500000 /dev/ttyUSB0
+```
+But you'll need to disable flow control with `Ctrl-A x`.
+
+Here is a good overview of UART USB-to-Serial adapters:
+
+* https://www.sjoerdlangkemper.nl/2019/03/20/usb-to-serial-uart/
+* https://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT232R.pdf
+
+Pin layout where #4 is next to USB-C port:
+
+| Pin num.| #1  | #2 | #3 | #4 |
+|---------|-----|----|----|----|
+| Purpose | GND | V5 | TX | RX |
+
+Remember that the `TX` and `RX` ports should be swapped between UART adapter and the board.
+
+The V5 pin does not need to be connected if you're powering the board from another source.
+
+See the full board diagram for more details:
+
+![Board diagram](https://wiki.friendlyarm.com/wiki/images/b/bb/NanoPC-T4_1802_Drawing.png)
+
+You can access the recovery console by holding the __Recovery__ button and then pressing the __Power__ button.
+For this to work the device will have to be off, which requires holding the __Power__ button long enough.
+

--- a/friendlyarm/nanopc-t4/default.nix
+++ b/friendlyarm/nanopc-t4/default.nix
@@ -1,0 +1,26 @@
+{ lib, pkgs, ... }:
+
+{
+  boot.loader = {
+    grub.enable = lib.mkDefault false;
+    # Enables the generation of /boot/extlinux/extlinux.conf.
+    generic-extlinux-compatible.enable = lib.mkDefault true;
+  };
+
+  # UART debug console bitrates.
+  services.mingetty.serialSpeed = [ 1500000 115200 ];
+
+  # Enable additional firmware (such as Wi-Fi drivers).
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  # Fix for not detecting the M.2 NVMe SSD. Will cause recompilation.
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.10") (lib.mkDefault pkgs.linuxPackages_latest);
+  boot.kernelPatches = lib.mkDefault [{
+    name = "pcie-rockchip-config.patch";
+    patch = null;
+    extraConfig = ''
+      PHY_ROCKCHIP_PCIE y
+      PCIE_ROCKCHIP_HOST y
+    '';
+  }];
+}


### PR DESCRIPTION
As suggested by @Mic92 in https://github.com/NixOS/nixpkgs/pull/111034 I'm submitting [my fixes](https://github.com/jakubgs/nixos-nanopc-t4) for the [FriendlyARM NanoPC-T4](https://www.friendlyarm.com/index.php?route=product/product&product_id=225) device.

I'm not sure if forcing a specific kernel version is kosher, but on the other hand I don't know if my kernel config changes will work on any other version. I'm open to suggestions as to how to do this better.

Also unusure if I should call the folder `friendlyarm` or `friendlyelec`.