### PR TITLE
Add support for ssd to Lenovo ThinkPad T480

### DIFF
--- a/lenovo/thinkpad/t480/default.nix
+++ b/lenovo/thinkpad/t480/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../../common/cpu/intel
     ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/ssd
     ../.
   ];
 


### PR DESCRIPTION
###### Description of changes

After seeing https://github.com/NixOS/nixos-hardware/pull/482 this is also relevant on the t480.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

