### PR TITLE
Changed asus battery script to work with multiple battery names.

### DIFF
--- a/asus/battery.nix
+++ b/asus/battery.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 let
   p = pkgs.writeScriptBin "charge-upto" ''
-    echo ''${0:-100} > /sys/class/power_supply/BAT0/charge_control_end_threshold
+    echo ''${0:-100} > /sys/class/power_supply/BAT?/charge_control_end_threshold
   '';
   cfg = config.hardware.asus.battery;
 in
@@ -30,7 +30,7 @@ in
       serviceConfig = {
         Type = "oneshot";
         Restart = "on-failure";
-        ExecStart = "${pkgs.runtimeShell} -c 'echo ${toString cfg.chargeUpto} > /sys/class/power_supply/BAT0/charge_control_end_threshold'";
+        ExecStart = "${pkgs.runtimeShell} -c 'echo ${toString cfg.chargeUpto} > /sys/class/power_supply/BAT?/charge_control_end_threshold'";
       };
     };
   };


### PR DESCRIPTION
###### Description of changes
ASUS laptop batteries may have different battery names. [From the Arch wiki](https://wiki.archlinux.org/title/Laptop/ASUS#:~:text=note%3A%20as%20of%202020-12-11%2C%20the%20following%20battery%20device%20names%20are%20recognized%3A%20bat0%2C%20bat1%2C%20batc%20and%20batt.%5B4%5D%20adjust%20accordingly%20or%20use%20the%20single%20character%20wildcard%20(%3F)%2C%20e.g.%20bat%3F.) (referencing [these kernel lines](https://github.com/torvalds/linux/blob/1797d588af15174d4a4e7159dac8c800538e4f8c/drivers/platform/x86/asus-wmi.c#L440-L448)), BAT0, BAT1, BATC and BATT are all recognized names for ASUS batteries. This changes the battery script to use the wildcard to work with all these battery names.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

