### PR TITLE
pine64-pinebook-pro: remove inappropriate overriding of min_freq

### DIFF
--- a/pine64/pinebook-pro/default.nix
+++ b/pine64/pinebook-pro/default.nix
@@ -77,14 +77,6 @@
     (pkgs.callPackage ./firmware/ap6256-firmware { })
   ];
 
-  systemd.tmpfiles.rules = [
-    # Tweak the minimum frequencies of the GPU and CPU governors to get a bit more performance
-    # https://github.com/elementary/os/blob/05a5a931806d4ed8bc90396e9e91b5ac6155d4d4/build-pinebookpro.sh#L288-L294
-    "w- /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq - - - - 1200000"
-    "w- /sys/devices/system/cpu/cpufreq/policy4/scaling_min_freq - - - - 1008000"
-    "w- /sys/class/devfreq/ff9a0000.gpu/min_freq - - - - 600000000"
-  ];
-
   # The default powersave makes the wireless connection unusable.
   networking.networkmanager.wifi.powersave = lib.mkDefault false;
 }


### PR DESCRIPTION
Power management should be left to a power management daemon (e.g. gnome-power-manager) or for users to set/override themselves (e.g. by setting a CPU governor).

I use governor 'schedutil', which is big.LITTLE aware, and thus can sensibly downclock, but min_freq prevents that.