### PR TITLE
Add Dell XPS 13 9350

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ See code for all available configurations.
 | [Dell XPS 13 7390](dell/xps/13-7390)                                | `<nixos-hardware/dell/xps/13-7390>`                |
 | [Dell XPS 13 9310](dell/xps/13-9310)                                | `<nixos-hardware/dell/xps/13-9310>`                |
 | [Dell XPS 13 9343](dell/xps/13-9343)                                | `<nixos-hardware/dell/xps/13-9343>`                |
+| [Dell XPS 13 9350](dell/xps/13-9350)                                | `<nixos-hardware/dell/xps/13-9350>`                |
 | [Dell XPS 13 9360](dell/xps/13-9360)                                | `<nixos-hardware/dell/xps/13-9360>`                |
 | [Dell XPS 13 9370](dell/xps/13-9370)                                | `<nixos-hardware/dell/xps/13-9370>`                |
 | [Dell XPS 13 9380](dell/xps/13-9380)                                | `<nixos-hardware/dell/xps/13-9380>`                |

--- a/dell/xps/13-9350/default.nix
+++ b/dell/xps/13-9350/default.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # The touchpad uses I²C, so PS/2 is unnecessary
+  boot.blacklistedKernelModules = [ "psmouse" ];
+
+  # Recommended in NixOS/nixos-hardware#127
+  services.thermald.enable = lib.mkDefault true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
       dell-xps-13-7390 = import ./dell/xps/13-7390;
       dell-xps-13-9310 = import ./dell/xps/13-9310;
       dell-xps-13-9343 = import ./dell/xps/13-9343;
+      dell-xps-13-9350 = import ./dell/xps/13-9350;
       dell-xps-13-9360 = import ./dell/xps/13-9360;
       dell-xps-13-9370 = import ./dell/xps/13-9370;
       dell-xps-13-9380 = import ./dell/xps/13-9380;


### PR DESCRIPTION
There’s not much to configure here, but I figure it’s worth documenting that.

Notable omissions:

  - `i915.enable_fbc` is unnecessary; frame buffer compression is enabled [automatically](https://github.com/torvalds/linux/blob/v5.18/drivers/gpu/drm/i915/display/intel_fbc.c#L1631-L1635).

    ```syslog
    i915 device info: display version: 9
    i915 device info: has_fbc: yes
    ```

  - `i915.enable_psr` is unnecessary; panel self refresh is enabled [by default](https://github.com/torvalds/linux/blob/v5.18/drivers/gpu/drm/i915/display/intel_psr.c#L994).

    ```syslog
    i915 device info: has_psr: yes
    i915 device info: has_psr_hw_tracking: yes
    ```

  - `i915.enable_rc6` [no longer exists](https://github.com/torvalds/linux/commit/fb6db0f5bf1d4d3a4af6242e287fa795221ec5b8); RC6 sleep is automatically configured.

    ```syslog
    i915 device info: has_rc6: yes
    i915 device info: has_rc6p: no
    ```

Not tested:

  - The Windows version of this laptop has a Broadcom wireless card, but I’m using the [Developer Edition](https://web.archive.org/web/20161012015151/http://www.dell.com/en-us/shop/productdetails/xps-13-9350-laptop-ubuntu) which has an Intel wireless card instead:

    ```syslog
    iwlwifi 0000:3a:00.0: Detected Intel(R) Dual Band Wireless AC 8260, REV=0x204
    ```
