### PR TITLE
Fix 9500 AX Crashes

### DIFF
--- a/dell/xps/15-9500/default.nix
+++ b/dell/xps/15-9500/default.nix
@@ -20,7 +20,7 @@ in
   services.thermald.configFile = lib.mkDefault thermald-conf;
   
   # WiFi speed is slow and crashes by default
-  # disable_11ax - doesn't actually disable AX but will fix the speed and crashes
+  # disable_11ax - required until ax driver support is fixed
   # power_save - works well on this card
   boot.extraModprobeConfig = ''
     options iwlwifi power_save=1 disable_11ax=1

--- a/dell/xps/15-9500/default.nix
+++ b/dell/xps/15-9500/default.nix
@@ -18,4 +18,11 @@ in
   # Thermald doesn't have a default config for the 9500 yet, the one in this repo
   # was generated with dptfxtract-static (https://github.com/intel/dptfxtract)
   services.thermald.configFile = lib.mkDefault thermald-conf;
+  
+  # WiFi speed is slow and crashes by default
+  # disable_11ax - doesn't actually disable AX but will fix the speed and crashes
+  # power_save - works well on this card
+  boot.extraModprobeConfig = ''
+    options iwlwifi power_save=1 disable_11ax=1
+  '';
 }

--- a/dell/xps/15-9500/default.nix
+++ b/dell/xps/15-9500/default.nix
@@ -19,7 +19,7 @@ in
   # was generated with dptfxtract-static (https://github.com/intel/dptfxtract)
   services.thermald.configFile = lib.mkDefault thermald-conf;
   
-  # WiFi speed is slow and crashes by default
+  # WiFi speed is slow and crashes by default (https://bugzilla.kernel.org/show_bug.cgi?id=213381)
   # disable_11ax - required until ax driver support is fixed
   # power_save - works well on this card
   boot.extraModprobeConfig = ''


### PR DESCRIPTION
# About

Fix WiFi support on Dell XPS 9500 ([Intel® Killer™ Wi-Fi 6 AX1650s](https://ark.intel.com/content/www/us/en/ark/products/211610/intel-killer-wi-fi-6-ax1650-i-s.html)) 

Currently seeing these crashes on AX networks along with very slow speeds.

```
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Microcode SW error detected. Restarting 0x0.
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Start IWL Error Log Dump:
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Status: 0x00000040, count: 6
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Loaded firmware version: 59.601f3a66.0 QuZ-a0-hr-b0-59.ucode
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x000019D7 | ADVANCED_SYSASSERT          
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000BE06 | trm_hw_status0
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | trm_hw_status1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x004CB046 | branchlink2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x004C12A2 | interruptlink1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x004C12A2 | interruptlink2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000077 | data1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000070 | data2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000007E | data3
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x04404F9A | beacon time
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x9D9A9088 | tsf low
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000012C | tsf hi
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | time gp1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00499063 | time gp2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000001 | uCode revision type
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000003B | uCode version major
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x601F3A66 | uCode version minor
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000351 | hw version
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x58C89004 | board version
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0477001C | hcmd
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0xE6F2B400 | isr0
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x01440000 | isr1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x08F0011A | isr2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00C6200F | isr3
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | isr4
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0476001C | last cmd Id
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00012A06 | wait_event
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000094 | l2p_control
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0001BC34 | l2p_duration
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | l2p_mhvalid
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x000000C7 | l2p_addr_match
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000009 | lmpm_pmg_sel
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | timestamp
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x000088F8 | flow_handler
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Start IWL Error Log Dump:
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Status: 0x00000040, count: 7
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x20000070 | NMI_INTERRUPT_LMAC_FATAL
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | umac branchlink1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x80456E90 | umac branchlink2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x804780C0 | umac interruptlink1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x804780C0 | umac interruptlink2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000400 | umac data1
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x804780C0 | umac data2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | umac data3
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000003B | umac major
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x601F3A66 | umac minor
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00499085 | frame pointer
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0xC0886274 | stack pointer
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0054019C | last host cmd
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000000 | isr status reg
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Fseq Registers:
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x60000000 | FSEQ_ERROR_CODE
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x80290033 | FSEQ_TOP_INIT_VERSION
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00090006 | FSEQ_CNVIO_INIT_VERSION
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000A482 | FSEQ_OTP_VERSION
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x00000003 | FSEQ_TOP_CONTENT_VERSION
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x4552414E | FSEQ_ALIVE_TOKEN
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x20000302 | FSEQ_CNVI_ID
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x01300504 | FSEQ_CNVR_ID
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x20000302 | CNVI_AUX_MISC_CHIP
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x01300504 | CNVR_AUX_MISC_CHIP
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x05B0905B | CNVR_SCU_SD_REGS_SD_REG_DIG_DCDC_VTRIM
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: 0x0000025B | CNVR_SCU_SD_REGS_SD_REG_ACTIVE_VDIG_MIRROR
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: WRT: Collecting data: ini trigger 4 fired.
Jun 09 12:15:09 nixos kernel: ieee80211 phy2: Hardware restart was requested
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Got NSS = 4 - trimming to 2
Jun 09 12:15:09 nixos kernel: iwlwifi 0000:00:14.3: Got NSS = 4 - trimming to 2
```