### PR TITLE
Fix legion 7 slim 15ach6

### DIFF
--- a/lenovo/legion/15ach6/default.nix
+++ b/lenovo/legion/15ach6/default.nix
@@ -1,4 +1,6 @@
-{ lib, ... }: {
+{ lib, config, ... }:
+let kernelPackages = config.boot.kernelPackages;
+in {
   imports = [
     ../../../common/cpu/amd
     ../../../common/gpu/amd
@@ -16,10 +18,19 @@
 
   # https://wiki.archlinux.org/title/backlight#Backlight_is_always_at_full_brightness_after_a_reboot_with_amdgpu_driver
   systemd.services.fix-brightness = {
-    before = [ "systemd-backlight@backlight:amdgpu_bl0.service" ];
+    before = [
+      "systemd-backlight@backlight:${
+        if lib.versionOlder kernelPackages.kernel.version "5.18" then "amdgpu_bl0" else "nvidia_wmi_ec_backlight"
+      }.service"
+    ];
     description = "Convert 16-bit brightness values to 8-bit before systemd-backlight applies it";
     script = ''
-      BRIGHTNESS_FILE="/var/lib/systemd/backlight/pci-0000:05:00.0:backlight:amdgpu_bl0"
+      BRIGHTNESS_FILE="/var/lib/systemd/backlight/${
+        if lib.versionOlder kernelPackages.kernel.version "5.18" then
+          "pci-0000:05:00.0:backlight:amdgpu_bl0"
+        else
+          "platform-PNP0C14:00:backlight:nvidia_wmi_ec_backlight"
+      }"
       BRIGHTNESS=$(cat "$BRIGHTNESS_FILE")
       BRIGHTNESS=$(($BRIGHTNESS*255/65535))
       BRIGHTNESS=''${BRIGHTNESS/.*} # truncating to int, just in case


### PR DESCRIPTION
Since the latest kernel `5.18` even when the onboard AMD GPU is active `/var/lib/systemd/backlight/pci-0000:05:00.0:backlight:amdgpu_bl0` does not exist.