### PR TITLE
p14s: ensure rtw89 driver is available

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen2/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen2/default.nix
@@ -15,6 +15,6 @@
   # Wifi support
   hardware.firmware = [ pkgs.rtw89-firmware ];
 
-  # For support of newer AMD GPUs, backlight and internal microphone
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.13") pkgs.linuxPackages_latest;
+  # For mainline support of rtw89 wireless networking
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
 }


### PR DESCRIPTION
When upgrading to 22.05, my wireless card did not work anymore, because the default linux version in NixOS 22.05 is 5.15, which does not yet include rtw89. This fixes this by ensuring that the latest version is used on older kernel versions.