### PR TITLE
thinkpad t14s amd: add amd gpu module

### DIFF
--- a/lenovo/thinkpad/t14s/amd/default.nix
+++ b/lenovo/thinkpad/t14s/amd/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../.
     ../../../../common/cpu/amd
+    ../../../../common/gpu/amd
   ];
 
   # For support of newer AMD GPUs, backlight and internal microphone


### PR DESCRIPTION
The Thinkpad T14s AMD editions include AMD integrated graphics that can be handled by the /common/gpu/amd module.