### PR TITLE
Add support for Framework laptop, 12th gen Intel Core edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ See code for all available configurations.
 | [Dell XPS 17 9710, intel only](dell/xps/17-9710/intel)              | `<nixos-hardware/dell/xps/17-9710/intel>`          |
 | [Dell XPS E7240](dell/e7240)                                        | `<nixos-hardware/dell/e7240>`                      |
 | [Framework](framework)                                              | `<nixos-hardware/framework>`                       |
+| [Framework 12th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
       dell-xps-17-9700-nvidia = import ./dell/xps/17-9700/nvidia;
       dell-xps-17-9710-intel = import ./dell/xps/17-9710/intel;
       framework = import ./framework;
+      framework-12th-gen-intel = import ./framework/12th-gen-intel;
       friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;

--- a/framework/12th-gen-intel/README.md
+++ b/framework/12th-gen-intel/README.md
@@ -1,0 +1,17 @@
+# [Framework Laptop](https://frame.work/)
+
+## Updating Firmware
+
+First put enable `fwupd`
+
+```nix
+services.fwupd.enable = true;
+```
+
+Then run
+
+```sh
+ $ sudo fwupdmgr update
+```
+
+[Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop.TGL.BIOS.firmware)

--- a/framework/12th-gen-intel/default.nix
+++ b/framework/12th-gen-intel/default.nix
@@ -14,9 +14,13 @@
     "nvme.noacpi=1"
   ];
 
-  # Requires at least 5.16 for working wi-fi and bluetooth.
-  # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") (lib.mkDefault pkgs.linuxPackages_latest);
+  # This enables the brightness keys to work
+  # https://community.frame.work/t/12th-gen-not-sending-xf86monbrightnessup-down/20605/11
+  boot.blacklistedKernelModules = [ "hid-sensor-hub" ];
+
+  # Alder Lake CPUs benefit from kernel 5.18 for ThreadDirector
+  # https://www.tomshardware.com/news/intel-thread-director-coming-to-linux-5-18
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.18") (lib.mkDefault pkgs.linuxPackages_latest);
 
   # Fix TRRS headphones missing a mic
   # https://community.frame.work/t/headset-microphone-on-linux/12387/3

--- a/framework/12th-gen-intel/default.nix
+++ b/framework/12th-gen-intel/default.nix
@@ -1,0 +1,47 @@
+{ lib, pkgs, ... }: {
+  imports = [
+    ../../common/cpu/intel
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+  ];
+
+  boot.kernelParams = [
+    # For Power consumption
+    # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
+    "mem_sleep_default=deep"
+    # For Power consumption
+    # https://community.frame.work/t/linux-battery-life-tuning/6665/156
+    "nvme.noacpi=1"
+  ];
+
+  # Requires at least 5.16 for working wi-fi and bluetooth.
+  # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") (lib.mkDefault pkgs.linuxPackages_latest);
+
+  # Fix TRRS headphones missing a mic
+  # https://community.frame.work/t/headset-microphone-on-linux/12387/3
+  boot.extraModprobeConfig = ''
+    options snd-hda-intel model=dell-headset-multi
+  '';
+
+  # For fingerprint support
+  services.fprintd.enable = lib.mkDefault true;
+
+  # Fix headphone noise when on powersave
+  # https://community.frame.work/t/headphone-jack-intermittent-noise/5246/55
+  services.udev.extraRules = ''
+    SUBSYSTEM=="pci", ATTR{vendor}=="0x8086", ATTR{device}=="0xa0e0", ATTR{power/control}="on"
+  '';
+
+  # Mis-detected by nixos-generate-config
+  # https://github.com/NixOS/nixpkgs/issues/171093
+  # https://wiki.archlinux.org/title/Framework_Laptop#Changing_the_brightness_of_the_monitor_does_not_work
+  hardware.acpilight.enable = lib.mkDefault true;
+
+  # HiDPI
+  # Leaving here for documentation
+  # hardware.video.hidpi.enable = lib.mkDefault true;
+
+  # Fix font sizes in X
+  # services.xserver.dpi = 200;
+}


### PR DESCRIPTION
This sets up a few things that differ slightly from the original 11th gen Intel edition of the laptop