### PR TITLE
Remove swappiness config

### DIFF
--- a/common/pc/hdd/default.nix
+++ b/common/pc/hdd/default.nix
@@ -1,7 +1,3 @@
 { lib, ... }:
 
-{
-  boot.kernel.sysctl = {
-    "vm.swappiness" = lib.mkDefault 10;
-  };
-}
+{}

--- a/common/pc/ssd/default.nix
+++ b/common/pc/ssd/default.nix
@@ -1,9 +1,5 @@
 { lib, ... }:
 
 {
-  boot.kernel.sysctl = {
-    "vm.swappiness" = lib.mkDefault 1;
-  };
-
   services.fstrim.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
Setting very low value to swapiness will not probably benefit most users, so I just removed those configs in hdd/ssd module to revert to kernel's default value.

https://askubuntu.com/questions/420026/why-is-the-default-swappiness-60-what-would-be-the-effect-if-i-lower-the-swappi/438363#438363
https://askubuntu.com/questions/184217/why-most-people-recommend-to-reduce-swappiness-to-10-20/184221#184221

Lower swappiness could just make the system slower when it runs out of memory, or even cause freezes: https://askubuntu.com/questions/184217/why-most-people-recommend-to-reduce-swappiness-to-10-20/1028193#1028193

With higher swappiness value the system copies infrequently used region of physical memory to the disk much earlier, recuding the latency of memory allocation in low-memory situations.

I did not remove common/pc/hdd/default.nix, as that could cause confusion to users using this file directly, I instead would like to show warnings to users who are using this file, but I don't know how.

Releated issue: #344