### PR TITLE
Remove `intel_iommu=on` by default for all X1 models.

### DIFF
--- a/lenovo/thinkpad/x1/default.nix
+++ b/lenovo/thinkpad/x1/default.nix
@@ -3,6 +3,4 @@
     ../.
     ../../../common/cpu/intel
   ];
-
-  boot.kernelParams = [ "intel_iommu=on" ];
 }


### PR DESCRIPTION
IOMMU still breaks suspend/resume on multiple Lenovo models including X1.
Currently broken on at least Gen4 which I'm testing on. Hard locks the system during suspend.

This thread claims it works on Gen4 with kernel 5.16.1 but it doesn't work on my hardware, firmware fully updated.
https://bugzilla.kernel.org/show_bug.cgi?id=197029

This should probably be turned on individually for models known to work until it can be more thoroughly tested.