### PR TITLE
rpi4: add module for audio settings

### DIFF
--- a/raspberry-pi/4/audio.nix
+++ b/raspberry-pi/4/audio.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".audio;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".audio = {
+      enable = lib.mkEnableOption ''
+        configuration for audio
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.deviceTree = {
+      overlays = [
+        # Equivalent to dtparam=audio=on
+        {
+          name = "audio-on-overlay";
+          dtsText = ''
+            /dts-v1/;
+            /plugin/;
+            / {
+              compatible = "brcm,bcm2711";
+              fragment@0 {
+                target = <&audio>;
+
+                __overlay__ {
+                  status = "okay";
+                };
+              };
+            };
+          '';
+        }
+      ];
+    };
+  };
+}
+

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./audio.nix
     ./dwc2.nix
     ./modesetting.nix
     ./poe-hat.nix


### PR DESCRIPTION
This adds an option to enable and configure audio on the Raspberry Pi 4.

### Usage

```nix
{
  imports = [
    ./nixos-hardware/raspberry-pi/4
  ];

  hardware.raspberry-pi."4".audio.enable = true;
}
```

Enabling this setting does two things:
1. Apply a dts overlay that is equivalent to `dtparam=audio=on`. This was [authored](https://gist.github.com/samueldr/e83102caf431ccef8bc2e825f9273ca7) by @samueldr, who told me to test and make a PR and here we are :)
2. configure `module-udev-detect` with `tsched=0` in pulseaudio's `default.pa`. This is a commonly recommended fix ([1](https://steamcommunity.com/app/353380/discussions/6/1642042464753800526) [2](https://steamcommunity.com/app/353380/discussions/6/1642042464753800526) [3](https://wiki.archlinux.org/title/PulseAudio/Troubleshooting#Glitches,_skips_or_crackling)) for audio glitches that appear after a while of usage. I haven't had audio issues since adding this snippet.

I don't know what the policies are around fixes like the second one on this repo? I thought it'd be easiest to make this PR as a basis for discussion. :)