### PR TITLE
nanopc-t4: remove deprecated serial speed

### DIFF
--- a/friendlyarm/nanopc-t4/default.nix
+++ b/friendlyarm/nanopc-t4/default.nix
@@ -8,7 +8,7 @@
   };
 
   # UART debug console bitrates.
-  services.mingetty.serialSpeed = [ 1500000 115200 ];
+  boot.kernelParams = [ "console=ttyS2,1500000" ];
 
   # Enable additional firmware (such as Wi-Fi drivers).
   hardware.enableRedistributableFirmware = lib.mkDefault true;


### PR DESCRIPTION
This option no longer has any effects. We can set kernel parameter now, but since I don't this device it's not clear to me which tty I would need to configure.

cc @jakubgs 