### PR TITLE
Revert "Merge pull request #333 from bobvanderlinden/pr-intel-32bit"

### DIFF
--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -12,11 +12,4 @@
     libvdpau-va-gl
     intel-media-driver
   ];
-
-  hardware.opengl.extraPackages32 = with pkgs.pkgsi686Linux; [
-    vaapiIntel
-    vaapiVdpau
-    libvdpau-va-gl
-    intel-media-driver
-  ];
 }


### PR DESCRIPTION
Reverts pr #333 as it breaks 21.05 based configurations.
Error:
`error: Package ‘intel-gmmlib-21.1.3’ in /nix/store/ql6s3pl8gfv6v1n3ffsww0yspbji5lx3-source/pkgs/development/libraries/intel-gmmlib/default.nix:21 is not supported on ‘i686-linux’, refusing to evaluate.`

To prevent people having to spend time to trace this error back to nixos-hardware, I think we should revert this now and discuss a solution afterwards.