### PR TITLE
framework: acpilight should be used

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -16,6 +16,11 @@
   # For fingerprint support
   services.fprintd.enable = true;
 
+  # Mis-detected by nixos-generate-config
+  # https://github.com/NixOS/nixpkgs/issues/171093
+  # https://wiki.archlinux.org/title/Framework_Laptop#Changing_the_brightness_of_the_monitor_does_not_work
+  hardware.acpilight.enable = lib.mkDefault true;
+
   # HiDPI
   # Leaving here for documentation
   # hardware.video.hidpi.enable = lib.mkDefault true;


### PR DESCRIPTION
Yesterday, I reported https://github.com/NixOS/nixpkgs/issues/171093 about how nixos-generate-config does not correctly detect the need for acpilight. I don't have the background or time to fix this in nixos-generate-config, but a friend who saw the bug suggested I could submit a workaround here. That seems worthwhile to me, as a way to capture the knowledge so nobody else has to rediscover it. I hope this PR is helpful!