### PR TITLE
Add rpi4 pwm0 support

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -8,6 +8,7 @@
     ./modesetting.nix
     ./poe-hat.nix
     ./tc358743.nix
+    ./pwm0.nix
   ];
 
   boot = {

--- a/raspberry-pi/4/pwm0.nix
+++ b/raspberry-pi/4/pwm0.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".pwm0;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".pwm0 = {
+      enable = lib.mkEnableOption ''
+        Enable support for the hardware pwm0 channel on GPIO_18
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.deviceTree = {
+      overlays = [{
+        name = "pwm-overlay";
+        dtsText = ''
+          /dts-v1/;
+          /plugin/;
+          / {
+            compatible = "brcm,bcm2711";
+
+            fragment@0 {
+              target = <&gpio>;
+              __overlay__ {
+                pwm_pins: pwm_pins {
+                  brcm,pins = <18>;
+                  brcm,function = <2>; /* Alt5 */
+                };
+              };
+            };
+
+            fragment@1 {
+              target = <&pwm>;
+              __overlay__ {
+                pinctrl-names = "default";
+                assigned-clock-rates = <100000000>;
+                status = "okay";
+                pinctrl-0 = <&pwm_pins>;
+              };
+            };
+
+          };
+        '';
+      }];
+    };
+  };
+}


### PR DESCRIPTION
This adds hardware PWM support on GPIO 18. There's probably a better way to do this, but this should be good enough for a start.

Usage: `hardware.raspberry-pi."4".pwm0.enable = true;`
