### PR TITLE
AMD: Add lib.mkDefault to AMD_VULKAN_ICD

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -19,5 +19,5 @@
     driSupport32Bit = lib.mkDefault true;
   };
 
-  environment.variables.AMD_VULKAN_ICD = "RADV";
+  environment.variables.AMD_VULKAN_ICD = lib.mkDefault "RADV";
 } 


### PR DESCRIPTION
I should have done this in #391.
Still, with this you can set `environment.variables.AMD_VULKAN_ICD = "AMDVLK";` in `configuration.nix`.