### PR TITLE
AMD: include 32-bit driver for Vulkan

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -10,6 +10,10 @@
     amdvlk
   ];
 
+  hardware.opengl.extraPackages32 = with pkgs; [
+    driversi686Linux.amdvlk
+  ];
+
   hardware.opengl = {
     driSupport = lib.mkDefault true;
     driSupport32Bit = lib.mkDefault true;


### PR DESCRIPTION
In order for many Proton Games to work OOTB with modern AMD graphics cards `driversi686Linux.amdvlk` is needed.

I didn't include the package previously as it hadn't been backported into stable, now I think it's a good time to include it.