### PR TITLE
xps-9310: Remove upstreamed kernel patches with custom config

### DIFF
--- a/dell/xps/13-9310/default.nix
+++ b/dell/xps/13-9310/default.nix
@@ -4,26 +4,13 @@
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];
-  
+
 
   # Includes the Wi-Fi and Bluetooth firmware for the QCA6390.
   hardware.enableRedistributableFirmware = true;
 
+  # Requires at least 5.12 for working wi-fi and bluetooth.
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.12") (lib.mkDefault pkgs.linuxPackages_latest);
-  # TODO: upstream this to NixOS
-  boot.kernelPatches = [{
-    name = "enable-qca6390-bluetooth";
-    patch = null;
-    extraConfig = ''
-      BT_QCA m
-      BT_HCIUART m
-      BT_HCIUART_QCA y
-      BT_HCIUART_SERDEV y
-      SERIAL_DEV_BUS y
-      SERIAL_DEV_CTRL_TTYPORT y
-    '';
-  }];
-  boot.kernelModules = [ "btqca" "hci_qca" "hci_uart" ];
 
   # Touchpad goes over i2c.
   # Without this we get errors in dmesg on boot and hangs when shutting down.


### PR DESCRIPTION
I've upstreamed these patches in NixOS/nixpkgs#144409, which means we no
longer have to build the kernel every time we update just to get
bluetooth working :tada:

While these changes have landed in master, they haven't been back-ported
to 21.05. They will be available via 21.11, which I'm currently testing
(along with this commit) by setting my `nixos` channel to the necessary
nixpkgs pre-release branch, e.g.

```bash
sudo nix-channel --remove nixos
sudo nix-channel --add https://github.com/NixOS/nixpkgs/archive/release-21.11.tar.gz nixos
sudo nix-channel --update nixos
```

*Note that if you use the above branch like I am, you might miss the
cache on some pkgs and spend even longer building those (looking at you
libreoffice).*

As of writing this PR, the current kernel is 5.15.4 and all seems to be
working well.