### PR TITLE
remove systemd-boot from hardware profiles

### DIFF
--- a/apple/macbook-pro/10-1/default.nix
+++ b/apple/macbook-pro/10-1/default.nix
@@ -6,10 +6,6 @@
     ../../../common/pc/laptop/ssd
   ];
 
-  # TODO: boot loader
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
   # TODO: reverse compat
   hardware.opengl.driSupport32Bit = true;
 

--- a/dell/xps/13-9360/default.nix
+++ b/dell/xps/13-9360/default.nix
@@ -8,12 +8,6 @@
 
   boot.blacklistedKernelModules = [ "psmouse" ]; # touchpad goes over i2c
 
-  # TODO: decide on boot loader policy
-  boot.loader = {
-    efi.canTouchEfiVariables = lib.mkDefault true;
-    systemd-boot.enable = lib.mkDefault true;
-  };
-
   # This will save you money and possibly your life!
   services.thermald.enable = true;
 }

--- a/dell/xps/15-9560/xps-common.nix
+++ b/dell/xps/15-9560/xps-common.nix
@@ -1,10 +1,7 @@
 { lib, ... }:
 
 {
-
   # Boot loader
-  boot.loader.systemd-boot.enable = lib.mkDefault true;
-  boot.loader.efi.canTouchEfiVariables = lib.mkDefault true;
   boot.kernelParams = lib.mkDefault [ "acpi_rev_override" ];
 
   # This will save you money and possibly your life!

--- a/dell/xps/15-9560/xps-common.nix
+++ b/dell/xps/15-9560/xps-common.nix
@@ -1,7 +1,6 @@
 { lib, ... }:
 
 {
-  # Boot loader
   boot.kernelParams = lib.mkDefault [ "acpi_rev_override" ];
 
   # This will save you money and possibly your life!


### PR DESCRIPTION
- We should not enable canTouchEfiVariables by default as this
  wears out the EFI storage.
- We should not set systemd-boot as default. This is up to the user to
  decide. There are exceptions when hardware only supports specific
  bootloaders so.