### PR TITLE
raspberry-pi-4: add i2c clock-frequency option

### DIFF
--- a/raspberry-pi/4/i2c.nix
+++ b/raspberry-pi/4/i2c.nix
@@ -2,7 +2,8 @@
 
 let
   cfg = config.hardware.raspberry-pi."4";
-  simple-overlay = { target, status }: {
+  optionalProperty = name: value: lib.optionalString (value != null) "${name} = <${builtins.toString value}>;";
+  simple-overlay = { target, status, frequency }: {
     name = "${target}-${status}-overlay";
     dtsText = ''
       /dts-v1/;
@@ -13,6 +14,7 @@ let
           target = <&${target}>;
           __overlay__ {
             status = "${status}";
+            ${optionalProperty "clock-frequency" frequency}
           };
         };
       };
@@ -21,26 +23,52 @@ let
 in
 {
   options.hardware.raspberry-pi."4" = {
-    i2c0.enable = lib.mkEnableOption ''
-      Turn on the VideoCore I2C bus (maps to /dev/i2c-22) and enable access from the i2c group.
-      After a reboot, i2c-tools (e.g. i2cdetect -F 22) should work for root or any user in i2c.
-    '';
-    i2c1.enable = lib.mkEnableOption ''
-      Turn on the ARM I2C bus (/dev/i2c-1 on GPIO pins 3 and 5) and enable access from the i2c group.
-      After a reboot, i2c-tools (e.g. i2cdetect -F 1) should work for root or any user in i2c.
-    '';
+    i2c0 = {
+      enable = lib.mkEnableOption ''
+        Turn on the VideoCore I2C bus (maps to /dev/i2c-22) and enable access from the i2c group.
+        After a reboot, i2c-tools (e.g. i2cdetect -F 22) should work for root or any user in i2c.
+      '';
+      frequency = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+        description = ''
+          interface clock-frequency
+        '';
+      };
+    };
+    i2c1 = {
+      enable = lib.mkEnableOption ''
+        Turn on the ARM I2C bus (/dev/i2c-1 on GPIO pins 3 and 5) and enable access from the i2c group.
+        After a reboot, i2c-tools (e.g. i2cdetect -F 1) should work for root or any user in i2c.
+      '';
+      frequency = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+        description = ''
+          interface clock-frequency
+        '';
+      };
+    };
   };
   config.hardware = lib.mkMerge [
     (lib.mkIf cfg.i2c0.enable {
       i2c.enable = lib.mkDefault true;
       deviceTree = {
-        overlays = [ (simple-overlay { target = "i2c0if"; status = "okay"; }) ];
+        overlays = [ (simple-overlay {
+          target = "i2c0if";
+          status = "okay";
+          frequency = cfg.i2c0.frequency;
+        }) ];
       };
     })
     (lib.mkIf cfg.i2c1.enable {
       i2c.enable = lib.mkDefault true;
       deviceTree = {
-        overlays = [ (simple-overlay { target = "i2c1"; status = "okay"; }) ];
+        overlays = [ (simple-overlay {
+          target = "i2c1";
+          status = "okay";
+          frequency = cfg.i2c1.frequency;
+        }) ];
       };
     })
   ];


### PR DESCRIPTION
Recently I had an application where I wanted to tweak the default 100khz clock frequency of the i2c0 bus to 1mhz, so I decided to expand the i2c dts'es here to include that option.

I'm still very new to nix expressions, so I am sure this code can be simplified in many different ways - feedback is appreciated.

## Test

Applying the following:
```nix
{
  options.hardware.raspberry-pi."4" = {
    i2c0 = {
      enabled = true;
      frequency = 1000000;
    };
  };
}
```

Results in:
```
xxd -g4  /proc/device-tree/soc/i2c@7e804000/clock-frequency
00000000: 000f4240 # 1_000_000
```