### PR TITLE
thinkpad/x1-extreme/gen4: add module

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`      |
 | [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`      |
 | [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2) | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>` |
+| [Lenovo ThinkPad X1 Extreme Gen 4](lenovo/thinkpad/x1-extreme/gen4) | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen4>` |
 | [Lenovo ThinkPad X13 Yoga](lenovo/thinkpad/x13/yoga)                | `<nixos-hardware/lenovo/thinkpad/x13/yoga>`        |
 | [Lenovo ThinkPad X13](lenovo/thinkpad/x13)                          | `<nixos-hardware/lenovo/thinkpad/x13>`             |
 | [Lenovo ThinkPad X140e](lenovo/thinkpad/x140e)                      | `<nixos-hardware/lenovo/thinkpad/x140e>`           |

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
       lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;
       lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
       lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
+      lenovo-thinkpad-x1-extreme-gen4 = import ./lenovo/thinkpad/x1-extreme/gen4;
       lenovo-thinkpad-x13 = import ./lenovo/thinkpad/x13;
       lenovo-thinkpad-x13-yoga = import ./lenovo/thinkpad/x13/yoga;
       lenovo-thinkpad-x140e = import ./lenovo/thinkpad/x140e;

--- a/lenovo/thinkpad/x1-extreme/gen4/default.nix
+++ b/lenovo/thinkpad/x1-extreme/gen4/default.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+
+{
+  imports = [
+    ../.
+  ];
+
+  # New ThinkPads have a different TrackPoint manufacturer/name.
+  hardware.trackpoint.device = "TPPS/2 Elan TrackPoint";
+
+  # Set the right DPI. xdpyinfo says the screen is 677x423 mm but
+  # it actually is 344×215 mm.
+  services.xserver.monitorSection = lib.mkDefault ''
+    DisplaySize 344 215
+  '';
+}


### PR DESCRIPTION
This doesn't configure NVIDIA graphics card settings as it's an optional component in this laptop and frankly I have no idea how to configure it - the problem is that HDMI port on laptops with NVIDIA card is connected to NVIDIA graphics card, and simply using `offload` won't make this work, but at the same time disabling power management is probably bad for battery if you don't need HDMI.