### PR TITLE
lenovo/thinkpad/t420: add tp-smapi

### DIFF
--- a/lenovo/thinkpad/t420/default.nix
+++ b/lenovo/thinkpad/t420/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../.
+    ../tp-smapi.nix
     ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc/laptop/acpi_call.nix
   ];


### PR DESCRIPTION
The T420 seems to have partial (readonly) support for the tp-smapi module, which TLP can make use of:

> Install tp-smapi kernel modules for extended battery info (e.g. the cycle count)

See https://github.com/linrunner/TLP/commit/903d7fa67d8da61af85d59e9bd5eac371d366dc1