### PR TITLE
lenovo/thinkpad/e495: use native acpi backlight

### DIFF
--- a/lenovo/thinkpad/e495/default.nix
+++ b/lenovo/thinkpad/e495/default.nix
@@ -8,4 +8,10 @@
 
   # see https://github.com/NixOS/nixpkgs/issues/69289
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.2") pkgs.linuxPackages_latest;
+
+  boot.kernelParams = [
+    # Force use of the thinkpad_acpi driver for backlight control.
+    # This allows the backlight save/load systemd service to work.
+    "acpi_backlight=native"
+  ];
 }


### PR DESCRIPTION
Saving/loading the backlight state requires the `acpi_backlight=native` kernel parameter.