### PR TITLE
Use a more recent kernel for Thinkpad X1

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X280](lenovo/thinkpad/x280)                        | `<nixos-hardware/lenovo/thinkpad/x280>`            |
 | [Lenovo ThinkPad X1 (6th Gen)](lenovo/thinkpad/x1/6th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`      |
 | [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`      |
+| [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`      |
 | [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2) | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>` |
 | [Lenovo ThinkPad X13](lenovo/thinkpad/x13)                          | `<nixos-hardware/lenovo/thinkpad/x13>`             |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
       lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
       lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
       lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
+      lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;
       lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
       lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
       lenovo-thinkpad-x13 = import ./lenovo/thinkpad/x13;

--- a/lenovo/thinkpad/x1/9th-gen/default.nix
+++ b/lenovo/thinkpad/x1/9th-gen/default.nix
@@ -1,0 +1,11 @@
+{ lib, pkgs, ... }:
+{
+  imports = [
+    ../.
+  ];
+
+  # This solves lagging noticeable on high-resolution screens.
+  boot.kernelPackages = lib.mkIf
+    (lib.versionOlder pkgs.linux.version "5.15")
+    (lib.mkDefault pkgs.linuxPackages_latest);
+}


### PR DESCRIPTION
This solves lagging noticeable on high-resolution screens.