### PR TITLE
raspberry-pi/4: Add modesetting option

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -1,6 +1,10 @@
 { lib, pkgs, ...}:
 
 {
+  imports = [
+    ./modesetting.nix
+  ];
+
   boot = {
     kernelPackages = lib.mkDefault pkgs.linuxPackages_rpi4;
     initrd.availableKernelModules = [ "usbhid" "usb_storage" "vc4" ];

--- a/raspberry-pi/4/modesetting.nix
+++ b/raspberry-pi/4/modesetting.nix
@@ -1,0 +1,107 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".fkms-3d;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".fkms-3d = {
+      enable = lib.mkEnableOption ''
+        Enable modesetting through fkms-3d
+      '';
+      cma = lib.mkOption {
+        type = lib.types.int;
+        default = 512;
+        description = ''
+          Amount of CMA (contiguous memory allocator) to reserve, in MiB.
+
+          The foundation overlay defaults to 256MiB, for backward compatibility.
+          As the Raspberry Pi 4 family of hardware has ample amount of memory, we
+          can reserve more without issue.
+
+          Additionally, reserving too much is not an issue. The kernel will use
+          CMA last if the memory is needed.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Configure for modesetting in the device tree
+    hardware.deviceTree = {
+      filter = "bcm2711-rpi-*.dtb";
+      overlays = [
+        # Equivalent to:
+        # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/cma-overlay.dts
+        {
+          name = "rpi4-cma-overlay";
+          dtsText = ''
+            // SPDX-License-Identifier: GPL-2.0
+            /dts-v1/;
+            /plugin/;
+
+            / {
+              compatible = "brcm,bcm2711";
+
+              fragment@0 {
+                target = <&cma>;
+                __overlay__ {
+                  size = <(${toString cfg.cma} * 1024 * 1024)>;
+                };
+              };
+            };
+          '';
+        }
+        # Equivalent to:
+        # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
+        {
+          name = "rpi4-vc4-fkms-v3d-overlay";
+          dtsText = ''
+            // SPDX-License-Identifier: GPL-2.0
+            /dts-v1/;
+            /plugin/;
+
+            / {
+              compatible = "brcm,bcm2711";
+
+              fragment@1 {
+                target = <&fb>;
+                __overlay__ {
+                  status = "disabled";
+                };
+              };
+
+              fragment@2 {
+                target = <&firmwarekms>;
+                __overlay__ {
+                  status = "okay";
+                };
+              };
+
+              fragment@3 {
+                target = <&v3d>;
+                __overlay__ {
+                  status = "okay";
+                };
+              };
+
+              fragment@4 {
+                target = <&vc4>;
+                __overlay__ {
+                  status = "okay";
+                };
+              };
+            };
+          '';
+        }
+      ];
+    };
+
+    # Also configure the system for modesetting.
+
+    services.xserver.videoDrivers = lib.mkBefore [
+      "modesetting" # Prefer the modesetting driver in X11
+      "fbdev" # Fallback to fbdev
+    ];
+  };
+}


### PR DESCRIPTION
This adds a pair of option to enable and configure the vendor-specific modesetting driver for the Raspberry Pi 4B.

### Usage

```nix
{
  imports = [
    ./nixos-hardware/raspberry-pi/4
  ];

  hardware.raspberry-pi."4".fkms-3d.enable = true;
}
```

Since we're using `lib.mkBefore`, even if a user has set `fbdev` (wrongly) in their `videoDrivers` it will use `modesetting` first. Adding `fbdev` ensures there's a fallback plan in case things break with modesetting in the future.

You'll know modesetting is enabled if you can configure the resolution of the display in your desktop environment.

There's also:

```
[samuel@pi4-nixdev:~]$ dmesg | grep -i kms
[    2.165923] vc4-drm gpu: bound fe600000.firmwarekms (ops vc4_fkms_ops [vc4])
```

* * *

### Why are the overlays in-lined?

 - https://logs.nix.samueldr.com/nixos-aarch64/2021-05-12#1620854599-1620855129;

Basically, the overlay says it's compatible with `brcm,bcm2835`, so when we apply it with our tooling, it sees `brcm,bcm2711` and (rightfully so) won't apply the overlay.

This is an upstream bug that is probably actually unfixable? Though maybe they could add two compatible entries... In that case we'd have to do more checks as right now the `compatible` checks in our `deviceTree` tooling is not great.

Though, with that said, in-lining the overlays gives us super-powers!! A NixOS option to configure the CMA! Though, sadly, users really don't need to customize the value. 512MiB is [the biggest value one can give through dtparams](https://github.com/raspberrypi/linux/blob/108ac8cefd05ef00bba93852e7e7f12d009674a5/arch/arm/boot/dts/overlays/README#L625-L639).

* * *

I don't like how `"4"` needs to be quoted here. But if I follow the naming scheme of the directories in the option names (and I think we should, and be strict about it), then that's what we have to do.