### PR TITLE
raspberry-pi/4: Include tsched=0 fix in audio module

### DIFF
--- a/raspberry-pi/4/audio.nix
+++ b/raspberry-pi/4/audio.nix
@@ -35,6 +35,12 @@ in
         }
       ];
     };
+
+    # set tsched=0 in pulseaudio config to avoid audio glitches
+    # see https://wiki.archlinux.org/title/PulseAudio/Troubleshooting#Glitches,_skips_or_crackling
+    hardware.pulseaudio.configFile = lib.mkDefault pkgs.runCommand "default.pa" {} ''
+      sed 's/module-udev-detect$/module-udev-detect tsched=0/' ${config.hardware.pulseaudio.package}/etc/pulse/default.pa > $out
+    '';
   };
 }
 


### PR DESCRIPTION
Follow-up to #301 :)

Watched a video yesterday evening, got audio glitches after some 15 minutes. Applied the setting, audio issues gone.