### PR TITLE
common/gpu/nvidia*: Migrate to common/gpu/nvidia/* and add non-prime

### DIFF
--- a/asus/rog-strix/g733qs/default.nix
+++ b/asus/rog-strix/g733qs/default.nix
@@ -2,7 +2,7 @@
 {
   imports = [
     ../../../common/cpu/amd/pstate.nix
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/ssd
     ../../battery.nix

--- a/asus/zephyrus/ga401/default.nix
+++ b/asus/zephyrus/ga401/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../common/cpu/amd
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];

--- a/asus/zephyrus/ga503/default.nix
+++ b/asus/zephyrus/ga503/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../common/cpu/amd
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];

--- a/common/gpu/nvidia-disable.nix
+++ b/common/gpu/nvidia-disable.nix
@@ -1,9 +1,11 @@
-{ lib, pkgs, ... }:
-
 {
-  # This runs only intel/amdgpu igpus and nvidia dgpus do not drain power.
+  imports = [ ./nvidia/disable.nix ];
 
-  ##### disable nvidia, very nice battery life.
-  hardware.nvidiaOptimus.disable = lib.mkDefault true;
-  boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" ];
+  warnings = [
+    ''
+      DEPRECATED: The <nixos-hardware/common/gpu/nvidia-disable.nix> module has been deprecated.
+
+      Switch to using <nixos-hardware/common/gpu/nvidia/disable.nix> instead.
+    ''
+  ];
 }

--- a/common/gpu/nvidia.nix
+++ b/common/gpu/nvidia.nix
@@ -1,26 +1,12 @@
-{ lib, pkgs, ... }:
-
-# This creates a new 'nvidia-offload' program that runs the application passed to it on the GPU
-# As per https://nixos.wiki/wiki/Nvidia
-let
-  nvidia-offload = pkgs.writeShellScriptBin "nvidia-offload" ''
-    export __NV_PRIME_RENDER_OFFLOAD=1
-    export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
-    export __GLX_VENDOR_LIBRARY_NAME=nvidia
-    export __VK_LAYER_NV_optimus=NVIDIA_only
-    exec "$@"
-  '';
-in
 {
-  services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
-  environment.systemPackages = [ nvidia-offload ];
+  imports = [ ./nvidia/prime.nix ];
 
-  hardware.nvidia.prime = {
-    offload.enable = lib.mkDefault true;
-    # Hardware should specify the bus ID for intel/nvidia devices
-  };
+  warnings = [
+    ''
+      DEPRECATED: The <nixos-hardware/common/gpu/nvidia.nix> module has been deprecated.
 
-  hardware.opengl.extraPackages = with pkgs; [
-    vaapiVdpau
+      Switch to using <nixos-hardware/common/gpu/nvidia/prime.nix> instead if you use prime offloading.
+      If you are using this without prime, consider switching to <nixos-hardware/common/gpu/nvidia> instead.
+    ''
   ];
 }

--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -1,0 +1,8 @@
+{ lib, pkgs, ... }:
+
+{
+  services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
+  hardware.opengl.extraPackages = with pkgs; [
+    vaapiVdpau
+  ];
+}

--- a/common/gpu/nvidia/disable.nix
+++ b/common/gpu/nvidia/disable.nix
@@ -1,0 +1,9 @@
+{ lib, pkgs, ... }:
+
+{
+  # This runs only intel/amdgpu igpus and nvidia dgpus do not drain power.
+
+  ##### disable nvidia, very nice battery life.
+  hardware.nvidiaOptimus.disable = lib.mkDefault true;
+  boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" ];
+}

--- a/common/gpu/nvidia/prime.nix
+++ b/common/gpu/nvidia/prime.nix
@@ -1,0 +1,22 @@
+{ lib, pkgs, ... }:
+
+# This creates a new 'nvidia-offload' program that runs the application passed to it on the GPU
+# As per https://nixos.wiki/wiki/Nvidia
+let
+  nvidia-offload = pkgs.writeShellScriptBin "nvidia-offload" ''
+    export __NV_PRIME_RENDER_OFFLOAD=1
+    export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
+    export __GLX_VENDOR_LIBRARY_NAME=nvidia
+    export __VK_LAYER_NV_optimus=NVIDIA_only
+    exec "$@"
+  '';
+in {
+  imports = [ ./. ];
+
+  environment.systemPackages = [ nvidia-offload ];
+
+  hardware.nvidia.prime = {
+    offload.enable = lib.mkDefault true;
+    # Hardware should specify the bus ID for intel/nvidia devices
+  };
+}

--- a/dell/g3/3779/default.nix
+++ b/dell/g3/3779/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../common/cpu/intel
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];

--- a/dell/xps/15-9500/nvidia/default.nix
+++ b/dell/xps/15-9500/nvidia/default.nix
@@ -2,7 +2,7 @@
 {
   imports = [
     ../default.nix
-    ../../../../common/gpu/nvidia.nix
+    ../../../../common/gpu/nvidia/prime.nix
   ];
 
   hardware.nvidia.prime = {

--- a/dell/xps/15-9550/default.nix
+++ b/dell/xps/15-9550/default.nix
@@ -5,7 +5,7 @@
     ../../../common/cpu/intel
     ../../../common/pc/laptop
     # To just use Intel integrated graphics with Intel's open source driver
-    # ../../../common/gpu/nvidia-disable
+    # ../../../common/gpu/nvidia/disable.nix
   ];
 
   # TODO: boot loader

--- a/dell/xps/15-9550/nvidia/default.nix
+++ b/dell/xps/15-9550/nvidia/default.nix
@@ -2,7 +2,7 @@
 {
   imports = [
     ../default.nix
-    ../../../../common/gpu/nvidia.nix
+    ../../../../common/gpu/nvidia/prime.nix
   ];
 
   hardware.nvidia.prime = {

--- a/dell/xps/15-9560/intel/default.nix
+++ b/dell/xps/15-9560/intel/default.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../../../common/cpu/intel
     ../../../../common/pc/laptop
-    ../../../../common/gpu/nvidia-disable.nix
+    ../../../../common/gpu/nvidia/disable.nix
     ../xps-common.nix
   ];
 }

--- a/dell/xps/15-9560/nvidia/default.nix
+++ b/dell/xps/15-9560/nvidia/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../../common/cpu/intel
-    ../../../../common/gpu/nvidia.nix
+    ../../../../common/gpu/nvidia/prime.nix
     ../../../../common/pc/laptop
     ../xps-common.nix
   ];

--- a/dell/xps/17-9700/intel/default.nix
+++ b/dell/xps/17-9700/intel/default.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../../../common/cpu/intel
     ../../../../common/pc/laptop
-    ../../../../common/gpu/nvidia-disable.nix
+    ../../../../common/gpu/nvidia/disable.nix
     ../common.nix
   ];
 }

--- a/dell/xps/17-9700/nvidia/default.nix
+++ b/dell/xps/17-9700/nvidia/default.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../../../common/cpu/intel
     ../../../../common/pc/laptop
-    ../../../../common/gpu/nvidia.nix
+    ../../../../common/gpu/nvidia/prime.nix
     ../common.nix
   ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -157,8 +157,9 @@
       common-gpu-amd-sea-islands = import ./common/gpu/amd/sea-islands;
       common-gpu-amd-southern-islands = import ./common/gpu/amd/southern-islands;
       common-gpu-intel = import ./common/gpu/intel.nix;
-      common-gpu-nvidia = import ./common/gpu/nvidia.nix;
-      common-gpu-nvidia-disable = import ./common/gpu/nvidia-disable.nix;
+      common-gpu-nvidia = import ./common/gpu/nvidia/prime.nix;
+      common-gpu-nvidia-nonprime = import ./common/gpu/nvidia;
+      common-gpu-nvidia-disable = import ./common/gpu/nvidia/disable.nix;
       common-pc = import ./common/pc;
       common-pc-hdd = import ./common/pc/hdd;
       common-pc-laptop = import ./common/pc/laptop;

--- a/lenovo/ideapad/15arh05/default.nix
+++ b/lenovo/ideapad/15arh05/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../common/cpu/amd
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/laptop/ssd

--- a/lenovo/legion/15ach6/default.nix
+++ b/lenovo/legion/15ach6/default.nix
@@ -4,7 +4,7 @@ in {
   imports = [
     ../../../common/cpu/amd
     ../../../common/gpu/amd
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];

--- a/lenovo/legion/15arh05h/default.nix
+++ b/lenovo/legion/15arh05h/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../common/cpu/amd
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];

--- a/lenovo/legion/16ithg6/default.nix
+++ b/lenovo/legion/16ithg6/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../../common/cpu/intel
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];

--- a/lenovo/thinkpad/e470/default.nix
+++ b/lenovo/thinkpad/e470/default.nix
@@ -4,7 +4,7 @@
   imports = [
     ../.
     ../../../common/cpu/intel/kaby-lake
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
   ];
 
   hardware.nvidia.prime = {

--- a/lenovo/thinkpad/p1/default.nix
+++ b/lenovo/thinkpad/p1/default.nix
@@ -3,7 +3,7 @@
     ../../../common/cpu/intel
     # might need nvidia module but we don't know the PCI ids:
     # https://github.com/NixOS/nixos-hardware/pull/274#discussion_r650483740
-    #../../../common/gpu/nvidia.nix
+    #../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/laptop/ssd
   ];

--- a/lenovo/thinkpad/p50/default.nix
+++ b/lenovo/thinkpad/p50/default.nix
@@ -1,6 +1,6 @@
 { lib, config, ... }: {
   imports = [
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/cpu/intel
     ../../../common/pc/laptop/acpi_call.nix
     ../.

--- a/lenovo/thinkpad/p51/default.nix
+++ b/lenovo/thinkpad/p51/default.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }: {
   imports = [
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/cpu/intel
     ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop/acpi_call.nix

--- a/lenovo/thinkpad/p52/default.nix
+++ b/lenovo/thinkpad/p52/default.nix
@@ -1,6 +1,6 @@
 { lib, config, ... }: {
   imports = [
-    ../../../common/gpu/nvidia.nix
+    ../../../common/gpu/nvidia/prime.nix
     ../../../common/cpu/intel
     ../../../common/pc/laptop/acpi_call.nix
     ../.

--- a/msi/gl62/default.nix
+++ b/msi/gl62/default.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../common/pc/laptop/ssd
     ../../common/cpu/intel
-    ../../common/gpu/nvidia.nix
+    ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop
   ];
 

--- a/omen/en00015p/default.nix
+++ b/omen/en00015p/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../../common/cpu/amd
-    ../../common/gpu/nvidia.nix
+    ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop
     ../../common/pc/ssd
   ];


### PR DESCRIPTION
###### Description of changes

Fixes #338

Annoyingly, the flake module can't be deprecated cleanly. Suggestions welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Note I can't properly test changes that involve prime/disable, so I'd appreciate confirmation that that works, as simple as this change looks. Also can't test the module changes, of course.

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

