### PR TITLE
framework: add nvme.noacpi=1 and make fprintd optional

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -5,9 +5,14 @@
     ../common/pc/laptop/ssd
   ];
 
-  # For Power consumption
-  # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
-  boot.kernelParams = [ "mem_sleep_default=deep" ];
+  boot.kernelParams = [
+    # For Power consumption
+    # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
+    "mem_sleep_default=deep"
+    # For Power consumption
+    # https://community.frame.work/t/linux-battery-life-tuning/6665/156
+    "nvme.noacpi=1"
+  ];
 
   # Requires at least 5.16 for working wi-fi and bluetooth.
   # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89

--- a/framework/default.nix
+++ b/framework/default.nix
@@ -20,7 +20,7 @@
   '';
 
   # For fingerprint support
-  services.fprintd.enable = true;
+  services.fprintd.enable = lib.mkDefault true;
 
   # Fix headphone noise when on powersave
   # https://community.frame.work/t/headphone-jack-intermittent-noise/5246/55


### PR DESCRIPTION
Two minor tweaks; one to improve power usage after resume - and one to make fprintd possible to disable from another nix config.