### PR TITLE
Fix source repo for MS Surface Go ATH10k Firmware image

### DIFF
--- a/microsoft/surface/firmware/surface-go/ath10k/ath10k-replace.nix
+++ b/microsoft/surface/firmware/surface-go/ath10k/ath10k-replace.nix
@@ -22,7 +22,7 @@ firmwareLinuxNonfree.overrideAttrs (old: rec {
     cp ${killernetworking_firmware}/board.bin $out/lib/firmware/ath10k/QCA6174/hw3.0/
   '';
 
-  outputHash = "1zvahsp06vikp83r89wkccwq7mixjiwcv10chw1xyikfjkqr48hr";
+  outputHash = "176cf5b9f370x2a532h2afjfkrxy13gqdygc11bam0sg8dlnrv21";
 
   meta = with lib; {
     description = "Standard binary firmware collection, adjusted with the Surface Go WiFi firmware";

--- a/microsoft/surface/firmware/surface-go/ath10k/ath10k-replace.nix
+++ b/microsoft/surface/firmware/surface-go/ath10k/ath10k-replace.nix
@@ -1,8 +1,7 @@
 {stdenv, lib, pkgs, firmwareLinuxNonfree, ...}:
 let
   repos = (pkgs.callPackage ../../../repos.nix {});
-  # killernetworking_firmware = ./K1535_Debian;
-  killernetworking_firmware = repos.ath10k-firmware + "/K1535_Debian";
+  killernetworking_firmware = repos.surface-go-ath10k-firmware_backup + "/K1535_Debian";
 in
 firmwareLinuxNonfree.overrideAttrs (old: rec {
   pname = "microsoft-surface-go-firmware-linux-nonfree";
@@ -23,7 +22,7 @@ firmwareLinuxNonfree.overrideAttrs (old: rec {
     cp ${killernetworking_firmware}/board.bin $out/lib/firmware/ath10k/QCA6174/hw3.0/
   '';
 
-  outputHash = "1nc56qii96dfvxnv3ad3lxz2rzyqcbldk0h9rbm3l2pgamkvj8dw";
+  outputHash = "1zvahsp06vikp83r89wkccwq7mixjiwcv10chw1xyikfjkqr48hr";
 
   meta = with lib; {
     description = "Standard binary firmware collection, adjusted with the Surface Go WiFi firmware";


### PR DESCRIPTION
The standard ATH10k source image doesn't work, and the version from KillerNetworking fails to download with non-browser tools.
This adjusts the source repo to github.com/mexisme/linux-surface_ath10k-firmware which is a mirror of the KillerNetworking image.

Note: https://github.com/linux-surface/linux-surface/issues/542 (via https://github.com/linux-surface/linux-surface/issues/41) will hopefully make this obsolete in the future, but getting the updated firmware image into the Kernel has proved slow and challenging.