### PR TITLE
Adds support for Thinkpad T460p

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T440s](lenovo/thinkpad/t440s)                      | `<nixos-hardware/lenovo/thinkpad/t440s>`           |
 | [Lenovo ThinkPad T450s](lenovo/thinkpad/t450s)                      | `<nixos-hardware/lenovo/thinkpad/t450s>`           |
 | [Lenovo ThinkPad T460](lenovo/thinkpad/t460)                        | `<nixos-hardware/lenovo/thinkpad/t460>`            |
+| [Lenovo ThinkPad T460p](lenovo/thinkpad/t460p)                      | `<nixos-hardware/lenovo/thinkpad/t460p>`           |
 | [Lenovo ThinkPad T460s](lenovo/thinkpad/t460s)                      | `<nixos-hardware/lenovo/thinkpad/t460s>`           |
 | [Lenovo ThinkPad T470s](lenovo/thinkpad/t470s)                      | `<nixos-hardware/lenovo/thinkpad/t470s>`           |
 | [Lenovo ThinkPad T480](lenovo/thinkpad/t480)                        | `<nixos-hardware/lenovo/thinkpad/t480>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
       lenovo-thinkpad-t440s = import ./lenovo/thinkpad/t440s;
       lenovo-thinkpad-t450s = import ./lenovo/thinkpad/t450s;
       lenovo-thinkpad-t460 = import ./lenovo/thinkpad/t460;
+      lenovo-thinkpad-t460p = import ./lenovo/thinkpad/t460p;
       lenovo-thinkpad-t460s = import ./lenovo/thinkpad/t460s;
       lenovo-thinkpad-t470s = import ./lenovo/thinkpad/t470s;
       lenovo-thinkpad-t480 = import ./lenovo/thinkpad/t480;

--- a/lenovo/legion/15ach6/default.nix
+++ b/lenovo/legion/15ach6/default.nix
@@ -1,4 +1,6 @@
-{ lib, ... }: {
+{ lib, config, ... }:
+let kernelPackages = config.boot.kernelPackages;
+in {
   imports = [
     ../../../common/cpu/amd
     ../../../common/gpu/amd
@@ -16,10 +18,19 @@
 
   # https://wiki.archlinux.org/title/backlight#Backlight_is_always_at_full_brightness_after_a_reboot_with_amdgpu_driver
   systemd.services.fix-brightness = {
-    before = [ "systemd-backlight@backlight:amdgpu_bl0.service" ];
+    before = [
+      "systemd-backlight@backlight:${
+        if lib.versionOlder kernelPackages.kernel.version "5.18" then "amdgpu_bl0" else "nvidia_wmi_ec_backlight"
+      }.service"
+    ];
     description = "Convert 16-bit brightness values to 8-bit before systemd-backlight applies it";
     script = ''
-      BRIGHTNESS_FILE="/var/lib/systemd/backlight/pci-0000:05:00.0:backlight:amdgpu_bl0"
+      BRIGHTNESS_FILE="/var/lib/systemd/backlight/${
+        if lib.versionOlder kernelPackages.kernel.version "5.18" then
+          "pci-0000:05:00.0:backlight:amdgpu_bl0"
+        else
+          "platform-PNP0C14:00:backlight:nvidia_wmi_ec_backlight"
+      }"
       BRIGHTNESS=$(cat "$BRIGHTNESS_FILE")
       BRIGHTNESS=$(($BRIGHTNESS*255/65535))
       BRIGHTNESS=''${BRIGHTNESS/.*} # truncating to int, just in case

--- a/lenovo/thinkpad/t460p/default.nix
+++ b/lenovo/thinkpad/t460p/default.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop/acpi_call.nix
+    ../.
+  ];
+}


### PR DESCRIPTION
This PR adds support for the Thinkpad T460p. It is identical to T460 and T460s. It's main purpose is to make it clear to users which to select to configure for that specific model without having to look at the other T460 variants and decide that they are all identical. It has been tested on a T460p.