### PR TITLE
kobol/helios4: init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
       pcengines-apu = import ./pcengines/apu;
       raspberry-pi-2 = import ./raspberry-pi/2;
       raspberry-pi-4 = import ./raspberry-pi/4;
+      kobol-helios4 = import ./kobol/helios4;
       samsung-np900x3c = import ./samsung/np900x3c;
       system76 = import ./system76;
       system76-darp6 = import ./system76/darp6;

--- a/kobol/helios4/default.nix
+++ b/kobol/helios4/default.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./modules/fancontrol.nix
+  ];
+
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  nixpkgs.hostPlatform = "armv7l-linux";
+
+  boot.initrd.availableKernelModules = [ "ahci_mvebu" ];
+
+  boot.kernelPackages = pkgs.linuxPackagesFor pkgs.linux_5_15_helios4;
+}

--- a/kobol/helios4/modules/90-helios4-hwmon.rules
+++ b/kobol/helios4/modules/90-helios4-hwmon.rules
@@ -1,0 +1,18 @@
+# Helios4 persistent hwmon
+ACTION=="remove", GOTO="helios4_hwmon_end"
+#
+KERNELS=="j10-pwm", SUBSYSTEMS=="platform", ENV{_HELIOS4_FAN_}="j10", ENV{_IS_HELIOS4_FAN_}="1", ENV{IS_HELIOS4_HWMON}="1"
+KERNELS=="j17-pwm", SUBSYSTEMS=="platform", ENV{_HELIOS4_FAN_}="j17", ENV{_IS_HELIOS4_FAN_}="1", ENV{IS_HELIOS4_HWMON}="1"
+KERNELS=="0-004c", SUBSYSTEMS=="i2c", DRIVERS=="lm75", ENV{IS_HELIOS4_HWMON}="1"
+SUBSYSTEM!="hwmon", GOTO="helios4_hwmon_end"
+ENV{HWMON_PATH}="/sys%p"
+#
+ATTR{name}=="f1072004mdiomii00", ENV{IS_HELIOS4_HWMON}="1", ENV{HELIOS4_SYMLINK}="/dev/thermal-eth"
+ATTR{name}=="armada_thermal", ENV{IS_HELIOS4_HWMON}="1", ENV{HELIOS4_SYMLINK}="/dev/thermal-cpu"
+ATTR{name}=="f10e4078.thermal", ENV{IS_HELIOS4_HWMON}="1", ENV{HELIOS4_SYMLINK}="/dev/thermal-cpu"
+#
+ENV{IS_HELIOS4_HWMON}=="1", ATTR{name}=="lm75", ENV{HELIOS4_SYMLINK}="/dev/thermal-board"
+ENV{_IS_HELIOS4_FAN_}=="1", ENV{HELIOS4_SYMLINK}="/dev/fan-$env{_HELIOS4_FAN_}"
+#
+ENV{IS_HELIOS4_HWMON}=="1", RUN+="/bin/ln -sf $env{HWMON_PATH} $env{HELIOS4_SYMLINK}"
+LABEL="helios4_hwmon_end"

--- a/kobol/helios4/modules/fancontrol.nix
+++ b/kobol/helios4/modules/fancontrol.nix
@@ -1,0 +1,44 @@
+{ pkgs, ... }:
+
+{
+  hardware.fancontrol.enable = true;
+  hardware.fancontrol.config = ''
+    # Helios4 PWM Fan Control Configuration
+    # Temp source : /dev/thermal-cpu
+    INTERVAL=10
+    FCTEMPS=/dev/fan-j10/pwm1=/dev/thermal-cpu/temp1_input /dev/fan-j17/pwm1=/dev/thermal-cpu/temp1_input
+    MINTEMP=/dev/fan-j10/pwm1=40 /dev/fan-j17/pwm1=40
+    MAXTEMP=/dev/fan-j10/pwm1=80 /dev/fan-j17/pwm1=80
+    MINSTART=/dev/fan-j10/pwm1=20 /dev/fan-j17/pwm1=20
+    MINSTOP=/dev/fan-j10/pwm1=29 /dev/fan-j17/pwm1=29
+    MINPWM=0
+  '';
+
+  boot.kernelModules = [ "lm75" ];
+
+  services.udev.packages = [
+    # Fan control
+    (pkgs.callPackage (
+      { stdenv, lib, coreutils }:
+      stdenv.mkDerivation {
+        name = "helios4-udev-fancontrol";
+
+        dontUnpack = true;
+        dontBuild = true;
+
+        installPhase = ''
+          mkdir -p "$out/etc/udev/rules.d/";
+          install -Dm644 "${./90-helios4-hwmon.rules}" \
+            "$out/etc/udev/rules.d/90-helios4-hwmon.rules"
+          substituteInPlace "$out/etc/udev/rules.d/90-helios4-hwmon.rules" \
+            --replace '/bin/ln'  '${lib.getBin coreutils}/bin/ln'
+        '';
+
+        meta = with lib; {
+          description = "Udev rules for fancontrol for the Helios4";
+          platforms = platforms.linux;
+        };
+      }
+    ) {})
+  ];
+}

--- a/kobol/helios4/overlay.nix
+++ b/kobol/helios4/overlay.nix
@@ -1,0 +1,48 @@
+final: prev: {
+  linux_5_15_helios4 = final.linux_5_15.override {
+    kernelPatches = [
+      # A patch to get both PWM fans working
+      # the patch has been successfully applied to 5.15 and 5.19
+      {
+        patch = final.fetchpatch {
+          url = "https://raw.githubusercontent.com/armbian/build/03dbd9d3a733f097e23595e76ac60771c655ebf1/patch/kernel/archive/mvebu-5.15/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch";
+          sha256 = "sha256-0h7v3Nua1LuHf4h53WdYEBrbUA9dOGdF06TDBlDplOQ=";
+        };
+      }
+      # support for Wake-On-Lan
+      {
+        patch = final.fetchpatch {
+          url = "https://raw.githubusercontent.com/armbian/build/03dbd9d3a733f097e23595e76ac60771c655ebf1/patch/kernel/archive/mvebu-5.15/92-mvebu-gpio-add_wake_on_gpio_support.patch";
+          sha256 = "sha256-OrvnVCU55P0U78jdoxGRJvl29i+Rvq8AdEGSCCpxa2I=";
+        };
+      }
+      {
+        patch = final.fetchpatch {
+          url = "https://raw.githubusercontent.com/armbian/build/03dbd9d3a733f097e23595e76ac60771c655ebf1/patch/kernel/archive/mvebu-5.15/94-helios4-dts-add-wake-on-lan-support.patch";
+          sha256 = "sha256-ai4161bTC22023eaVVWsvbk6fQKjkv0P4DQ4DA1Zgow=";
+        };
+      }
+
+    ];
+    defconfig = "mvebu_v7_defconfig";
+    # Make the kernel build a bit faster by disabling GPU modules, which we don't need anyways
+    structuredExtraConfig = with final.lib.kernel; {
+      DRM = no;
+    };
+  };
+
+  ubootHelios4 = final.buildUBoot rec {
+    defconfig = "helios4_defconfig";
+    filesToInstall = [ "u-boot-spl.kwb" ];
+    # 2021.07 and later are broken, similar to this bug report:
+    # https://www.mail-archive.com/u-boot@lists.denx.de/msg451013.html#
+    version = "2021.04";
+    src = final.fetchFromGitHub {
+      owner = "u-boot";
+      repo = "u-boot";
+      rev = "v${version}";
+      sha256 = "sha256-QxrTPcx0n0NWUJ990EuIWyOBtknW/fHDRcrYP0yQzTo=";
+    };
+    patches = [];
+  };
+}


### PR DESCRIPTION
- [x] fancontrol
- [x] wake-on-lan (untested)
- [ ] hdd activity leds

This is ready for review, I might add the hdd activity led support later if I get to it, but it should already be useful without that.