### PR TITLE
extract GPU stuff from common/cpu/intel to common/gpu/intel.nix

### DIFF
--- a/common/cpu/intel/cpu-only.nix
+++ b/common/cpu/intel/cpu-only.nix
@@ -1,0 +1,6 @@
+{ config, lib, pkgs, ... }:
+
+{
+  hardware.cpu.intel.updateMicrocode =
+    lib.mkDefault config.hardware.enableRedistributableFirmware;
+}

--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -1,19 +1,8 @@
 { config, lib, pkgs, ... }:
 
 {
-  boot.initrd.kernelModules = [ "i915" ];
-
-  environment.variables = {
-    VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
-  };
-
-  hardware.cpu.intel.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
-  
-  hardware.opengl.extraPackages = with pkgs; [
-    vaapiIntel
-    vaapiVdpau
-    libvdpau-va-gl
-    intel-media-driver
+  imports = [
+    ./cpu-only.nix
+    ../../gpu/intel.nix
   ];
 }

--- a/common/gpu/intel.nix
+++ b/common/gpu/intel.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  boot.initrd.kernelModules = [ "i915" ];
+
+  environment.variables = {
+    VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
+  };
+
+  hardware.opengl.extraPackages = with pkgs; [
+    vaapiIntel
+    libvdpau-va-gl
+    intel-media-driver
+  ];
+}

--- a/common/gpu/nvidia.nix
+++ b/common/gpu/nvidia.nix
@@ -19,4 +19,8 @@ in
     offload.enable = lib.mkDefault true;
     # Hardware should specify the bus ID for intel/nvidia devices
   };
+
+  hardware.opengl.extraPackages = with pkgs; [
+    vaapiVdpau
+  ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
 
       common-cpu-amd = import ./common/cpu/amd;
       common-cpu-intel = import ./common/cpu/intel;
+      common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only;
       common-cpu-intel-kaby-lake = import ./common/cpu/intel/kaby-lake;
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;
       common-gpu-amd = import ./common/gpu/amd;

--- a/flake.nix
+++ b/flake.nix
@@ -121,7 +121,7 @@
 
       common-cpu-amd = import ./common/cpu/amd;
       common-cpu-intel = import ./common/cpu/intel;
-      common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only;
+      common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only.nix;
       common-cpu-intel-kaby-lake = import ./common/cpu/intel/kaby-lake;
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;
       common-gpu-amd = import ./common/gpu/amd;


### PR DESCRIPTION
Is this a good idea?

Should all the profiles using `common/cpu/intel` be modified to also have `common/gpu/intel`? If the same computer model can sometime have an Nvidia card, it could cause the problem I'm trying to fix.

An alternative could be to use an optional `withGPU ? true` .

Another alternative could be to use `mkOverride 900 "nvidia"` with the `common/gpu/nvidia` (see https://github.com/NixOS/nixos-hardware/issues/388#issuecomment-1060933059)

fix #388