### PR TITLE
nvidia: remove `-a` flag from exec

### DIFF
--- a/common/gpu/nvidia.nix
+++ b/common/gpu/nvidia.nix
@@ -8,7 +8,7 @@ let
     export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
     export __GLX_VENDOR_LIBRARY_NAME=nvidia
     export __VK_LAYER_NV_optimus=NVIDIA_only
-    exec -a "$0" "$@"
+    exec "$@"
   '';
 in
 {


### PR DESCRIPTION
The `-a` from exec sets the `$0` from the process. So `exec -a "$0"` would set the name of the new process to `nvidia-offload` (the name of the script), however this is causing issues with a few programs that try to interpret `$0` in a special way. For example, see `wine`:

```
$ nvidia-offload /nix/store/zhv91s26gsrl1w8yn9800xd03a31r3wj-wine-osu-7.0/bin/wine .osu/drive_c/osu/osu\!.exe
/nix/store/zhv91s26gsrl1w8yn9800xd03a31r3wj-wine-osu-7.0/bin/nvidia-offload: could not open
```

What I think `wine` is doing here is trying to re-exec `wine` again, but to do so it tries to figure out the original call of wine by readind `$0`, and will fail in this case because the `$0` was changed because of the `nvidia-offload` script using `-a` flag, as explained above.

Instead, let's simplify this. There is no good reason to rename the `$0` from the script anyway (it just sets a few environment variables), so let's just remove it. We may lose the ability to know if the command is being offloaded, but I think having more commands to work is a good trade-off.
