### PR TITLE
Tlp and power profiles daemon clash

### DIFF
--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -6,9 +6,5 @@
   # Gnome 40 introduced a new way of managing power, without tlp.
   # However, these 2 services clash when enabled simultaneously.
   # https://github.com/NixOS/nixos-hardware/issues/260
-  services.tlp.enable = lib.mkDefault
-    (if config.services.power-profiles-daemon.enable == true then
-      false
-    else
-      true);
+  services.tlp.enable = lib.mkDefault !config.services.power-profiles-daemon.enable;
 }

--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -6,9 +6,9 @@
   # Gnome 40 introduced a new way of managing power, without tlp.
   # However, these 2 services clash when enabled simultaneously.
   # https://github.com/NixOS/nixos-hardware/issues/260
-  services.tlp.enable =
-    if config.services.power-profiles-daemon.enable == true then
+  services.tlp.enable = lib.mkDefault
+    (if config.services.power-profiles-daemon.enable == true then
       false
     else
-      true;
+      true);
 }

--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -6,5 +6,5 @@
   # Gnome 40 introduced a new way of managing power, without tlp.
   # However, these 2 services clash when enabled simultaneously.
   # https://github.com/NixOS/nixos-hardware/issues/260
-  services.tlp.enable = lib.mkDefault !config.services.power-profiles-daemon.enable;
+  services.tlp.enable = lib.mkDefault (!config.services.power-profiles-daemon.enable);
 }

--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -3,5 +3,12 @@
 {
   imports = [ ../. ];
 
-  services.tlp.enable = lib.mkDefault true;
+  # Gnome 40 introduced a new way of managing power, without tlp.
+  # However, these 2 services clash when enabled simultaneously.
+  # https://github.com/NixOS/nixos-hardware/issues/260
+  services.tlp.enable =
+    if config.services.power-profiles-daemon.enable == true then
+      false
+    else
+      true;
 }


### PR DESCRIPTION
Gnome 40 now uses [power-profile-daemon](https://gitlab.freedesktop.org/hadess/power-profiles-daemon ),which clashes with tlp.
This check will disable tlp whenever it finds that the
power-profiles-daemon is activated. This should also
fix the issue mentioned in #260.

I'm not 100% sure if this is "the way" to do it, but it fixes the problem
on my end. For reference, I'm using the Lenovo Thinkpad T495.

Also, this will be my first pull request to this project. So if I'm doing
anything wrong, please let me know :).