### PR TITLE
raspberry-pi-4: add poe-plus-hat, update poe-hat, use dtmerge instead of fdtoverlay

### DIFF
--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -21,7 +21,7 @@ with lib; (base: overlays': stdenvNoCC.mkDerivation {
         echo "Applying overlay ${o.name} to $( basename $dtb )"
         mv $dtb{,.in}
         cp ${o.dtboFile}{,.dtbo}
-        ${libraspberrypi}/bin/dtmerge "$dtb.in" "$dtb" ${o.dtboFile}.dtbo;
+        dtmerge "$dtb.in" "$dtb" ${o.dtboFile}.dtbo;
         rm $dtb.in ${o.dtboFile}.dtbo
       fi
       '')}

--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -27,4 +27,4 @@ with lib; (base: overlays': stdenvNoCC.mkDerivation {
       '')}
     done
   '';
-});
+})

--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -1,9 +1,11 @@
+# modification of nixpkgs deviceTree.applyOverlays to resolve https://github.com/NixOS/nixpkgs/issues/125354
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/device-tree/default.nix
 { lib, pkgs, stdenvNoCC, dtc, libraspberrypi }:
 
 with lib; {
   applyOverlays = (base: overlays': stdenvNoCC.mkDerivation {
     name = "device-tree-overlays";
-    nativeBuildInputs = [ dtc ];
+    nativeBuildInputs = [ dtc libraspberrypi ];
     buildCommand = let
       overlays = toList overlays';
     in ''

--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -2,31 +2,29 @@
 # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/device-tree/default.nix
 { lib, pkgs, stdenvNoCC, dtc, libraspberrypi }:
 
-with lib; {
-  applyOverlays = (base: overlays': stdenvNoCC.mkDerivation {
-    name = "device-tree-overlays";
-    nativeBuildInputs = [ dtc libraspberrypi ];
-    buildCommand = let
-      overlays = toList overlays';
-    in ''
-      mkdir -p $out
-      cd ${base}
-      find . -type f -name '*.dtb' -print0 \
-        | xargs -0 cp -v --no-preserve=mode --target-directory $out --parents
-      for dtb in $(find $out -type f -name '*.dtb'); do
-        dtbCompat="$( fdtget -t s $dtb / compatible )"
-        ${flip (concatMapStringsSep "\n") overlays (o: ''
-        overlayCompat="$( fdtget -t s ${o.dtboFile} / compatible )"
-        # overlayCompat in dtbCompat
-        if [[ "$dtbCompat" =~ "$overlayCompat" ]]; then
-          echo "Applying overlay ${o.name} to $( basename $dtb )"
-          mv $dtb{,.in}
-          cp ${o.dtboFile}{,.dtbo}
-          ${libraspberrypi}/bin/dtmerge "$dtb.in" "$dtb" ${o.dtboFile}.dtbo;
-          rm $dtb.in ${o.dtboFile}.dtbo
-        fi
-        '')}
-      done
-    '';
-  });
-}
+with lib; (base: overlays': stdenvNoCC.mkDerivation {
+  name = "device-tree-overlays";
+  nativeBuildInputs = [ dtc libraspberrypi ];
+  buildCommand = let
+    overlays = toList overlays';
+  in ''
+    mkdir -p $out
+    cd ${base}
+    find . -type f -name '*.dtb' -print0 \
+      | xargs -0 cp -v --no-preserve=mode --target-directory $out --parents
+    for dtb in $(find $out -type f -name '*.dtb'); do
+      dtbCompat="$( fdtget -t s $dtb / compatible )"
+      ${flip (concatMapStringsSep "\n") overlays (o: ''
+      overlayCompat="$( fdtget -t s ${o.dtboFile} / compatible )"
+      # overlayCompat in dtbCompat
+      if [[ "$dtbCompat" =~ "$overlayCompat" ]]; then
+        echo "Applying overlay ${o.name} to $( basename $dtb )"
+        mv $dtb{,.in}
+        cp ${o.dtboFile}{,.dtbo}
+        ${libraspberrypi}/bin/dtmerge "$dtb.in" "$dtb" ${o.dtboFile}.dtbo;
+        rm $dtb.in ${o.dtboFile}.dtbo
+      fi
+      '')}
+    done
+  '';
+});

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -7,8 +7,10 @@
     ./i2c.nix
     ./modesetting.nix
     ./poe-hat.nix
+    ./poe-plus-hat.nix
     ./tc358743.nix
     ./pwm0.nix
+    ./pkgs-overlays.nix
   ];
 
   boot = {

--- a/raspberry-pi/4/pkgs-overlays.nix
+++ b/raspberry-pi/4/pkgs-overlays.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, modulesPath, ... }:
+let
+  callPackage = path: overrides:
+    let f = import path;
+    in f ((builtins.intersectAttrs (builtins.functionArgs f) pkgs) // overrides);
+  cfg = config.hardware.raspberry-pi."4".apply-overlays-dtmerge;
+  dt_ao_overlay = (final: prev: {
+    deviceTree.applyOverlays = (prev.callPackage ./apply-overlays-dtmerge.nix { }).applyOverlays;
+  });
+in {
+  options.hardware = {
+    raspberry-pi."4".apply-overlays-dtmerge = {
+      enable = lib.mkEnableOption ''
+        replace deviceTree.applyOverlays implementation to use dtmerge from libraspberrypi.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays = [ dt_ao_overlay ];
+  };
+}

--- a/raspberry-pi/4/pkgs-overlays.nix
+++ b/raspberry-pi/4/pkgs-overlays.nix
@@ -1,17 +1,15 @@
 { config, lib, pkgs, modulesPath, ... }:
 let
-  callPackage = path: overrides:
-    let f = import path;
-    in f ((builtins.intersectAttrs (builtins.functionArgs f) pkgs) // overrides);
   cfg = config.hardware.raspberry-pi."4".apply-overlays-dtmerge;
   dt_ao_overlay = (final: prev: {
-    deviceTree.applyOverlays = (prev.callPackage ./apply-overlays-dtmerge.nix { }).applyOverlays;
+    deviceTree.applyOverlays = (prev.callPackage ./apply-overlays-dtmerge.nix { })
   });
 in {
   options.hardware = {
     raspberry-pi."4".apply-overlays-dtmerge = {
       enable = lib.mkEnableOption ''
         replace deviceTree.applyOverlays implementation to use dtmerge from libraspberrypi.
+        this can resolve issues with applying dtbs for the pi.
       '';
     };
   };

--- a/raspberry-pi/4/pkgs-overlays.nix
+++ b/raspberry-pi/4/pkgs-overlays.nix
@@ -2,7 +2,7 @@
 let
   cfg = config.hardware.raspberry-pi."4".apply-overlays-dtmerge;
   dt_ao_overlay = (final: prev: {
-    deviceTree.applyOverlays = (prev.callPackage ./apply-overlays-dtmerge.nix { })
+    deviceTree.applyOverlays = (prev.callPackage ./apply-overlays-dtmerge.nix { });
   });
 in {
   options.hardware = {


### PR DESCRIPTION
Changes here:
* update the poe-hat-overlay dts to work with the 5.15y release of rpis kernel
* add poe-plus-hat-overlay for use with the [PoE+ HAT](https://www.raspberrypi.com/products/poe-plus-hat/)
* using `dtmerge` from `libraspberypi` instead of `fdtoverlay` for the added overlays that require it's the usage

This should provide a ready-to-use solution for:
* https://github.com/NixOS/nixpkgs/pull/79370#issuecomment-772373007
* https://discourse.nixos.org/t/fdt-err-notfound-when-trying-to-apply-device-tree-overlay-on-raspberry-pi-4/19650

There's likely many ways these expressions could be made better, so feedback is very much appreciated.