### PR TITLE
raspberry-pi/4: fix usage of mkDefault in audio module

### DIFF
--- a/raspberry-pi/4/audio.nix
+++ b/raspberry-pi/4/audio.nix
@@ -38,9 +38,9 @@ in
 
     # set tsched=0 in pulseaudio config to avoid audio glitches
     # see https://wiki.archlinux.org/title/PulseAudio/Troubleshooting#Glitches,_skips_or_crackling
-    hardware.pulseaudio.configFile = lib.mkDefault pkgs.runCommand "default.pa" {} ''
+    hardware.pulseaudio.configFile = lib.mkOverride 990 (pkgs.runCommand "default.pa" {} ''
       sed 's/module-udev-detect$/module-udev-detect tsched=0/' ${config.hardware.pulseaudio.package}/etc/pulse/default.pa > $out
-    '';
+    '');
   };
 }
 


### PR DESCRIPTION
Fixes #302, by fixing the syntax (parenthesis) and using mkOverride 990 as a slightly higher priority default - two identical priorities apparently also clash.