### PR TITLE
framework: bump kernel version

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -9,9 +9,9 @@
   # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
   boot.kernelParams = [ "mem_sleep_default=deep" ];
 
-  # Requires at least 5.12 for working wi-fi and bluetooth.
+  # Requires at least 5.17 for working wi-fi and bluetooth.
   # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.12") (lib.mkDefault pkgs.linuxPackages_latest);
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.17") (lib.mkDefault pkgs.linuxPackages_latest);
 
   # For fingerprint support
   services.fprintd.enable = true;

--- a/framework/default.nix
+++ b/framework/default.nix
@@ -11,7 +11,7 @@
 
   # Requires at least 5.17 for working wi-fi and bluetooth.
   # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.17") (lib.mkDefault pkgs.linuxPackages_latest);
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") (lib.mkDefault pkgs.linuxPackages_latest);
 
   # For fingerprint support
   services.fprintd.enable = true;

--- a/framework/default.nix
+++ b/framework/default.nix
@@ -9,7 +9,7 @@
   # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
   boot.kernelParams = [ "mem_sleep_default=deep" ];
 
-  # Requires at least 5.17 for working wi-fi and bluetooth.
+  # Requires at least 5.16 for working wi-fi and bluetooth.
   # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") (lib.mkDefault pkgs.linuxPackages_latest);
 


### PR DESCRIPTION
The current lts (5.15) also did not work with this wifi chip. I have not tested 5.16 but 5.17 works for me.