### PR TITLE
thinkpad/x1: enable Intel IOMMU

### DIFF
--- a/lenovo/thinkpad/x1/default.nix
+++ b/lenovo/thinkpad/x1/default.nix
@@ -3,4 +3,6 @@
     ../.
     ../../../common/cpu/intel
   ];
+
+  boot.kernelParams = [ "intel_iommu=on" ];
 }


### PR DESCRIPTION
NixOS disables the Intel IOMMU by default (NixOS/nixpkgs#4956) due to hardware comparability issues. In testing I've discovered no issues with either a X1 Gen 1 or X1 Gen 9, so it stands to reason the X1 line generally supports the Intel IOMMU.