### PR TITLE
Update E14 AMD

### DIFF
--- a/lenovo/thinkpad/e14/amd/default.nix
+++ b/lenovo/thinkpad/e14/amd/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../.
     ../../../../common/cpu/amd
+    ../../../../common/gpu/amd
   ];
 
   boot.kernelParams = [
@@ -11,13 +12,9 @@
     # either crashes or is not able to attach to the GPU depending on
     # the kernel version. I've seen no issues with the IOMMU disabled.
     #
-    # BIOS version 1.13 claims to fix IOMMU issues, but we leave the
-    # IOMMU off to avoid a sad experience for those people that drew
+    # BIOS version 1.13 fixes the IOMMU issues, but we leave the IOMMU
+    # in software mode to avoid a sad experience for those people that drew
     # the short straw when they bought their laptop.
-    "iommu=off"
+    "iommu=soft"
   ];
-
-  # As of writing this, Linux 5.8 is the oldest kernel that is still
-  # supported and has decent Renoir support.
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.8") pkgs.linuxPackages_latest;
 }

--- a/lenovo/thinkpad/e14/default.nix
+++ b/lenovo/thinkpad/e14/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../.
+    ../../../common/pc/laptop/ssd
     ../../../common/pc/laptop/acpi_call.nix
   ];
 


### PR DESCRIPTION
This updates the settings for the Thinkpad E14 AMD.

These changes are based on the changes @blitz made for the L14 and also work for the E14. I tested this for a while and am currently running this configuration.