### PR TITLE
gpd/pocket-3: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See code for all available configurations.
 | [Framework](framework)                                              | `<nixos-hardware/framework>`                       |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
+| [GPD Pocket 3](gpd/pocket-3)                                        | `<nixos-hardware/gpd/pocket-3>`                     |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                            | `<nixos-hardware/hp/elitebook/2560p>`              |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                               | `<nixos-hardware/intel/nuc/8i7beh>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
       friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;
+      gpd-pocket-3 = import ./gpd/pocket-3;
       hp-elitebook-2560p = import ./hp/elitebook/2560p;
       intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;

--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -1,0 +1,43 @@
+{ lib, pkgs, ... }:
+let inherit (lib) mkDefault;
+in
+{
+	imports = [
+		../../common/pc/laptop
+		../../common/pc/laptop/ssd
+	];
+
+  # Necessary kernel modules
+	boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "usbhid" "thunderbolt" ];
+
+	# GPU is an Intel Iris Xe, on a “TigerLake” mobile CPU
+	boot.initrd.kernelModules = [ "i915" ];  # Early loading so the passphrase prompt appears on external displays
+	services.xserver.videoDrivers = [ "intel" ];
+	hardware.opengl.extraPackages = with pkgs; [ intel-media-driver vaapiIntel ];
+
+	boot.kernelParams = [
+		# S3 suspend is broken as of Sept. 2022 (screen does not come back properly), use S2
+		"mem_sleep_default=s2idle"
+
+		# The GPD Pocket3 uses a tablet OLED display, that is mounted rotated 90° counter-clockwise
+		"fbcon=rotate:1" "video=DSI-1:panel_orientation=right_side_up"
+	];
+
+	fonts.fontconfig = {
+		subpixel.rgba = "vbgr";  # Pixel order for rotated screen
+
+		# The OLED display has √(1920² + 1200²) px / 8in ≃ 283 dpi
+		# Per the documentation, antialiasing, hinting, etc. have no visible effect at such high pixel densities anyhow.
+		hinting.enable = mkDefault false;
+		antialias = false;  #TODO(nicoo): Fix nixpkgs' HiDPI module
+	};
+
+	# More HiDPI settings
+	hardware.video.hidpi.enable = true;
+	services.xserver.dpi = 280;
+
+	# Necessary for audio support on the 1195G7 model
+	boot.extraModprobeConfig = ''
+		options snd-intel-dspcfg dsp_driver=1
+	'';
+}

--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, ... }:
-let inherit (lib) mkDefault;
+let inherit (lib) mkDefault mkIf;
 in
 {
 	imports = [
@@ -28,8 +28,9 @@ in
 
 		# The OLED display has √(1920² + 1200²) px / 8in ≃ 283 dpi
 		# Per the documentation, antialiasing, hinting, etc. have no visible effect at such high pixel densities anyhow.
+		# Set manually, as the hiDPI module had incorrect settings prior to NixOS 22.11; see nixpkgs#194594.
 		hinting.enable = mkDefault false;
-		antialias = false;  #TODO(nicoo): Fix nixpkgs' HiDPI module
+		antialias = mkIf (lib.versionOlder (lib.versions.majorMinor lib.version) "22.11") false;
 	};
 
 	# More HiDPI settings


### PR DESCRIPTION
## New configuration for the GPD Pocket 3 computer
- [x] necessary kernel modules are set;
- [x] suspend-to-RAM is configured to use ACPI S2 sleep (S3 currently broken due to a firmware issue) ;
- [x] `snd-intel-dspcfg` driver is configured for audio to work on the 1195G7 model;
- [x] video drivers and hardware codec acceleration are configured;
- [x] kernel & fontconfig parameters are set to deal with the sideways & hiDPI screen.

This should presumably wait until NixOS/nixpkgs#194594 is merged, as I made the
workaround for `fonts.fontconfig.antialias` conditional on nixpkgs version.


## Potential TODOs
- Sideway screen
  - [x] Find why the `video=` kernel cmdline setting is insufficient for `sway` to orient correctly.
  - [ ] Fix touchscreen input orientation
  - [ ] Test under X.org too.
- [ ] Add support / automatic rotation when flipping the screen over (tablet mode)
- [ ] Test the webcam
- [ ] Help get support for the [fingerprint sensor](https://gitlab.freedesktop.org/libfprint/wiki/-/issues/47)
- [ ] Find someone to test with the N6000 model (which I do not own) or sponsor one.
