### PR TITLE
add thinkpad x1 yoga 7th-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T550](lenovo/thinkpad/t550)                        | `<nixos-hardware/lenovo/thinkpad/t550>`            |
 | [Lenovo ThinkPad T590](lenovo/thinkpad/t590)                        | `<nixos-hardware/lenovo/thinkpad/t590>`            |
 | [Lenovo ThinkPad X1 Yoga](lenovo/thinkpad/x1/yoga)                  | `<nixos-hardware/lenovo/thinkpad/x1/yoga>`         |
+| [Lenovo ThinkPad X1 Yoga Gen 7](lenovo/thinkpad/x1/yoga/7th-gen/)   | `<nixos-hardware/lenovo/thinkpad/x1/yoga/7th-gen>` |
 | [Lenovo ThinkPad X1 (6th Gen)](lenovo/thinkpad/x1/6th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`      |
 | [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`      |
 | [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`      |

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,7 @@
       lenovo-thinkpad-t590 = import ./lenovo/thinkpad/t590;
       lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
       lenovo-thinkpad-x1-yoga = import ./lenovo/thinkpad/x1/yoga;
+      lenovo-thinkpad-x1-yoga-7th-gen = import ./lenovo/thinkpad/x1/yoga/7th-gen;
       lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
       lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
       lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;

--- a/lenovo/thinkpad/x1/yoga/7th-gen/default.nix
+++ b/lenovo/thinkpad/x1/yoga/7th-gen/default.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }: {
+  imports = [
+    ../.
+    ../../../../../common/pc/laptop/ssd
+  ];
+
+  # This laptop is too new for the kernel currently in nixos-unstable.
+  # On Kernel 5.15.x, dmesg shows the `hardware is newer than drivers` message.
+  # When starting the system with 5.15.x, only a tty is being displayed.
+  # After our tests, at least version 5.19 is required for the system to work properly.
+  boot.kernelPackages = lib.mkIf
+    (lib.versionOlder pkgs.linux.version "5.19")
+    (lib.mkDefault pkgs.linuxPackages_latest);
+}


### PR DESCRIPTION
The Thinkpad X1 yoga 7th gen comes with an intel Alder Lake CPU.
The default Kernel in nixos-unstable did not work with this device:
dmesg had the `hardware newer than driver` error.
After trying out one kernel at a time, at least 5.19 seems to be needed.
Without, only a TTY would show up.

The specific device being used for testing: https://www.lenovo.com/de/de/laptops/thinkpad/thinkpad-x1/ThinkPad-X1-Yoga-Gen-7-14-inch-Intel/p/LEN101T0010