### PR TITLE
surface: add iptsd

### DIFF
--- a/microsoft/surface/default.nix
+++ b/microsoft/surface/default.nix
@@ -5,4 +5,9 @@
   environment.systemPackages = with pkgs; [ surface-control ];
   users.groups.surface-control = { };
   services.udev.packages = [ pkgs.surface-control ];
+  systemd.services.iptsd = {
+    description = "IPTSD";
+    script = "${pkgs.iptsd}/bin/iptsd";
+    wantedBy = [ "multi-user.target" ];
+  };
 }


### PR DESCRIPTION
depends on https://github.com/NixOS/nixpkgs/pull/124600

Tested on Surface Pro 5 along with the current kernel patching (5.10.19). I'm interested in upgrading to 5.11.