### PR TITLE
common/cpu/intel: define VDPAU_DRIVER env variable

### DIFF
--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -3,6 +3,10 @@
 {
   boot.initrd.kernelModules = [ "i915" ];
 
+  environment.variables = {
+    VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
+  };
+
   hardware.cpu.intel.updateMicrocode =
     lib.mkDefault config.hardware.enableRedistributableFirmware;
   


### PR DESCRIPTION
`libvdpau-va-gl` is a wrapper around VAAPI to have a VDPAU driver, which is required for Intel GPU's. `VDPAU_DRIVER` environment variable is set to "va_gl" now, since it defaults to "nvidia".