### PR TITLE
thinkpad/x1: import ssd config for relevant models

### DIFF
--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -10,6 +10,7 @@
   imports = [
     ../.
     ../../../../common/pc/laptop/acpi_call.nix
+    ../../../../common/pc/laptop/ssd
   ];
 
   # New ThinkPads have a different TrackPoint manufacturer/name.

--- a/lenovo/thinkpad/x1/7th-gen/default.nix
+++ b/lenovo/thinkpad/x1/7th-gen/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ../.
     ../../../../common/pc/laptop/acpi_call.nix
+    ../../../../common/pc/laptop/ssd
     ./audio.nix
   ];
 }

--- a/lenovo/thinkpad/x1/9th-gen/default.nix
+++ b/lenovo/thinkpad/x1/9th-gen/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ../.
+    ../../../../common/pc/laptop/ssd
   ];
 
   # This solves lagging noticeable on high-resolution screens.


### PR DESCRIPTION
Import ssd config for models that always use an ssd.

I did not add the import for all X1 models since the [earlier models](https://pcsupport.lenovo.com/eg/en/products/laptops-and-netbooks/thinkpad-x-series-laptops/thinkpad-x1-carbon-type-20a7-20a8/solutions/pd013126-notebook-hard-drives-reference-guide) might have an internal HDD depending on the configuration.