### PR TITLE
Dell Latitude 3340

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ See code for all available configurations.
 | [Dell Inspiron 5509](dell/inspiron/5509)                            | `<nixos-hardware/dell/inspiron/5509>`              |
 | [Dell Inspiron 5515](dell/inspiron/5515)                            | `<nixos-hardware/dell/inspiron/5515>`              |
 | [Dell Inspiron 7405](dell/inspiron/7405)                            | `<nixos-hardware/dell/inspiron/7405>`              |
+| [Dell Latitude 3340](dell/latitude/3340)                            | `<nixos-hardware/dell/latitude/3340>`              |
 | [Dell Latitude 3480](dell/latitude/3480)                            | `<nixos-hardware/dell/latitude/3480>`              |
 | [Dell Latitude 5520](dell/latitude/5520)                            | `<nixos-hardware/dell/latitude/5520>`              |
 | [Dell Latitude 7490](dell/latitude/7490)                            | `<nixos-hardware/dell/latitude/7490>`              |
@@ -117,7 +118,7 @@ See code for all available configurations.
 | [Framework 12th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
-| [GPD Pocket 3](gpd/pocket-3)                                        | `<nixos-hardware/gpd/pocket-3>`                     |
+| [GPD Pocket 3](gpd/pocket-3)                                        | `<nixos-hardware/gpd/pocket-3>`                    |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                            | `<nixos-hardware/hp/elitebook/2560p>`              |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                               | `<nixos-hardware/intel/nuc/8i7beh>`                |

--- a/dell/latitude/3340/default.nix
+++ b/dell/latitude/3340/default.nix
@@ -1,0 +1,11 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
+}

--- a/dell/latitude/3340/default.nix
+++ b/dell/latitude/3340/default.nix
@@ -6,6 +6,4 @@
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];
-
-  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -102,16 +102,13 @@
       lenovo-thinkpad-t590 = import ./lenovo/thinkpad/t590;
       lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
       lenovo-thinkpad-x1-yoga = import ./lenovo/thinkpad/x1/yoga;
-      lenovo-thinkpad-x1-yoga-7th-gen =
-        import ./lenovo/thinkpad/x1/yoga/7th-gen;
+      lenovo-thinkpad-x1-yoga-7th-gen = import ./lenovo/thinkpad/x1/yoga/7th-gen;
       lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
       lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
       lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;
       lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
-      lenovo-thinkpad-x1-extreme-gen2 =
-        import ./lenovo/thinkpad/x1-extreme/gen2;
-      lenovo-thinkpad-x1-extreme-gen4 =
-        import ./lenovo/thinkpad/x1-extreme/gen4;
+      lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
+      lenovo-thinkpad-x1-extreme-gen4 = import ./lenovo/thinkpad/x1-extreme/gen4;
       lenovo-thinkpad-x13 = import ./lenovo/thinkpad/x13;
       lenovo-thinkpad-x13-yoga = import ./lenovo/thinkpad/x13/yoga;
       lenovo-thinkpad-x140e = import ./lenovo/thinkpad/x140e;
@@ -157,8 +154,7 @@
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;
       common-gpu-amd = import ./common/gpu/amd;
       common-gpu-amd-sea-islands = import ./common/gpu/amd/sea-islands;
-      common-gpu-amd-southern-islands =
-        import ./common/gpu/amd/southern-islands;
+      common-gpu-amd-southern-islands = import ./common/gpu/amd/southern-islands;
       common-gpu-intel = import ./common/gpu/intel.nix;
       common-gpu-nvidia = import ./common/gpu/nvidia.nix;
       common-gpu-nvidia-disable = import ./common/gpu/nvidia-disable.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       dell-inspiron-5509 = import ./dell/inspiron/5509;
       dell-inspiron-5515 = import ./dell/inspiron/5515;
       dell-inspiron-7405 = import ./dell/inspiron/7405;
+      dell-latitude-3340 = import ./dell/latitude/3340;
       dell-latitude-3480 = import ./dell/latitude/3480;
       dell-latitude-5520 = import ./dell/latitude/5520;
       dell-latitude-7490 = import ./dell/latitude/7490;
@@ -101,13 +102,16 @@
       lenovo-thinkpad-t590 = import ./lenovo/thinkpad/t590;
       lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
       lenovo-thinkpad-x1-yoga = import ./lenovo/thinkpad/x1/yoga;
-      lenovo-thinkpad-x1-yoga-7th-gen = import ./lenovo/thinkpad/x1/yoga/7th-gen;
+      lenovo-thinkpad-x1-yoga-7th-gen =
+        import ./lenovo/thinkpad/x1/yoga/7th-gen;
       lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
       lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
       lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;
       lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
-      lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
-      lenovo-thinkpad-x1-extreme-gen4 = import ./lenovo/thinkpad/x1-extreme/gen4;
+      lenovo-thinkpad-x1-extreme-gen2 =
+        import ./lenovo/thinkpad/x1-extreme/gen2;
+      lenovo-thinkpad-x1-extreme-gen4 =
+        import ./lenovo/thinkpad/x1-extreme/gen4;
       lenovo-thinkpad-x13 = import ./lenovo/thinkpad/x13;
       lenovo-thinkpad-x13-yoga = import ./lenovo/thinkpad/x13/yoga;
       lenovo-thinkpad-x140e = import ./lenovo/thinkpad/x140e;
@@ -153,7 +157,8 @@
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;
       common-gpu-amd = import ./common/gpu/amd;
       common-gpu-amd-sea-islands = import ./common/gpu/amd/sea-islands;
-      common-gpu-amd-southern-islands = import ./common/gpu/amd/southern-islands;
+      common-gpu-amd-southern-islands =
+        import ./common/gpu/amd/southern-islands;
       common-gpu-intel = import ./common/gpu/intel.nix;
       common-gpu-nvidia = import ./common/gpu/nvidia.nix;
       common-gpu-nvidia-disable = import ./common/gpu/nvidia-disable.nix;


### PR DESCRIPTION
###### Description of changes

The Dell Latitude 3340 does not have the same touchpad situation as later Latitudes. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration [here](https://github.com/quinn-dougherty/configuration.nix/tree/main/agent-latitude)
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

(I'm not actually sure what an end to end test would be) 