### PR TITLE
framework: Add iio in order to enable brightness control

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -38,6 +38,9 @@
   # https://wiki.archlinux.org/title/Framework_Laptop#Changing_the_brightness_of_the_monitor_does_not_work
   hardware.acpilight.enable = lib.mkDefault true;
 
+  # Needed for desktop environments to detect/manage display brightness
+  hardware.sensor.iio.enable = lib.mkDefault true;
+
   # HiDPI
   # Leaving here for documentation
   # hardware.video.hidpi.enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes

Enabling iio makes the Framework's brightness controls available to desktop environments like Gnome.

With this enabled, Gnome has a brightness slider and the automatic brightness adjustment option is available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

