### PR TITLE
Fixed utillinux package renaming

### DIFF
--- a/msi/gs60/default.nix
+++ b/msi/gs60/default.nix
@@ -20,10 +20,10 @@
   # Laptop can't correctly suspend if wlan is active
   powerManagement = {
     powerDownCommands = ''
-      ${pkgs.utillinux}/bin/rfkill block wlan
+      ${pkgs.util-linux}/bin/rfkill block wlan
     '';
     resumeCommands = ''
-      ${pkgs.utillinux}/bin/rfkill unblock wlan
+      ${pkgs.util-linux}/bin/rfkill unblock wlan
     '';
   };
 }


### PR DESCRIPTION
NixOs renamed `utillinux` to `util-linux`
```
error: attribute 'utillinux' missing

       at /nix/store/xmdajfhdaxc38kjymr7rdfdya6yv9r0s-source/msi/gs60/default.nix:26:9:

           25|     resumeCommands = ''
           26|       ${pkgs.utillinux}/bin/rfkill unblock wlan
             |         ^
           27|     '';
(use '--show-trace' to show detailed location information)
```