### PR TITLE
thinkpad/x1/6th-gen/QHD: drop gtk hidpi env variables

### DIFF
--- a/lenovo/thinkpad/x1/6th-gen/QHD/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/QHD/default.nix
@@ -10,11 +10,6 @@
   services.xserver.dpi = 210;
   fonts.fontconfig.dpi = 210;
 
-  # Fix sizes of GTK/GNOME ui elements
-  environment.variables = {
-    GDK_SCALE = lib.mkDefault "2";
-    GDK_DPI_SCALE= lib.mkDefault "0.5";
-  };
   # Enable readable font on console. The example configuration that
   # follows is taliored towards western languages. To see how to
   # configure the font download the source tarball from


### PR DESCRIPTION
Those actually break Gnome/wayland. They might work on x11.