### PR TITLE
Fix flake output lenovo-thinkpad-l13-yoga

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
       lenovo-thinkpad-e470 = import ./lenovo/thinkpad/e470;
       lenovo-thinkpad-e495 = import ./lenovo/thinkpad/e495;
       lenovo-thinkpad-l13 = import ./lenovo/thinkpad/l13;
-      lenovo-thinkpad-l13-yoga = import ./lenovo/thinkpad/l13-yoga/yoga;
+      lenovo-thinkpad-l13-yoga = import ./lenovo/thinkpad/l13/yoga;
       lenovo-thinkpad-l14-intel = import ./lenovo/thinkpad/l14/intel;
       lenovo-thinkpad-l14-amd = import ./lenovo/thinkpad/l14/amd;
       lenovo-thinkpad-p1 = import ./lenovo/thinkpad/p1;


### PR DESCRIPTION
Flake output `nixosModules.lenovo-thinkpad-l13-yoga` referenced wrong module path `./lenovo/thinkpad/l13-yoga/yoga`:
```
$ nix flake check --no-build --keep-going
error (ignored): error: getting status of '/nix/store/hpj9vw2smvlwc257w96k78fk12q2v6cy-source/lenovo/thinkpad/l13-yoga': No such file or directory
error: some errors were encountered during the evaluation
```
This merge request changes the path to `./lenovo/thinkpad/l13/yoga`