### PR TITLE
lenovo/thinkpad/x1-extreme: remove acpi_call

### DIFF
--- a/lenovo/thinkpad/x1-extreme/default.nix
+++ b/lenovo/thinkpad/x1-extreme/default.nix
@@ -2,7 +2,6 @@
   imports = [
     ../.
     ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/laptop/ssd
   ];
 }


### PR DESCRIPTION
It's deprecated and doesn't work correctly anyway. Recent firmwares can power the GPU off if it drops off the bus, which can be forced with udev rules.