### PR TITLE
inspiron-5515: fix race for fix-touchpad.sh

### DIFF
--- a/dell/inspiron/5515/default.nix
+++ b/dell/inspiron/5515/default.nix
@@ -12,12 +12,17 @@
   # hack around it by unloading and reloading module i2c_hid
   systemd.services.fix-touchpad = {
     path = [ pkgs.kmod ];
-    serviceConfig.ExecStart = "${./fix_touchpad.sh}";
+    serviceConfig.ExecStart = ''${pkgs.systemd}/bin/systemd-inhibit --what=sleep --why="fixing touchpad must finish before sleep" --mode=delay  ${./fix_touchpad.sh}'';
+    serviceConfig.Type = "oneshot";
     description = "reload touchpad driver";
     # must run at boot (and not too early), and after suspend
-    wantedBy = [ "display-manager.service" "sleep.target" ];
-    after = [ "sleep.target" ];
+    wantedBy = [ "display-manager.service" "post-resume.target" ];
+    # prevent running before suspend
+    after = [ "post-resume.target" ];
   };
+
+  # so that post-resume.service exists
+  powerManagement.enable = true;
 
 
   # fix suspend

--- a/dell/inspiron/5515/fix_touchpad.sh
+++ b/dell/inspiron/5515/fix_touchpad.sh
@@ -11,10 +11,11 @@ unload () {
 
 wait_unload() {
   while sleep 1; do
-    case "$(unload "$1")" in
+    output="$(unload "$1")"
+    case "$output" in
       *is\ in\ use*) :;;
       *ok*) return 0;;
-      *) echo giving up; return 1;
+      *) echo "modprobe said: $output"; echo giving up; return 1;
     esac
   done
 }


### PR DESCRIPTION
On rare occasions, the module would be removed before suspend and the touchpad would be
disabled on boot.

I have been testing this for weeks and it does not look racy anymore.