### PR TITLE
raspberrypi/4: allow pi libs to detect pi 4

### DIFF
--- a/raspberry-pi/4/cpu-revision.nix
+++ b/raspberry-pi/4/cpu-revision.nix
@@ -1,0 +1,25 @@
+{ ... }:
+{
+  hardware.deviceTree.overlays = [
+    {
+      name = "rpi4-cpu-revision";
+      dtsText = ''
+        /dts-v1/;
+        /plugin/;
+
+        / {
+          compatible = "raspberrypi,4-model-b";
+
+          fragment@0 {
+            target-path = "/";
+            __overlay__ {
+              system {
+                linux,revision = <0x00d03114>;
+              };
+            };
+          };
+        };
+      '';
+    }
+  ];
+}

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./audio.nix
+    ./cpu-revision.nix
     ./dwc2.nix
     ./i2c.nix
     ./modesetting.nix


### PR DESCRIPTION
Lot of libraries have checks to detect that they are running on a Raspberry Pi 4 and fail otherwise.
See https://github.com/gpiozero/gpiozero/issues/837.

This also happens with the current NixOS image, specifically:
```
$ python3
>>> from RPi import GPIO
>>> GPIO.setup(9, GPIO.IN)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Not running on a RPi!
>>>
```

This sets the CPU revision which is the newest way these libraries do their detection.
I've been running this for a while with great results, finally remembered to post something here.