### PR TITLE
Add onenetbook/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X1 (7th Gen)][]  | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`      |
 | Lenovo ThinkPad X1 Extreme Gen 2  | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>` |
 | [Lenovo ThinkPad X13][]           | `<nixos-hardware/lenovo/thinkpad/x13`              |
+| [One-Netbook OneNetbook 4][]      | `<nixos-hardware/onenetbook/4`                     |
 | [Microsoft Surface Range][]       | `<nixos-hardware/microsoft/surface>`               |
 | [Microsoft Surface Pro 3][]       | `<nixos-hardware/microsoft/surface-pro/3>`         |
 | [MSI GS60 2QE][]                  | `<nixos-hardware/msi/gs60>`                        |
@@ -181,6 +182,7 @@ See code for all available configurations.
 [Lenovo ThinkPad X260]: lenovo/thinkpad/x260
 [Microsoft Surface Pro 3]: microsoft/surface-pro/3
 [MSI GS60 2QE]: msi/gs60
+[One-Netbook OneNetbook 4]: onenetbook/4
 [Raspberry Pi 2]: raspberry-pi/2
 [Samsung Series 9 NP900X3C]: samsung/np900x3c
 [System76 (generic)]: system76

--- a/onenetbook/4/default.nix
+++ b/onenetbook/4/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, config, ... }:
+
+{
+  imports = [
+    ../../common/cpu/intel
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+  ];
+
+  # OneNetbook 4 has `GXTP7386:00 27C6:011A Stylus` exporting no buttons in 5.12
+  # and libinput does't consider it a tablet without them, but a touchscreen.
+  # This leads to real weird effects,
+  # starting from clicking as soon as the pen gets tracked.
+  # A kernel patch exists to resolve that, compiled as an out-of-tree module here
+  # to avoid recompiling the kernel for such a small change.
+  # `hid-multitouch-onenetbook4` is the fixed one, don't use `hid-multitouch`.
+  boot.blacklistedKernelModules = [ "hid-multitouch" ];
+  boot.extraModulePackages = [
+    (config.boot.kernelPackages.callPackage ./goodix-stylus-mastykin {})
+  ];
+}

--- a/onenetbook/4/goodix-stylus-mastykin/5.12.12.patch.patch
+++ b/onenetbook/4/goodix-stylus-mastykin/5.12.12.patch.patch
@@ -1,0 +1,17 @@
+--- orig/patch1
++++ updated/patch1
+@@ -10,11 +10,11 @@
+  /* quirks to control the device */
+  #define MT_QUIRK_NOT_SEEN_MEANS_UP	BIT(0)
+  #define MT_QUIRK_SLOT_IS_CONTACTID	BIT(1)
+-@@ -70,6 +73,7 @@
+- #define MT_QUIRK_WIN8_PTP_BUTTONS	BIT(18)
++@@ -71,6 +74,7 @@
+  #define MT_QUIRK_SEPARATE_APP_REPORT	BIT(19)
+  #define MT_QUIRK_FORCE_MULTI_INPUT	BIT(20)
+-+#define MT_QUIRK_NON_MT_PEN		BIT(21)
++ #define MT_QUIRK_DISABLE_WAKEUP		BIT(21)
+++#define MT_QUIRK_NON_MT_PEN		BIT(22)
+  
+  #define MT_INPUTMODE_TOUCHSCREEN	0x02
+  #define MT_INPUTMODE_TOUCHPAD		0x03

--- a/onenetbook/4/goodix-stylus-mastykin/Makefile
+++ b/onenetbook/4/goodix-stylus-mastykin/Makefile
@@ -1,0 +1,7 @@
+obj-m += hid-multitouch-onenetbook4.o
+
+all:
+	make -C $(KERNEL_DIR) M=$(PWD) modules
+
+install:
+	make -C $(KERNEL_DIR) M=$(PWD) modules_install

--- a/onenetbook/4/goodix-stylus-mastykin/default.nix
+++ b/onenetbook/4/goodix-stylus-mastykin/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, kernel, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name = "hid-multitouch-onenetbook4-${version}";
+  version = kernel.version;
+
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  src = ./.;
+  patches = [
+    (fetchpatch {
+      url = "https://marc.info/?l=linux-input&m=161847127221531&q=p3";
+      name = "goodix-stylus-mastykin-1-pen-support.patch";
+      sha256 = "sha256-1oc8OvfhScYvtsMeV9A4hU+09i59tEJ6HZS6jspsJR8=";
+    })
+    (fetchpatch {
+      url = "https://marc.info/?l=linux-input&m=161847127221531&q=p4";
+      name = "goodix-stylus-mastykin-2-buttons.patch";
+      sha256 = "sha256-HxmR8iEgoj4PJopGWJdWsjFxbfISwTMzz+HyG81mRG4=";
+    })
+  ];
+
+  postUnpack = ''
+    tar -C goodix-stylus-mastykin \
+      --strip-components=3 -xf ${kernel.src} --wildcards \
+      '*/drivers/hid/hid-ids.h' '*/drivers/hid/hid-multitouch.c'
+  '';
+  patchFlags = "-p3";
+  postPatch = ''
+    mv hid-multitouch.c hid-multitouch-onenetbook4.c
+    substituteInPlace hid-multitouch-onenetbook4.c --replace \
+      '.name = "hid-multitouch",' \
+      '.name = "hid-multitouch-onenetbook4",'
+    substituteInPlace hid-multitouch-onenetbook4.c --replace \
+      I2C_DEVICE_ID_GOODIX_0113 \
+      0x011A
+  '';
+
+  makeFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "hid-multitouch module patched for OneNetbook 4";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
One Netbook 4 has a buggy stylus driver.
This submission compiles a patched one as an alternative kernel module and blacklists the mainline one.
No idea how idiomatic this is, suggestions are welcome.