### PR TITLE
apple/macbook-pro/11-5: various tweaks and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ See code for all available configurations.
 | [Apple MacBook Air 4,X](apple/macbook-air/4)                        | `<nixos-hardware/apple/macbook-air/4>`             |
 | [Apple MacBook Air 6,X](apple/macbook-air/6)                        | `<nixos-hardware/apple/macbook-air/6>`             |
 | [Apple MacBook Pro 10,1](apple/macbook-pro/10-1)                    | `<nixos-hardware/apple/macbook-pro/10-1>`          |
+| [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                    | `<nixos-hardware/apple/macbook-pro/11-5>`          |
 | [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                    | `<nixos-hardware/apple/macbook-pro/12-1>`          |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                      | `<nixos-hardware/asus/rog-strix/g733qs>`           |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                  | `<nixos-hardware/asus/zephyrus/ga401>`             |

--- a/apple/macbook-pro/11-5/README.md
+++ b/apple/macbook-pro/11-5/README.md
@@ -24,19 +24,34 @@ This configuration will **not** work with MacBook Pro 11,2 or 11,3 models.
 
 The [MacBookPro11,4 and MacBookPro11,5](https://support.apple.com/kb/SP719) models ship with a discrete ATI/AMD graphics card (whereas MacBookPro11,2 and MacBookPro11,3 ship with NVidia cards). This is alongside the usual integrated Intel GPU.
 
-You may wish to look into dynamic switching between integrated and discrete graphics, but this config doesn't attempt it.
+To switch from the older `radeon` driver to the newer `amdgpu` driver (via experimental `si_support`), include `nixos-hardware.nixosModules.common-gpu-amd-southern-islands` (or `${nixos-hardware}/common/gpu/amd/southern-islands`) in your configuration. This will get you vulkan support among other benefits.
 
-Currently this uses the experimental `si_support` to disable the older radeon driver and enable the more modern `amdgpu` driver.
+For example, in your `flake.nix`:
+
+```nix
+nixosConfigurations = {
+  macbook-pro-11-5 = lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [
+      nixos-hardware.nixosModules.apple-macbook-pro-11-5
+      nixos-hardware.nixosModules.common-gpu-amd-southern-islands
+      {
+        # Your personal configuration
+      }
+    ];
+  };
+};
+```
 
 ## Hardware probes
 
 Hardware probes generated with `nix run nixpkgs#hw-probe -- -all -upload`:
 
-* Probe [#305905e674](https://linux-hardware.org/?probe=305905e674) of Apple MacBookPro11,5
+* Probe [#305905e674](https://linux-hardware.org/?probe=305905e674) of Apple MacBookPro11,5 (with `amdgpu` driver)
 
 DRM (Direct Rendering Manager) snapshots generated with `drm_info -j | curl -d @- https://drmdb.emersion.fr/submit`:
 
-* Snapshot [#e8f8076f1f1b](https://drmdb.emersion.fr/snapshots/e8f8076f1f1b)
+* Snapshot [#e8f8076f1f1b](https://drmdb.emersion.fr/snapshots/e8f8076f1f1b) (with `amdgpu` driver)
 
 ## Additional resources
 

--- a/apple/macbook-pro/11-5/README.md
+++ b/apple/macbook-pro/11-5/README.md
@@ -43,6 +43,11 @@ nixosConfigurations = {
 };
 ```
 
+## Power management
+
+You may also wish to look into dynamic switching between integrated and discrete graphics, but this config doesn't currently attempt it.
+See the removed [hardware.amdHybridGraphics.disable](https://github.com/NixOS/nixpkgs/pull/33915) option for an entry point.
+
 ## Hardware probes
 
 Hardware probes generated with `nix run nixpkgs#hw-probe -- -all -upload`:

--- a/apple/macbook-pro/11-5/README.md
+++ b/apple/macbook-pro/11-5/README.md
@@ -28,6 +28,16 @@ You may wish to look into dynamic switching between integrated and discrete grap
 
 Currently this uses the experimental `si_support` to disable the older radeon driver and enable the more modern `amdgpu` driver.
 
+## Hardware probes
+
+Hardware probes generated with `nix run nixpkgs#hw-probe -- -all -upload`:
+
+* Probe [#305905e674](https://linux-hardware.org/?probe=305905e674) of Apple MacBookPro11,5
+
+DRM (Direct Rendering Manager) snapshots generated with `drm_info -j | curl -d @- https://drmdb.emersion.fr/submit`:
+
+* Snapshot [#e8f8076f1f1b](https://drmdb.emersion.fr/snapshots/e8f8076f1f1b)
+
 ## Additional resources
 
 * Arch linux wiki: [MacBookPro11,x](https://wiki.archlinux.org/index.php/MacBookPro11,x)

--- a/apple/macbook-pro/11-5/README.md
+++ b/apple/macbook-pro/11-5/README.md
@@ -22,11 +22,19 @@ This configuration will **not** work with MacBook Pro 11,2 or 11,3 models.
 
 ## Graphics
 
-The [MacBookPro11,4 and MacBookPro11,5](https://support.apple.com/kb/SP719) models ship with a discrete ATI graphics card (whereas MacBookPro11,2 and MacBookPro11,3 ship with NVidia cards). This is alongside the usual integrated Intel GPU.
+The [MacBookPro11,4 and MacBookPro11,5](https://support.apple.com/kb/SP719) models ship with a discrete ATI/AMD graphics card (whereas MacBookPro11,2 and MacBookPro11,3 ship with NVidia cards). This is alongside the usual integrated Intel GPU.
 
 You may wish to look into dynamic switching between integrated and discrete graphics, but this config doesn't attempt it.
+
+Currently this uses the experimental `si_support` to disable the older radeon driver and enable the more modern `amdgpu` driver.
 
 ## Additional resources
 
 * Arch linux wiki: [MacBookPro11,x](https://wiki.archlinux.org/index.php/MacBookPro11,x)
 * Kernel patches: [MacBookPro11,x](https://bugzilla.kernel.org/buglist.cgi?quicksearch=macbookpro11)
+
+For more context about experimental `amdgpu` support, see:
+
+* [Enabling AMDGPU by default for SI & CIK (November 2021)](https://gitlab.freedesktop.org/drm/amd/-/issues/1776)
+* [Enabling AMDGPU by default for SI & CIK (August 2020))](https://lists.freedesktop.org/archives/amd-gfx/2020-August/052243.html)
+* [Feature support matrix](https://wiki.gentoo.org/wiki/AMDGPU#Feature_support)

--- a/apple/macbook-pro/11-5/default.nix
+++ b/apple/macbook-pro/11-5/default.nix
@@ -17,7 +17,7 @@ in
   ];
 
   # Enable broadcom-43xx firmware
-  hardware.enableRedistributableFirmware = true;
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
 
   services.udev.extraRules =
     # Disable XHC1 wakeup signal to avoid resume getting triggered some time

--- a/apple/macbook-pro/11-5/default.nix
+++ b/apple/macbook-pro/11-5/default.nix
@@ -10,15 +10,14 @@ in
   imports = [
     ../.
     ../../../common/pc/laptop/ssd
+
+    # Radeon Venus XT is a GCN 1 microarchitecture
+    # (amdgpu driver support is experimental and must be explicitly enabled)
+    ../../../common/gpu/amd/southern-islands
   ];
 
   # Enable broadcom-43xx firmware
   hardware.enableRedistributableFirmware = true;
-
-  # Apparently this is currently only supported by ati_unfree drivers, not ati
-  hardware.opengl.driSupport32Bit = false;
-
-  services.xserver.videoDrivers = [ "ati" ];
 
   services.udev.extraRules =
     # Disable XHC1 wakeup signal to avoid resume getting triggered some time

--- a/apple/macbook-pro/11-5/default.nix
+++ b/apple/macbook-pro/11-5/default.nix
@@ -10,10 +10,6 @@ in
   imports = [
     ../.
     ../../../common/pc/laptop/ssd
-
-    # Radeon Venus XT is a GCN 1 microarchitecture
-    # (amdgpu driver support is experimental and must be explicitly enabled)
-    ../../../common/gpu/amd/southern-islands
   ];
 
   # Enable broadcom-43xx firmware

--- a/apple/macbook-pro/11-5/default.nix
+++ b/apple/macbook-pro/11-5/default.nix
@@ -10,8 +10,10 @@ in
   imports = [
     ../.
     ../../../common/pc/laptop/ssd
-    <nixpkgs/nixos/modules/hardware/network/broadcom-43xx.nix>
   ];
+
+  # Enable broadcom-43xx firmware
+  hardware.enableRedistributableFirmware = true;
 
   # Apparently this is currently only supported by ati_unfree drivers, not ati
   hardware.opengl.driSupport32Bit = false;


### PR DESCRIPTION
This:

* fixes a problematic reference to `<nixpkgs>`
* removes the old `"ati"` driver (`radeon` is the default now)
* documents how to use `amdgpu` driver via experimental "Southern Islands" support
* notes regarding switcheroo
* adds example hardware probes for reference