### PR TITLE
Add Ethernet Support on Framework

### DIFF
--- a/framework/12th-gen-intel/default.nix
+++ b/framework/12th-gen-intel/default.nix
@@ -34,10 +34,13 @@
   # For fingerprint support
   services.fprintd.enable = lib.mkDefault true;
 
-  # Fix headphone noise when on powersave
-  # https://community.frame.work/t/headphone-jack-intermittent-noise/5246/55
+  # Custom udev rules
   services.udev.extraRules = ''
+    # Fix headphone noise when on powersave
+    # https://community.frame.work/t/headphone-jack-intermittent-noise/5246/55
     SUBSYSTEM=="pci", ATTR{vendor}=="0x8086", ATTR{device}=="0xa0e0", ATTR{power/control}="on"
+    # Ethernet expansion card support
+    ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0bda", ATTR{idProduct}=="8156", ATTR{power/autosuspend}="20"
   '';
 
   # Mis-detected by nixos-generate-config

--- a/framework/default.nix
+++ b/framework/default.nix
@@ -27,10 +27,13 @@
   # For fingerprint support
   services.fprintd.enable = lib.mkDefault true;
 
-  # Fix headphone noise when on powersave
-  # https://community.frame.work/t/headphone-jack-intermittent-noise/5246/55
+  # Custom udev rules
   services.udev.extraRules = ''
+    # Fix headphone noise when on powersave
+    # https://community.frame.work/t/headphone-jack-intermittent-noise/5246/55
     SUBSYSTEM=="pci", ATTR{vendor}=="0x8086", ATTR{device}=="0xa0e0", ATTR{power/control}="on"
+    # Ethernet expansion card support
+    ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0bda", ATTR{idProduct}=="8156", ATTR{power/autosuspend}="20"
   '';
 
   # Mis-detected by nixos-generate-config


### PR DESCRIPTION
###### Description of changes

Add Ethernet Expansion Card support for the framework laptop. Due to automatic USB device suspension, the Ethernet Expansion Card was not working. Adding a udev rule to only suspend the card after 20 seconds fixes the problem. 
The framework support confirmed via email that all current Ethernet Expansion Cards share the same Product ID.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

