### PR TITLE
Add thinkpad t14 amd gen3

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad P53](lenovo/thinkpad/p53)                          | `<nixos-hardware/lenovo/thinkpad/p53>`             |
 | [Lenovo ThinkPad T14 AMD Gen 1](lenovo/thinkpad/t14/amd/gen1)       | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen1>`    |
 | [Lenovo ThinkPad T14 AMD Gen 2](lenovo/thinkpad/t14/amd/gen2)       | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen2>`    |
+| [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)       | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`    |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                          | `<nixos-hardware/lenovo/thinkpad/t14>`             |
 | [Lenovo ThinkPad T14s AMD Gen 1](lenovo/thinkpad/t14s/amd/gen1)     | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`   |
 | [Lenovo ThinkPad T14s](lenovo/thinkpad/t14s)                        | `<nixos-hardware/lenovo/thinkpad/t14s>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
       lenovo-thinkpad-t14 = import ./lenovo/thinkpad/t14;
       lenovo-thinkpad-t14-amd-gen1 = import ./lenovo/thinkpad/t14/amd/gen1;
       lenovo-thinkpad-t14-amd-gen2 = import ./lenovo/thinkpad/t14/amd/gen2;
+      lenovo-thinkpad-t14-amd-gen3 = import ./lenovo/thinkpad/t14/amd/gen3;
       lenovo-thinkpad-t14s = import ./lenovo/thinkpad/t14s;
       lenovo-thinkpad-t14s-amd-gen1 = import ./lenovo/thinkpad/t14s/amd/gen1;
       lenovo-thinkpad-t410 = import ./lenovo/thinkpad/t410;

--- a/lenovo/thinkpad/t14/amd/gen3/default.nix
+++ b/lenovo/thinkpad/t14/amd/gen3/default.nix
@@ -1,0 +1,11 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+  ];
+
+  # For the Qualcomm NFA-725A (Device 1103) wireless network controller
+  # See https://bugzilla.redhat.com/show_bug.cgi?id=2047878
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
+}


### PR DESCRIPTION
Tests were run and all pass.

I set the kernel to be 5.16 based on [this bug report](https://bugzilla.redhat.com/show_bug.cgi?id=2047878) discussing the necessary patch making it in to 5.16. In reality, this configuration results in my machine using 5.19.8 (5.16 [is EOL](https://lore.kernel.org/lkml/164987613419048@kroah.com/)) and works just fine. Please let me know if it's better to use 5.19 and I'll update.