### PR TITLE
Add acpi_call for lenovo thinkpad x270

### DIFF
--- a/lenovo/thinkpad/x270/default.nix
+++ b/lenovo/thinkpad/x270/default.nix
@@ -2,6 +2,8 @@
   imports = [
     ../.
     ../../../common/cpu/intel
+    ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/laptop/ssd
   ];
 
   boot.kernelParams = [


### PR DESCRIPTION
This pull request adds acpi call for lenovo thinkpad x270, thus allowing to use tlp.

I also use `<nixos-hardware/common/pc/laptop/ssd/default.nix>` but not all x270 have an SSD (though the majority have it I think)
I wonder if I can add the ssd config even if all x270 don’t have an SSD

- [x] maybe add ssd ? 