### PR TITLE
Remove intel drivers from nvidia-disable

### DIFF
--- a/common/gpu/nvidia-disable.nix
+++ b/common/gpu/nvidia-disable.nix
@@ -6,5 +6,4 @@
   ##### disable nvidia, very nice battery life.
   hardware.nvidiaOptimus.disable = lib.mkDefault true;
   boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" ];
-  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
 }


### PR DESCRIPTION
Two reasons for this change:
- `intel` drivers are not updated from quite a long time (since ~2019), and `modesetting` is the preferred one for Intel iGPUs.
- Technically you may want to disable NVIDIA GPUs on laptops with AMD processors too.

We don't want to pin `modesetting` here because it is already the default since PR: https://github.com/NixOS/nixpkgs/pull/111551.