### PR TITLE
Add support for ssd to Lenovo ThinkPad T480s

### DIFF
--- a/lenovo/thinkpad/t480s/default.nix
+++ b/lenovo/thinkpad/t480s/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../../common/cpu/intel
     ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/ssd
     ../.
   ];
 


### PR DESCRIPTION
I just realised that ssd support is missing despite the model having ssd