### PR TITLE
raspberry-pi/4: add pcie_brcmstb and reset-raspberrypi to kernelParams

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -16,7 +16,13 @@
 
   boot = {
     kernelPackages = lib.mkDefault pkgs.linuxPackages_rpi4;
-    initrd.availableKernelModules = [ "usbhid" "usb_storage" "vc4" ];
+    initrd.availableKernelModules = [
+      "usbhid"
+      "usb_storage"
+      "vc4"
+      "pcie_brcmstb"      # required for the pcie bus to work
+      "reset-raspberrypi" # required for vl805 firmware to load
+    ];
 
     loader = {
       grub.enable = lib.mkDefault false;


### PR DESCRIPTION
###### Description of changes

This is required for things like USB Boot to work correctly. Without it, NixOS will fail to discover the disk in Stage 1 of boot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input