### PR TITLE
kobol/helios64: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ See code for all available configurations.
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
 | [Inverse Path USB armory](inversepath/usbarmory)                    | `<nixos-hardware/inversepath/usbarmory>`           |
+| [Kobol Helios64](kobol/helios64)                                    | `<nixos-hardware/kobol/helios64>`                  |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                          | `<nixos-hardware/lenovo/ideapad/z510>`             |
 | [Lenovo ThinkPad E14 (Intel)](lenovo/thinkpad/e14/intel)            | `<nixos-hardware/lenovo/thinkpad/e14/intel>`       |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                | `<nixos-hardware/lenovo/thinkpad/e14/amd>`         |

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;
       inversepath-usbarmory = import ./inversepath/usbarmory;
+      kobol-helios64 = import ./kobol/helios64;
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;
       lenovo-thinkpad-e14-intel = import ./lenovo/thinkpad/e14/intel;
       lenovo-thinkpad-e14-amd = import ./lenovo/thinkpad/e14/amd;

--- a/kobol/helios64/README.md
+++ b/kobol/helios64/README.md
@@ -1,0 +1,57 @@
+Kobol Helios64
+==============
+
+The `default.nix` module provides the required setup for the system to work.
+
+The `recommended.nix` module adds recommended settings for the system.
+
+Status
+------
+
+### Works
+
+ - SATA hard drives
+ - Ethernet (1gbps)
+ - Serial through USB type-c (`ttyS2`)
+
+### Untested
+
+ - Ethernet (2.5gbps)
+ - DP video out
+ - UPS behaviour
+ - `rootfs` on SATA drives
+
+### Disabled
+
+Due to misbehaviour, `ttyS0` (`&uart0`, `serial@ff180000`) has been disabled
+via a kernel patch.
+
+Without this change, using, or attempting to use `ttyS0` will break serial
+output from `ttyS2`.
+
+
+Kernel
+------
+
+Only Linux 5.10 (LTS) is supported, using the patch set derived from Armbian.
+
+
+Requirements
+------------
+
+A *platform firmware* needs to be provided out of band for the system.
+
+The author recommends Tow-Boot, for which a [draft pull request](https://github.com/Tow-Boot/Tow-Boot/pull/54)
+adds support for the Helios64.
+
+Any other supported *platform firmware* should work too.
+
+
+Notes
+-----
+
+### Baud rate
+
+The serial baud rate is configured for `115200`, which is a more common default
+than the usual for Rockchip at `1500000`. See [the rationale for the decision](https://github.com/Tow-Boot/Tow-Boot/pull/33).
+

--- a/kobol/helios64/README.md
+++ b/kobol/helios64/README.md
@@ -46,6 +46,11 @@ adds support for the Helios64.
 
 Any other supported *platform firmware* should work too.
 
+> **NOTE**: at the time of writing (2021-10-10) the *platform firmware*
+> **must** make use of the proprietary ram training. The open source equivalent
+> will make the system unstable, and worse, will cause silent memory
+> corruption, in addition to loud memory corruption.
+
 
 Notes
 -----

--- a/kobol/helios64/default.nix
+++ b/kobol/helios64/default.nix
@@ -1,0 +1,22 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [
+    ./modules/fancontrol.nix
+    ./modules/heartbeat.nix
+    ./modules/ups.nix
+    ./modules/usbnet.nix
+  ];
+
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  boot.kernelParams = lib.mkAfter [
+    "console=ttyS2,115200n8"
+    "earlyprintk"
+    "earlycon=uart8250,mmio32,0xff1a0000"
+  ];
+
+  boot.kernelPackages = pkgs.linuxPackagesFor pkgs.linux_5_10_helios64;
+}

--- a/kobol/helios64/modules/bsp/50-usb-realtek-net.rules
+++ b/kobol/helios64/modules/bsp/50-usb-realtek-net.rules
@@ -1,0 +1,38 @@
+# This is used to change the default configuration of Realtek USB ethernet adapters
+
+ACTION!="add", GOTO="usb_realtek_net_end"
+SUBSYSTEM!="usb", GOTO="usb_realtek_net_end"
+ENV{DEVTYPE}!="usb_device", GOTO="usb_realtek_net_end"
+
+# Modify this to change the default value
+ENV{REALTEK_NIC_MODE}="1"
+
+# Realtek
+ATTR{idVendor}=="0bda", ATTR{idProduct}=="8156", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="0bda", ATTR{idProduct}=="8153", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="0bda", ATTR{idProduct}=="8152", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+
+# Samsung
+ATTR{idVendor}=="04e8", ATTR{idProduct}=="a101", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+
+# Lenovo
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="304f", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3052", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3054", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3057", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3082", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="7205", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="720a", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="720b", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="720c", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="721e", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="a359", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="a387", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+
+# TP-LINK
+ATTR{idVendor}=="2357", ATTR{idProduct}=="0601", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+
+# Nvidia
+ATTR{idVendor}=="0955", ATTR{idProduct}=="09ff", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+
+LABEL="usb_realtek_net_end"

--- a/kobol/helios64/modules/bsp/70-keep-usb-lan-as-eth1.rules
+++ b/kobol/helios64/modules/bsp/70-keep-usb-lan-as-eth1.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="eth1"

--- a/kobol/helios64/modules/bsp/90-helios64-hwmon.rules
+++ b/kobol/helios64/modules/bsp/90-helios64-hwmon.rules
@@ -1,0 +1,23 @@
+# Helios64 persistent hwmon
+
+ACTION=="remove", GOTO="helios64_hwmon_end"
+
+#
+KERNELS=="p6-fan", SUBSYSTEMS=="platform", ENV{_HELIOS64_FAN_}="p6", ENV{_IS_HELIOS64_FAN_}="1", ENV{IS_HELIOS64_HWMON}="1"
+KERNELS=="p7-fan", SUBSYSTEMS=="platform", ENV{_HELIOS64_FAN_}="p7", ENV{_IS_HELIOS64_FAN_}="1", ENV{IS_HELIOS64_HWMON}="1"
+KERNELS=="2-004c", SUBSYSTEMS=="i2c", DRIVERS=="lm75", ENV{IS_HELIOS64_HWMON}="1"
+
+SUBSYSTEM!="hwmon", GOTO="helios64_hwmon_end"
+
+ENV{HWMON_PATH}="/sys%p"
+#
+ATTR{name}=="cpu", ENV{IS_HELIOS64_HWMON}="1", ENV{HELIOS64_SYMLINK}="/dev/thermal-cpu"
+#
+ENV{IS_HELIOS64_HWMON}=="1", ATTR{name}=="lm75", ENV{HELIOS64_SYMLINK}="/dev/thermal-board"
+ENV{_IS_HELIOS64_FAN_}=="1", ENV{HELIOS64_SYMLINK}="/dev/fan-$env{_HELIOS64_FAN_}"
+
+#
+ENV{IS_HELIOS64_HWMON}=="1", RUN+="/bin/ln -sf $env{HWMON_PATH} $env{HELIOS64_SYMLINK}"
+
+LABEL="helios64_hwmon_end"
+

--- a/kobol/helios64/modules/bsp/90-helios64-ups.rules
+++ b/kobol/helios64/modules/bsp/90-helios64-ups.rules
@@ -1,0 +1,11 @@
+ACTION=="add", GOTO="helios64_ups_end"
+ACTION=="remove", GOTO="helios64_ups_end"
+
+# Power loss event
+ACTION=="change", SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTRS{online}=="0", RUN+="/usr/bin/systemctl start helios64-ups.timer"
+
+# Power restore event
+ACTION=="change", SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTRS{online}=="1", RUN+="/usr/bin/systemctl stop helios64-ups.timer"
+
+LABEL="helios64_ups_end"
+

--- a/kobol/helios64/modules/fancontrol.nix
+++ b/kobol/helios64/modules/fancontrol.nix
@@ -1,0 +1,41 @@
+{ pkgs, ... }:
+{
+  hardware.fancontrol.enable = true;
+  hardware.fancontrol.config = ''
+    # Helios64 PWM Fan Control Configuration
+    # Temp source : /dev/thermal-cpu
+    INTERVAL=10
+    FCTEMPS=/dev/fan-p6/pwm1=/dev/thermal-cpu/temp1_input /dev/fan-p7/pwm1=/dev/thermal-cpu/temp1_input
+    MINTEMP=/dev/fan-p6/pwm1=40 /dev/fan-p7/pwm1=40
+    MAXTEMP=/dev/fan-p6/pwm1=80 /dev/fan-p7/pwm1=80
+    MINSTART=/dev/fan-p6/pwm1=60 /dev/fan-p7/pwm1=60
+    MINSTOP=/dev/fan-p6/pwm1=29 /dev/fan-p7/pwm1=29
+    MINPWM=20
+  '';
+
+  services.udev.packages = [
+    # Fan control
+    (pkgs.callPackage (
+      { stdenv, lib, coreutils }:
+      stdenv.mkDerivation {
+        name = "helios64-udev-fancontrol";
+
+        dontUnpack = true;
+        dontBuild = true;
+
+        installPhase = ''
+          mkdir -p "$out/etc/udev/rules.d/";
+          install -Dm644 "${./bsp/90-helios64-hwmon.rules}" \
+            "$out/etc/udev/rules.d/90-helios64-hwmon.rules"
+          substituteInPlace "$out/etc/udev/rules.d/90-helios64-hwmon.rules" \
+            --replace '/bin/ln'  '${lib.getBin coreutils}/bin/ln'
+        '';
+
+        meta = with lib; {
+          description = "Udev rules for fancontrol for the Helios64";
+          platforms = platforms.linux;
+        };
+      }
+    ) {})
+  ];
+}

--- a/kobol/helios64/modules/heartbeat.nix
+++ b/kobol/helios64/modules/heartbeat.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, ... }:
+{
+  systemd.services.heartbeat = {
+    enable = true;
+    description = "Enable heartbeat & network activity led on Helios64";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = ''
+        ${lib.getBin pkgs.bash}/bin/bash -c 'echo heartbeat | ${lib.getBin pkgs.coreutils}/bin/tee /sys/class/leds/helios64\\:\\:status/trigger'
+        ${lib.getBin pkgs.bash}/bin/bash -c 'echo netdev | ${lib.getBin pkgs.coreutils}/bin/tee /sys/class/leds/helios64\\:blue\\:net/trigger'
+        ${lib.getBin pkgs.bash}/bin/bash -c 'echo eth0 | ${lib.getBin pkgs.coreutils}/bin/tee /sys/class/leds/helios64\\:blue\\:net/device_name'
+        ${lib.getBin pkgs.bash}/bin/bash -c 'echo 1 | ${lib.getBin pkgs.coreutils}/bin/tee /sys/class/leds/helios64\\:blue\\:net/link'
+        ${lib.getBin pkgs.bash}/bin/bash -c 'echo 1 | ${lib.getBin pkgs.coreutils}/bin/tee /sys/class/leds/helios64\\:blue\\:net/rx'
+        ${lib.getBin pkgs.bash}/bin/bash -c 'echo 1 | ${lib.getBin pkgs.coreutils}/bin/tee /sys/class/leds/helios64\\:blue\\:net/tx'
+      '';
+    };
+    after = [ "getty.target" ];
+    wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/kobol/helios64/modules/ups.nix
+++ b/kobol/helios64/modules/ups.nix
@@ -1,0 +1,51 @@
+{ pkgs, ... }:
+{
+  systemd.services.helios64-ups = {
+    enable = true;
+    description = "Helios64 UPS Action";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.systemd}/bin/poweroff";
+    };
+  };
+
+  systemd.timers.helios64-ups = {
+    enable = true;
+    description = "Helios64 UPS Shutdown timer on power loss";
+    # disabling the timer by default. Even though armbian enaled
+    # the timer by default through this, we don't, as we can't
+    # rely on the udev rules to disable it after a system switch.
+    # wantedBy = [ "multi-user.target" ];
+    timerConfig = {
+      OnActiveSec = "10m";
+      AccuracySec = "1s";
+      Unit = "helios64-ups.service";
+    };
+  };
+  # The udev rule that will trigger the above service.
+  services.udev.packages = [
+    (pkgs.callPackage (
+      { stdenv, lib, coreutils, systemd }:
+      stdenv.mkDerivation {
+          name = "helios64-udev-ups";
+
+          dontUnpack = true;
+          dontBuild = true;
+
+          installPhase = ''
+              mkdir -p "$out/etc/udev/rules.d/";
+              install -Dm644 "${./bsp/90-helios64-ups.rules}" \
+                "$out/etc/udev/rules.d/90-helios64-ups.rules"
+              substituteInPlace "$out/etc/udev/rules.d/90-helios64-ups.rules" \
+                  --replace '/bin/ln'  '${lib.getBin coreutils}/bin/ln' \
+                  --replace '/usr/bin/systemctl' '${lib.getBin systemd}/bin/systemctl'
+          '';
+
+          meta = with lib; {
+              description = "Udev rules for UPS for the Helios64";
+              platforms = platforms.linux;
+          };
+      }
+    ) {})
+  ];
+}

--- a/kobol/helios64/modules/usbnet.nix
+++ b/kobol/helios64/modules/usbnet.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }:
+
+{
+  services.udev.packages = [
+    # this one will set the usb net ethernet into the right mode
+    # and stop it from spamming the console.
+    (pkgs.callPackage (
+      { stdenv, lib, coreutils }:
+      stdenv.mkDerivation {
+        name = "helios64-udev-usb-net";
+
+        dontUnpack = true;
+        dontBuild = true;
+
+        installPhase = ''
+          mkdir -p "$out/etc/udev/rules.d/";
+          install -Dm644 "${./bsp/50-usb-realtek-net.rules}" \
+            "$out/etc/udev/rules.d/50-usb-realtek-net.rules"
+          install -Dm644 "${./bsp/70-keep-usb-lan-as-eth1.rules}" \
+            "$out/etc/udev/rules.d/70-keep-usb-lan-as-eth1.rules"
+          substituteInPlace "$out/etc/udev/rules.d/50-usb-realtek-net.rules" \
+          --replace '/bin/ln'  '${lib.getBin coreutils}/bin/ln'
+        '';
+
+        meta = with lib; {
+          description = "Udev rules for the USB network interface for the Helios64";
+          platforms = platforms.linux;
+        };
+      }
+    ) {})
+  ];
+}

--- a/kobol/helios64/overlay.nix
+++ b/kobol/helios64/overlay.nix
@@ -1,0 +1,74 @@
+self: super: {
+  linux_5_10_helios64 = self.linux_5_10.override {
+
+    kernelPatches = [
+      {
+        name = "helios64-patch-set.patch";
+        patch = self.fetchurl {
+          # v5.10.68..v5.10-helios64-2021-10-10 @ https://github.com/samueldr/linux
+          # Hosted as a pre-rendered patch because `fetchpatch` strips added files.
+          url = "https://gist.githubusercontent.com/samueldr/1a409f88f2107054c87a70403686b871/raw/abee3d5d5415c466f8111371b63f759f614547c6/helios64.patch";
+          sha256 = "1gx2z345vb4r2mdfmydbzc5baj58rrn416rzb2fz7azxpyib5ym4";
+        };
+      }
+    ];
+
+    # Configuration mainly to remove unused platforms and things.
+    structuredExtraConfig = with self.lib.kernel; {
+      ARCH_ROCKCHIP = yes;
+
+      ARCH_ACTIONS = no;
+      ARCH_AGILEX = no;
+      ARCH_SUNXI = no;
+      ARCH_ALPINE = no;
+      ARCH_BCM2835 = no;
+      ARCH_BERLIN = no;
+      ARCH_BRCMSTB = no;
+      ARCH_EXYNOS = no;
+      ARCH_K3 = no;
+      ARCH_LAYERSCAPE = no;
+      ARCH_LG1K = no;
+      ARCH_HISI = no;
+      ARCH_MEDIATEK = no;
+      ARCH_MESON = no;
+      ARCH_MVEBU = no;
+      ARCH_MXC = no;
+      ARCH_QCOM = no;
+      ARCH_RENESAS = no;
+      ARCH_S32 = no;
+      ARCH_SEATTLE = no;
+      ARCH_STRATIX10 = no;
+      ARCH_SYNQUACER = no;
+      ARCH_TEGRA = no;
+      ARCH_SPRD = no;
+      ARCH_THUNDER = no;
+      ARCH_THUNDER2 = no;
+      ARCH_UNIPHIER = no;
+      ARCH_VEXPRESS = no;
+      ARCH_VISCONTI = no;
+      ARCH_XGENE = no;
+      ARCH_ZX = no;
+      ARCH_ZYNQMP = no;
+      ARCH_RANDOM = no;
+      ARCH_R8A77995 = no;
+      ARCH_R8A77990 = no;
+      ARCH_R8A77950 = no;
+      ARCH_R8A77951 = no;
+      ARCH_R8A77965 = no;
+      ARCH_R8A77960 = no;
+      ARCH_R8A77961 = no;
+      ARCH_R8A77980 = no;
+      ARCH_R8A77970 = no;
+      ARCH_R8A774C0 = no;
+      ARCH_R8A774E1 = no;
+      ARCH_R8A774A1 = no;
+      ARCH_R8A774B1 = no;
+      ARCH_STACKWALK = no;
+    };
+  };
+
+  # Force modules closure to be built even if some modules are missing
+  # (Workaround for a NixOS change in strictness)
+  makeModulesClosure = x:
+    super.makeModulesClosure (x // { allowMissing = true; });
+}

--- a/kobol/helios64/recommended.nix
+++ b/kobol/helios64/recommended.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+{
+  # Since 20.03, you must explicitly specify to use dhcp on an interface
+  networking.interfaces.eth0.useDHCP = lib.mkDefault true;
+
+  # Helps with 4GiB of RAM
+  zramSwap.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
This adds support for the Kobol Helios64 to nixos-hardware.

This pull request does not configure anything related to either the *platform firmware* or the *bootloader*, by design.

The kernel used is mainline 5.10 (LTS), with a patchset [borrowed from Armbian](https://github.com/armbian/build/tree/744ea89a589d62cb6f409baab60fc6664520bc39/patch/kernel/archive/rockchip64-5.10). Only generic patches or Helios64 patches were kept from that directory. Their *overlay* patches were dropped.

> :warning: **The platform firmware requires usage of the proprietary RAM training!!** Using the default open source RAM training from U-Boot *will cause instability*. This instability is observed in memory being unreliable in different scenarios, but generally under load. *This instability can lead to data loss.* Under the same scenarios, and harsher scenarios, using the proprietary RAM training was rock solid, while the open source RAM training was pretty reproducibly problematic.

* * *

[I would like to make it easy for end-users to build an installer image](https://github.com/NixOS/nixos-hardware/issues/317) (either SD image or UEFI iso) before merging this.

* * *

I recommend my own project (Tow-Boot) for the *platform firmware*. Hopefully this is okay to do.

* * *

I have been playing with the SD image build, booted from USB, and it seems to work just fine for NAS use cases.

* * *

cc @angerman