### PR TITLE
msi/gl62: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X270](lenovo/thinkpad/x270)                        | `<nixos-hardware/lenovo/thinkpad/x270>`            |
 | [Lenovo ThinkPad X280](lenovo/thinkpad/x280)                        | `<nixos-hardware/lenovo/thinkpad/x280>`            |
 | [MSI GS60 2QE](msi/gs60)                                            | `<nixos-hardware/msi/gs60>`                        |
+| [MSI GL62/CX62](msi/gl62)                                           | `<nixos-hardware/msi/gl62>`                        |
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                  | `<nixos-hardware/microsoft/surface-pro/3>`         |
 | [Microsoft Surface Range](microsoft/surface)                        | `<nixos-hardware/microsoft/surface>`               |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,7 @@
       microsoft-surface = import ./microsoft/surface;
       microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
       msi-gs60 = import ./msi/gs60;
+      msi-gl62 = import ./msi/gl62;
       onenetbook-4 = import ./onenetbook/4;
       pcengines-apu = import ./pcengines/apu;
       pine64-pinebook-pro = import ./pine64/pinebook-pro;

--- a/msi/gl62/default.nix
+++ b/msi/gl62/default.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }:
+
+{
+  imports = [
+    ../../common/pc/laptop/ssd
+    ../../common/cpu/intel
+    ../../common/gpu/nvidia.nix
+    ../../common/pc/laptop
+  ];
+
+  boot.kernelParams = [
+    # For Power consumption in case of NVME SSD
+    # was installed.
+    "nvme.noacpi=1"
+
+    # For fixing interferences with Fn- action keys
+    "video.report_key_events=0"
+  ];
+
+  hardware.nvidia.prime = {
+    # Bus ID of the Intel GPU.
+    intelBusId = lib.mkDefault "PCI:0:2:0";
+
+    # Bus ID of the NVIDIA GPU.
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
+}


### PR DESCRIPTION
This PR initialize support for MS-16J61 Laptop Motherboard with unified BIOS of E16J6IMS, which includes:

  - MSI GL62 6QD
  - MSI GL62 6QC
  - MSI CX62 6QD
  - MSI CR62 6M