### PR TITLE
starfive/visionfive/v1: Make sd-image more flake-friendly

### DIFF
--- a/starfive/visionfive/v1/README.md
+++ b/starfive/visionfive/v1/README.md
@@ -1,4 +1,4 @@
-### Build the SD image
+## Build the SD image
 - ``nix-build "<nixpkgs/nixos>" -A config.system.build.sdImage -I nixos-config=iso.nix``
 
 - ``iso.nix``
@@ -16,10 +16,10 @@
     }
     ```
 
-### Relevant documentation
+## Relevant documentation
 - Flashing
-- - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/hardware_connection.html
-- - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/using_xmodem1.html
+  - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/hardware_connection.html
+  - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/using_xmodem1.html
 - Recovery
-- - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/hardware_setup.html
-- - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/for_maclinux4.html
+  - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/hardware_setup.html
+  - https://doc-en.rvspace.org/VisionFive/Quick_Start_Guide/VisionFive_QSG/for_maclinux4.html

--- a/starfive/visionfive/v1/sd-image-installer.nix
+++ b/starfive/visionfive/v1/sd-image-installer.nix
@@ -1,12 +1,14 @@
 # To build, use:
 # nix-build "<nixpkgs/nixos>" -I nixos-config=starfive/visionfive/v1/sd-image-installer.nix -A config.system.build.sdImage
+{ modulesPath, ... }:
+
 {
   imports = [
-    <nixpkgs/nixos/modules/profiles/installation-device.nix>
+    "${modulesPath}/profiles/installation-device.nix"
     ./sd-image.nix
   ];
 
-  # the installation media is also the installation target,
+  # The installation media is also the installation target,
   # so we don't want to provide the installation configuration.nix.
   installer.cloneConfig = false;
 }

--- a/starfive/visionfive/v1/sd-image.nix
+++ b/starfive/visionfive/v1/sd-image.nix
@@ -1,13 +1,13 @@
 # To build, use:
-# nix-build "<nixpkgs}/nixos>" -I nixos-config=starfive/visionfive/v1/sd-image.nix -A config.system.build.sdImage
-{ config, pkgs, ... }:
+# nix-build "<nixpkgs/nixos>" -I nixos-config=starfive/visionfive/v1/sd-image.nix -A config.system.build.sdImage
+{ config, pkgs, modulesPath, ... }:
 
 let
   firmware = pkgs.callPackage ./firmware.nix { };
 in {
   imports = [
-    <nixpkgs/nixos/modules/profiles/base.nix>
-    <nixpkgs/nixos/modules/installer/sd-card/sd-image.nix>
+    "${modulesPath}/profiles/base.nix"
+    "${modulesPath}/installer/sd-card/sd-image.nix"
     ./default.nix
   ];
 


### PR DESCRIPTION
###### Description of changes
Do not force channels for ``sd-image``.
Fixup README.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

