### PR TITLE
AMD: Prefer RADV

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -18,4 +18,6 @@
     driSupport = lib.mkDefault true;
     driSupport32Bit = lib.mkDefault true;
   };
+
+  environment.variables.AMD_VULKAN_ICD = "RADV";
 } 


### PR DESCRIPTION
RADV has been proven faster than AMDVLK by [more](https://www.phoronix.com/scan.php?page=article&item=amdvlk-radv-eo2021&num=1) [than](https://www.phoronix.com/scan.php?page=article&item=radv-amdvlk-july21&num=1) [one](https://linuxreviews.org/The_Best_Linux_Vulkan_Driver_For_AMD_GPUs:_Mesa_RADV_vs_AMDVLK) benchmark, and is recommended by projects like [DXVK](https://github.com/doitsujin/dxvk/wiki/Driver-support#amd-drivers).

I set an environment variable instead of removing AMDLK so that it can be easily switched to by setting `AMD_VULKAN_ICD=AMDVLK`.