### PR TITLE
add p52

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad P1 Gen 3](lenovo/thinkpad/p1/3th-gen)              | `<nixos-hardware/lenovo/thinkpad/p1/3th-gen>`      |
 | [Lenovo ThinkPad P14s AMD Gen 2](lenovo/thinkpad/p14s/amd/gen2)     | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen2>`   |
 | [Lenovo ThinkPad P1](thinkpad/p1)                                   | `<nixos-hardware/lenovo/thinkpad/p1>`              |
+| [Lenovo ThinkPad P52](lenovo/thinkpad/p52)                          | `<nixos-hardware/lenovo/thinkpad/p52>`             |
 | [Lenovo ThinkPad P53](lenovo/thinkpad/p53)                          | `<nixos-hardware/lenovo/thinkpad/p53>`             |
 | [Lenovo ThinkPad T14 AMD Gen 1](lenovo/thinkpad/t14/amd/gen1)       | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen1>`    |
 | [Lenovo ThinkPad T14 AMD Gen 2](lenovo/thinkpad/t14/amd/gen2)       | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen2>`    |

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
       lenovo-thinkpad-p1 = import ./lenovo/thinkpad/p1;
       lenovo-thinkpad-p1-gen3 = import ./lenovo/thinkpad/p1/3th-gen;
       lenovo-thinkpad-p14s-amd-gen2 = import ./lenovo/thinkpad/p14s/amd/gen2;
+      lenovo-thinkpad-p52 = import ./lenovo/thinkpad/p52;
       lenovo-thinkpad-p53 = import ./lenovo/thinkpad/p53;
       lenovo-thinkpad-t14 = import ./lenovo/thinkpad/t14;
       lenovo-thinkpad-t14-amd-gen1 = import ./lenovo/thinkpad/t14/amd/gen1;

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -10,8 +10,8 @@
   hardware = {
     nvidia = {
       prime = {
-        intelBusId = "PCI:0:2:0";
-        nvidiaBusId = "PCI:1:0:0";
+        intelBusId = lib.mkDefault "PCI:0:2:0";
+        nvidiaBusId = lib.mkDefault "PCI:1:0:0";
       };
     };
 
@@ -23,7 +23,7 @@
   };
 
   # required to make wireless work
-  hardware.enableAllFirmware = true;
+  hardware.enableAllFirmware = lib.mkDefault true;
 
   # throttled vs. thermald
   # -----------------------

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -36,6 +36,11 @@
       enable = lib.mkDefault true;
     };
 
+  # Make the DPI the same in sync mode as in offload mode (disabled because
+  # these thinkpads come with many kinds of screens, but this is valid for the
+  # 1920x1080 ones)
+  #services.xserver.dpi = 96;
+
   # silence ACPI "errors" at boot shown before NixOS stage 1 output (default is 4)
   #boot.consoleLogLevel = 3;
 

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -25,6 +25,9 @@
   # required to make wireless work
   hardware.enableAllFirmware = lib.mkDefault true;
 
+  # fix suspend/resume screen corruption
+  #hardware.nvidia.powerManagement.enable = true;
+  
   # throttled vs. thermald
   # -----------------------
   #

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -53,5 +53,5 @@
   # higher when running throttled than when running in the other two scenarios,
   # but still substantially under critical temp.
 
-  services.thermald.enable = lib.mkDefault true;
+  services.throttled.enable = lib.mkDefault true;
 }

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -1,0 +1,66 @@
+{ lib, ... }:
+{
+  imports = [
+    ../../../common/gpu/nvidia.nix
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop/acpi_call.nix
+    ../.
+  ];
+
+  hardware = {
+    nvidia = {
+      prime = {
+        intelBusId = "PCI:0:2:0";
+        nvidiaBusId = "PCI:1:0:0";
+      };
+    };
+
+    # is this too much?  It's convenient for Steam.
+    opengl = {
+      driSupport = lib.mkDefault true;
+      driSupport32Bit = lib.mkDefault true;
+    };
+  };
+
+  # Sleep
+  # -----
+  #
+  # The system will not stay asleep properly while on battery power or AC in
+  # either offload mode or sync mode.  This is true whether TLP is enabled or
+  # disabled.  When the system is told to sleep, it will appear to go into a
+  # sleep state, but within five minutes (and sometimes much more quickly; in
+  # my case especially if a USB hub is connected), it will wake itself.  I
+  # attempted to identify what was causing this to happen, but was not
+  # successful.  Note that this behavior is different from that of the P50 or
+  # P51, both of which can be convinced to sleep by changing TLP config.
+  #
+  # throttled vs. thermald
+  # -----------------------
+  #
+  # NB: the p53 profile currently uses throttled to prevent too-eager CPU
+  # throttling.  I understand throttled to have been a workaround solution at
+  # the time the p53 profile was created (throttled's original name was
+  # "lenovo_fix").  thermald would have been preferred if it worked at the
+  # time.
+  #
+  # I read
+  # https://wiki.archlinux.org/title/Lenovo_ThinkPad_X1_Carbon_(Gen_6)#Power_management.2FThrottling_issues
+  # as saying that thermald is fixed under the circumstance that led to the
+  # development of throttled given version 5.12+ of the kernel combined
+  # with version 2.4.3+ of thermald.  At the time of this writing, the
+  # stable NixOS kernel is 5.15 and 2.4.9 of thermald.
+  #
+  # In the meantime, I also ran the "s-tui" program which can stress test the
+  # system, while eyeing up the core temps and CPU frequency under three
+  # scenarios: under thermald, under throttled, and with neither.  None of the
+  # scenarios seem to have massively improved fan behavior, core temps, or
+  # average CPU frequency than another.  The highest core temp always seems to
+  # hover around 90 degrees C, the lowest CPU Ghz around 3.4 on a 3.8Ghz machine.
+  #
+  # I ended up choosing throttled because subjectively, the fans seem quieter
+  # when it's stressed and it allows the average temps to get a degree or two
+  # higher when running throttled than when running in the other two scenarios,
+  # but still substantially under critical temp.
+
+  services.thermald.enable = lib.mkDefault true;
+}

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -22,18 +22,9 @@
     };
   };
 
-  # Sleep
-  # -----
-  #
-  # The system will not stay asleep properly while on battery power or AC in
-  # either offload mode or sync mode.  This is true whether TLP is enabled or
-  # disabled.  When the system is told to sleep, it will appear to go into a
-  # sleep state, but within five minutes (and sometimes much more quickly; in
-  # my case especially if a USB hub is connected), it will wake itself.  I
-  # attempted to identify what was causing this to happen, but was not
-  # successful.  Note that this behavior is different from that of the P50 or
-  # P51, both of which can be convinced to sleep by changing TLP config.
-  #
+  # required to make wireless work
+  hardware.enableAllFirmware = true;
+
   # throttled vs. thermald
   # -----------------------
   #

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -1,5 +1,4 @@
-{ lib, ... }:
-{
+{ lib, config, ... }: {
   imports = [
     ../../../common/gpu/nvidia.nix
     ../../../common/cpu/intel
@@ -25,9 +24,21 @@
   # required to make wireless work
   hardware.enableAllFirmware = lib.mkDefault true;
 
-  # fix suspend/resume screen corruption
-  #hardware.nvidia.powerManagement.enable = true;
-  
+  # fix suspend/resume screen corruption in sync mode
+  hardware.nvidia.powerManagement =
+    lib.mkIf config.hardware.nvidia.prime.sync.enable {
+      enable = lib.mkDefault true;
+    };
+
+  # fix screen tearing in sync mode
+  hardware.nvidia.modesetting =
+    lib.mkIf config.hardware.nvidia.prime.sync.enable {
+      enable = lib.mkDefault true;
+    };
+
+  # silence ACPI "errors" at boot shown before NixOS stage 1 output (default is 4)
+  #boot.consoleLogLevel = 3;
+
   # throttled vs. thermald
   # -----------------------
   #


### PR DESCRIPTION
Add a profile for the Lenovo Thinkpad P52.

Note that this is very similar to the P50 PR submitted in https://github.com/NixOS/nixos-hardware/pull/432 . 