### PR TITLE
Refactor ath10k-replace to no longer need an outputHash

### DIFF
--- a/microsoft/surface/firmware/surface-go/ath10k/ath10k-replace.nix
+++ b/microsoft/surface/firmware/surface-go/ath10k/ath10k-replace.nix
@@ -3,30 +3,23 @@ let
   repos = (pkgs.callPackage ../../../repos.nix {});
   killernetworking_firmware = repos.surface-go-ath10k-firmware_backup + "/K1535_Debian";
 in
-firmwareLinuxNonfree.overrideAttrs (old: rec {
+stdenv.mkDerivation {
   pname = "microsoft-surface-go-firmware-linux-nonfree";
-  srcs = [
-    firmwareLinuxNonfree.src
-    killernetworking_firmware
-  ];
-  sourceRoot = firmwareLinuxNonfree.src;
+  inherit (firmwareLinuxNonfree) version;
+  src = firmwareLinuxNonfree;
+  phases = [ "unpackPhase" "installPhase" ];
 
-  dontMakeSourcesWritable = true;
-  postInstall = ''
-    # Delete the non-working firmware:
-    rm -v $out/lib/firmware/ath10k/QCA6174/{hw2.1,hw3.0}/board.bin
-    rm -v $out/lib/firmware/ath10k/QCA6174/{hw2.1,hw3.0}/board-2.bin
-
+  installPhase = ''
     # Install the Surface Go Wifi firmware:
-    cp ${killernetworking_firmware}/board.bin $out/lib/firmware/ath10k/QCA6174/hw2.1/
-    cp ${killernetworking_firmware}/board.bin $out/lib/firmware/ath10k/QCA6174/hw3.0/
-  '';
+    cp ${killernetworking_firmware}/board.bin lib/firmware/ath10k/QCA6174/hw2.1/
+    cp ${killernetworking_firmware}/board.bin lib/firmware/ath10k/QCA6174/hw3.0/
 
-  outputHash = "176cf5b9f370x2a532h2afjfkrxy13gqdygc11bam0sg8dlnrv21";
+    mkdir $out; cp -r ./. $out
+  '';
 
   meta = with lib; {
     description = "Standard binary firmware collection, adjusted with the Surface Go WiFi firmware";
     platforms = platforms.linux;
     priority = 5;
   };
-})
+}


### PR DESCRIPTION
The outputHash would change and frequently cause this to not work. This
gets around the issue by using the built version firmwareLinuxNonfree as
a source instead of trying to patch it directly.