### PR TITLE
Raspberry pi 4: Add dwc2 usb otg gadget support

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./dwc2.nix
     ./modesetting.nix
   ];
 

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -15,6 +15,7 @@
     };
   };
 
+  hardware.deviceTree.filter = "bcm2711-rpi-*.dtb";
 
   # Required for the Wireless firmware
   hardware.enableRedistributableFirmware = true;

--- a/raspberry-pi/4/dwc2.nix
+++ b/raspberry-pi/4/dwc2.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".dwc2;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".dwc2 = {
+      enable = lib.mkEnableOption ''
+        Enable the UDC controller to support USB OTG gadget functions.
+
+        In order to verify that this works, connect the Raspberry Pi with
+        another computer via the USB C cable, and then do one of:
+
+        - `modprobe g_serial`
+        - `modprobe g_mass_storage file=/path/to/some/iso-file.iso`
+
+        On the Raspberry Pi, `dmesg` should then show success-indicating output
+        that is related to the dwc2 and g_serial/g_mass_storage modules.
+        On the other computer, a serial/mass-storage device should pop up in
+        the system logs.
+
+        For more information about what gadget functions exist along with handy
+        guides on how to test them, please refer to:
+        https://www.kernel.org/doc/Documentation/usb/gadget-testing.txt
+      '';
+      dr_mode = lib.mkOption {
+        type = lib.types.enum [ "host" "peripheral" "otg" ];
+        default = "otg";
+        description = ''
+          Dual role mode setting for the dwc2 USB controller driver.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Configure for modesetting in the device tree
+    hardware.deviceTree = {
+      overlays = [
+        # this *should* be equivalent to (which doesn't work):
+        # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/dwc2-overlay.dts
+        # but actually it's obtained using
+        # dtc -I dtb -O dts ${config.hardware.deviceTree.kernelPackage}/dtbs/overlays/dwc2.dtbo
+        # (changes: modified top-level "compatible" field)
+        # which is slightly different and works
+        {
+          name = "dwc2-overlay";
+          dtsText = ''
+            /dts-v1/;
+            /plugin/;
+
+            / {
+              compatible = "brcm,bcm2711";
+
+              fragment@0 {
+                target = <&usb>;
+                #address-cells = <0x01>;
+                #size-cells = <0x01>;
+
+                __overlay__ {
+                  compatible = "brcm,bcm2835-usb";
+                  dr_mode = "${cfg.dr_mode}";
+                  g-np-tx-fifo-size = <0x20>;
+                  g-rx-fifo-size = <0x22e>;
+                  g-tx-fifo-size = <0x200 0x200 0x200 0x200 0x200 0x100 0x100>;
+                  status = "okay";
+                  phandle = <0x01>;
+                };
+              };
+            };
+          '';
+        }
+      ];
+    };
+  };
+}

--- a/raspberry-pi/4/modesetting.nix
+++ b/raspberry-pi/4/modesetting.nix
@@ -29,7 +29,6 @@ in
   config = lib.mkIf cfg.enable {
     # Configure for modesetting in the device tree
     hardware.deviceTree = {
-      filter = "bcm2711-rpi-*.dtb";
       overlays = [
         # Equivalent to:
         # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/cma-overlay.dts


### PR DESCRIPTION
This pull request adds the nixos module option

```
hardware.raspberry-pi."4".dwc2.enable = true;
```

which puts the dwc2 controller into otg mode by default, which can also be changed using:

```
hardware.raspberry-pi."4".dwc2.dr_mode = <one of "host", "peripheral", "otg" (otg is default)>;
```

the DTS content should basically be the same as  https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/dwc2-overlay.dts, but that did not work.
I ended up decompiling `dwc2.dtbo` from the rpi4 kernel package (selected by `hardware.deviceTree.kernelPackage`) using this command:

```
${pkgs.dtc}/bin/dtc -I dtb -O dts ${config.hardware.deviceTree.kernelPackage}/dtbs/overlays/dwc2.dtbo
```

and then took its content, modified the top-level `compatible` clause and that worked.

thanks @samueldr for the awesome support in the nixos on arm matrix channel!

I tested to see if this works by doing the following steps:

1. after a reboot (assuming the raspberry pi is plugged via usb C into another computer) with this option being enabled, the following kernel messages should appear (and *not* appear without this setting):

```
04:47 guest@raspi4 ~ $ dmesg | grep dwc2
[    9.946445] dwc2 fe980000.usb: supply vusb_d not found, using dummy regulator
[    9.946685] dwc2 fe980000.usb: supply vusb_a not found, using dummy regulator
[   10.154676] dwc2 fe980000.usb: EPs: 8, dedicated fifos, 4080 entries in SPRAM
[   10.154879] dwc2 fe980000.usb: DWC OTG Controller
[   10.154896] dwc2 fe980000.usb: new USB bus registered, assigned bus number 3
[   10.154927] dwc2 fe980000.usb: irq 23, io mem 0xfe980000
[   10.155119] usb usb3: Manufacturer: Linux 5.10.17 dwc2_hsotg
```

2. create a mass storage device:

```sh
sudo modprobe g_mass_storage file=/path/to/nixos-installer.iso # just some example path
```

and then the kernel should say:

```
[  459.777781] Mass Storage Function, version: 2009/09/11
[  459.777800] LUN: removable file: (no medium)
[  459.777887] LUN: file: /home/guest/Downloads/latest-nixos-minimal-x86_64-linux.iso
[  459.777892] Number of LUNs=1
[  459.778094] g_mass_storage gadget: Mass Storage Gadget, version: 2009/09/11
[  459.778100] g_mass_storage gadget: userspace failed to provide iSerialNumber
[  459.778105] g_mass_storage gadget: g_mass_storage ready
[  459.778116] dwc2 fe980000.usb: bound driver g_mass_storage
```

and also, the raspberry pi should now appear as a usb storage stick plugged into the other computer with the right content.