### PR TITLE
apple/macbook-pro: add support for 14,1

### DIFF
--- a/apple/macbook-pro/14-1/README.md
+++ b/apple/macbook-pro/14-1/README.md
@@ -1,0 +1,17 @@
+# MacBook Pro 14,1
+
+## Audio
+
+Audio is a lost cause. Bribe an Apple or Cirrus engineer for the datasheet. ;)
+
+## Thunderbolt
+
+The thunderbolt module will oops upon system resume, and subsequently refuse to work until next reboot.
+
+## Suspend/Resume
+
+The d3cold state needs to be disabled on the NVME controller for it to wake up.
+
+## Bluetooth
+The Bluetooth UART (/dev/ttyS0) is created and then deleted by udev in early boot.
+Hack around it by reloading the 8250_dw module, causing it to be re-created.

--- a/apple/macbook-pro/14-1/btfix.sh
+++ b/apple/macbook-pro/14-1/btfix.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+##
+# For some reason /dev/ttyS0 is created, and then removed by udev. We need this
+# for bluetooth, and the only way to get it again is to reload 8502_dw. Do so.
+##
+
+
+##
+# /sys/devices/pci0000:00/0000:00:1e.0/driver -> intel-lpss
+# /sys/bus/pci/devices/0000:00:1e.0
+# /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:8a/BCM2E7C:00
+##
+
+# udevadm info --query=all --path=/sys/bus/serial/devices/serial0-0
+# P: /devices/pci0000:00/0000:00:1e.0/dw-apb-uart.2/serial0/serial0-0
+# M: serial0-0
+# R: 0
+# U: serial
+# E: DEVPATH=/devices/pci0000:00/0000:00:1e.0/dw-apb-uart.2/serial0/serial0-0
+# E: SUBSYSTEM=serial
+# E: MODALIAS=acpi:BCM2E7C:APPLE-UART-BLTH:
+# E: USEC_INITIALIZED=12406199
+# E: PATH=/nix/store/56jhf2k9q31gwvhjxmm2akkkhi4a8nz1-udev-path/bin:/nix/store/56jhf2k9q31gwvhjxmm2akkkhi4a8nz1-udev-path/sbin
+# E: ID_VENDOR_FROM_DATABASE=Broadcom
+
+
+if [[ ! -e "/sys/devices/pci0000:00/0000:00:1e.0/dw-apb-uart.2/tty/ttyS0" ]]; then
+    if [[ -e /sys/module/8250_dw ]]; then
+        rmmod 8250_dw
+    fi
+
+    modprobe 8250_dw
+fi
+
+exec btattach --protocol=h4 --bredr=/dev/ttyS0 --speed=3000000

--- a/apple/macbook-pro/14-1/default.nix
+++ b/apple/macbook-pro/14-1/default.nix
@@ -25,7 +25,7 @@
     path        = [ pkgs.bash pkgs.coreutils ];
 
     serviceConfig.Type = "oneshot";
-    serviceConfig.ExecStart = ./disable-nvme-d3cold.sh;
+    serviceConfig.ExecStart = "${./disable-nvme-d3cold.sh}";
     serviceConfig.TimeoutSec = 0;
 
     wantedBy = [ "multi-user.target" "suspend.target" ];
@@ -44,7 +44,7 @@
     path = [ pkgs.bash pkgs.kmod pkgs.bluez ];
 
     serviceConfig.Type = "simple";
-    serviceConfig.ExecStart = ./btfix.sh;
+    serviceConfig.ExecStart = "${./btfix.sh}";
 
     wantedBy = [ "multi-user.target" ];
   };

--- a/apple/macbook-pro/14-1/default.nix
+++ b/apple/macbook-pro/14-1/default.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../common/pc/laptop/ssd
+  ];
+
+  ##
+  # Make the keyboard work in stage1
+  # https://www.kernelconfig.io/config_keyboard_applespi
+  ##
+  boot.initrd.kernelModules = [ "applespi" "spi_pxa2xx_platform" "intel_lpss_pci" "applesmc" ];
+
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.0") pkgs.linuxPackages_latest;
+
+  ##
+  # Disable d3cold on the NVME controller so the machine can actually
+  # wake up.
+  # https://github.com/Dunedan/mbp-2016-linux
+  ##
+  systemd.services.disable-nvme-d3cold = {
+    description = "Disables d3cold on the NVME controller";
+    before      = [ "suspend.target" ];
+    path        = [ pkgs.bash pkgs.coreutils ];
+
+    serviceConfig.Type = "oneshot";
+    serviceConfig.ExecStart = ./disable-nvme-d3cold.sh;
+    serviceConfig.TimeoutSec = 0;
+
+    wantedBy = [ "multi-user.target" "suspend.target" ];
+  };
+
+  ##
+  # For some reason /dev/ttyS0 is created, and then removed by udev. We need this
+  # for bluetooth, and the only way to get it again is to reload 8502_dw. Luckily,
+  # nothing else uses it.
+  ##
+  systemd.services.btattach-bcm2e7c = lib.mkIf config.hardware.bluetooth.enable {
+    before = [ "bluetooth.target" ];
+
+    # Hacky, as it's a different device,  but this always comes after ttyS0
+    after = [ "sys-devices-platform-serial8250-tty-ttyS1.device" ];
+    path = [ pkgs.bash pkgs.kmod pkgs.bluez ];
+
+    serviceConfig.Type = "simple";
+    serviceConfig.ExecStart = ./btfix.sh;
+
+    wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/apple/macbook-pro/14-1/disable-nvme-d3cold.sh
+++ b/apple/macbook-pro/14-1/disable-nvme-d3cold.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+driver_path=/sys/bus/pci/devices/0000:01:00.0
+
+if [[ ! -e "$driver_path" ]]; then
+    echo "$driver_path does not exist, exiting..."
+    exit 1
+fi
+
+driver=$(basename $(readlink "$driver_path/driver"))
+
+if [[ "$driver" -ne "nvme" ]]; then
+    echo "$driver_path is not an NVME device, got $driver, exiting..."
+    exit 1
+fi
+
+echo 0 > "$driver_path/d3cold_allowed"
+

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
       apple-macbook-pro-10-1 = import ./apple/macbook-pro/10-1;
       apple-macbook-pro-11-5 = import ./apple/macbook-pro/11-5;
       apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;
+      apple-macbook-pro-14-1 = import ./apple/macbook-pro/14-1;
       asus-battery = import ./asus/battery.nix;
       asus-fx504gd = import ./asus/fx504gd;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;


### PR DESCRIPTION
Extracted from my system configs. There's still a few issues with this machine:

1. Audio is a lost cause. Will probably need to bribe an Apple or Cirrus engineer for the datasheet.
2. The thunderbolt module will oops upon system resume, and subsequently refuse to work until next reboot.
3. The d3cold state needs to be disabled on the NVME controller for it to wake up.
4. The Bluetooth UART (/dev/ttyS0) is created and then deleted by udev in early boot. I am yet to figure out why. Hack around it by reloading the 8250_dw module, causing it to be re-created.

Any ideas for an alternative to the `/dev/ttyS0` hack are welcome,.