### PR TITLE
fix(intel): add opengl packages for 32bit

### DIFF
--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -12,4 +12,11 @@
     libvdpau-va-gl
     intel-media-driver
   ];
+
+  hardware.opengl.extraPackages32 = with pkgs.pkgsi686Linux; [
+    vaapiIntel
+    vaapiVdpau
+    libvdpau-va-gl
+    intel-media-driver
+  ];
 }


### PR DESCRIPTION
At the moment the OpenGL extraPackages for Intel are only added for the 64bit variant, but not the 32bit one.
The AMD does add its modules to the 32bit variant: https://github.com/NixOS/nixos-hardware/blob/a57fc74bc3c88537b7f80bc7bee428dd9e9a34ca/common/gpu/amd/default.nix#L13-L15

Note that `pkgsi686Linux` was used instead of `driversi686Linux`, because `intel-media-driver` was not defined for `driversi686Linux` in nixpkgs: https://github.com/nixos/nixpkgs/blob/87304645b876629a056d4e4b3043b99d125a054d/pkgs/top-level/all-packages.nix#L15882-L15892