### PR TITLE
thinkpad/x1/9th-gen: enable fwupd

### DIFF
--- a/lenovo/thinkpad/x1/9th-gen/default.nix
+++ b/lenovo/thinkpad/x1/9th-gen/default.nix
@@ -9,4 +9,7 @@
   boot.kernelPackages = lib.mkIf
     (lib.versionOlder pkgs.linux.version "5.15")
     (lib.mkDefault pkgs.linuxPackages_latest);
+  
+
+  services.fwupd.enable = true;
 }


### PR DESCRIPTION
The X1 Gen 9 supports `fwupd` for multiple types of firmware. I've successfully updated UEFI, disk, and touchpad firmware using `fwupdmgr`.