### PR TITLE
asus/battery.nix: fix chargeUpto after suspend/resume, make script optional

### DIFF
--- a/asus/battery.nix
+++ b/asus/battery.nix
@@ -3,19 +3,35 @@ let
   p = pkgs.writeScriptBin "charge-upto" ''
     echo ''${0:-100} > /sys/class/power_supply/BAT0/charge_control_end_threshold
   '';
-  cfg = config.hardware.asus;
+  cfg = config.hardware.asus.battery;
 in
 
 {
-  options.hardware.asus.battery.chargeUpto = lib.mkOption {
-    description = "Maximum level of charge for your battery, as a percentage.";
-    default = 100;
-    type = lib.types.int;
+  options.hardware.asus.battery = {
+    chargeUpto = lib.mkOption {
+      description = "Maximum level of charge for your battery, as a percentage.";
+      default = 100;
+      type = lib.types.int;
+    };
+    addChargeUptoScript = lib.mkOption {
+      description = "Whether to add charge-upto to environment.systemPackages. `charge-upto 75` temporarily sets the charge limit to 75%.";
+      default = true;
+      type = lib.types.bool;
+    };
   };
   config = {
-    environment.systemPackages = [ p ];
-    systemd.tmpfiles.rules = [
-      "w /sys/class/power_supply/BAT0/charge_control_end_threshold - - - - ${toString cfg.battery.chargeUpto}"
-    ];
+    environment.systemPackages = lib.mkIf cfg.addChargeUptoScript [ p ];
+    systemd.services.battery-charge-threshold = {
+      wantedBy = [ "local-fs.target" "suspend.target" ];
+      after = [ "local-fs.target" "suspend.target" ];
+      description = "Set the battery charge threshold to ${toString cfg.chargeUpto}%";
+      startLimitBurst = 5;
+      startLimitIntervalSec = 1;
+      serviceConfig = {
+        Type = "oneshot";
+        Restart = "on-failure";
+        ExecStart = "/bin/sh -c 'echo ${toString cfg.chargeUpto} > /sys/class/power_supply/BAT0/charge_control_end_threshold'";
+      };
+    };
   };
 }

--- a/asus/battery.nix
+++ b/asus/battery.nix
@@ -30,7 +30,7 @@ in
       serviceConfig = {
         Type = "oneshot";
         Restart = "on-failure";
-        ExecStart = "/bin/sh -c 'echo ${toString cfg.chargeUpto} > /sys/class/power_supply/BAT0/charge_control_end_threshold'";
+        ExecStart = "${pkgs.runtimeShell} -c 'echo ${toString cfg.chargeUpto} > /sys/class/power_supply/BAT0/charge_control_end_threshold'";
       };
     };
   };

--- a/asus/battery.nix
+++ b/asus/battery.nix
@@ -13,14 +13,14 @@ in
       default = 100;
       type = lib.types.int;
     };
-    addChargeUptoScript = lib.mkOption {
+    enableChargeUptoScript = lib.mkOption {
       description = "Whether to add charge-upto to environment.systemPackages. `charge-upto 75` temporarily sets the charge limit to 75%.";
       default = true;
       type = lib.types.bool;
     };
   };
   config = {
-    environment.systemPackages = lib.mkIf cfg.addChargeUptoScript [ p ];
+    environment.systemPackages = lib.mkIf cfg.enableChargeUptoScript [ p ];
     systemd.services.battery-charge-threshold = {
       wantedBy = [ "local-fs.target" "suspend.target" ];
       after = [ "local-fs.target" "suspend.target" ];


### PR DESCRIPTION
Fixes chargeUpto setting getting reset after suspend/resume cycle by using a systemd service which runs after suspend instead of tmpfiles.

Fixes #373 