### PR TITLE
dell-xps-15-9560-nvidia: switch to Nvidia Offload mode to save battery power

### DIFF
--- a/dell/xps/15-9560/nvidia/default.nix
+++ b/dell/xps/15-9560/nvidia/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../../../common/cpu/intel
+    ../../../../common/gpu/nvidia.nix
     ../../../../common/pc/laptop
     ../xps-common.nix
   ];
@@ -11,10 +12,11 @@
   # This runs only nvidia, great for games or heavy use of render applications
 
   ##### disable intel, run nvidia only and as default
-  services.xserver.videoDrivers = lib.mkDefault ["nvidia"];
-  hardware.nvidia.modesetting.enable = lib.mkDefault true;
-  hardware.nvidia.optimus_prime.enable = lib.mkDefault true;
-  hardware.nvidia.optimus_prime.nvidiaBusId = lib.mkDefault "PCI:1:0:0";
-  hardware.nvidia.optimus_prime.intelBusId = lib.mkDefault "PCI:0:2:0";
+  hardware.nvidia.prime = {
+    # Bus ID of the Intel GPU.
+    intelBusId = lib.mkDefault "PCI:0:2:0";
 
+    # Bus ID of the NVIDIA GPU.
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
 }


### PR DESCRIPTION
Also rename deprecated `hardware.nvidia.optimus_prime.*' to `hardware.nvidia.prime.*' since NixOS 20.09.

> The hardware.nvidia.optimus_prime.enable service has been renamed to
> hardware.nvidia.prime.sync.enable and has many new enhancements.
> Related nvidia prime settings may have also changed.

See https://nixos.org/manual/nixos/stable/release-notes.html#sec-release-20.09