### PR TITLE
Add Lenovo Legion 5 Pro Gen 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See code for all available configurations.
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                          | `<nixos-hardware/lenovo/ideapad/z510>`             |
 | [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                  | `<nixos-hardware/lenovo/legion/15arh05h>`          |
 | [Lenovo Legion 7 Slim 15ach6](lenovo/legion/15ach6)                 | `<nixos-hardware/lenovo/legion/15ach6>`            |
+| [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                | `<nixos-hardware/lenovo/legion/16ach6h>`           |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                | `<nixos-hardware/lenovo/thinkpad/e14/amd>`         |
 | [Lenovo ThinkPad E14 (Intel)](lenovo/thinkpad/e14/intel)            | `<nixos-hardware/lenovo/thinkpad/e14/intel>`       |
 | [Lenovo ThinkPad E470](lenovo/thinkpad/e470)                        | `<nixos-hardware/lenovo/thinkpad/e470>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;
       lenovo-legion-15ach6 = import ./lenovo/legion/15ach6;
       lenovo-legion-15arh05h = import ./lenovo/legion/15arh05h;
+      lenovo-legion-16ach6h = import ./lenovo/legion/16ach6h;
       lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
       lenovo-thinkpad = import ./lenovo/thinkpad;
       lenovo-thinkpad-e14-amd = import ./lenovo/thinkpad/e14/amd;

--- a/lenovo/legion/16ach6h/README.md
+++ b/lenovo/legion/16ach6h/README.md
@@ -1,0 +1,19 @@
+## Setup at the time of testing
+```
+$ nix-info -m
+ - system: `"x86_64-linux"`
+ - host os: `Linux 6.0.9, NixOS, 22.11 (Raccoon), 22.11beta19.c9538a9b707`
+ - multi-user?: `yes`
+ - sandbox: `yes`
+ - version: `nix-env (Nix) 2.11.0`
+ - channels(root): `"nixos-22.11"`
+ - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixos`
+ ```
+ ```
+ $ lspci
+...
+01:00.0 VGA compatible controller: NVIDIA Corporation GA104M [GeForce RTX 3070 Mobile / Max-Q] (rev a1)
+...
+06:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Cezanne (rev c5)
+...
+```

--- a/lenovo/legion/16ach6h/default.nix
+++ b/lenovo/legion/16ach6h/default.nix
@@ -1,0 +1,18 @@
+{ lib, config, ... }:
+let kernelPackages = config.boot.kernelPackages;
+in {
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/gpu/amd
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  hardware.nvidia.prime = {
+    amdgpuBusId = "PCI:6:0:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+
+  services.thermald.enable = lib.mkDefault true;
+}

--- a/lenovo/legion/16ach6h/default.nix
+++ b/lenovo/legion/16ach6h/default.nix
@@ -1,6 +1,6 @@
-{ lib, config, ... }:
-let kernelPackages = config.boot.kernelPackages;
-in {
+{ lib, ... }:
+
+{
   imports = [
     ../../../common/cpu/amd
     ../../../common/gpu/amd


### PR DESCRIPTION
###### Description of changes

Adds suport for the Legion 5 Pro 16ACH6H. AMD CPU+GPU files are due to the iGPU, is it correct to use them both?

Makes my Laptop boot with the propietary drivers which is already an advancement from where I was before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

There's a strange quirk with how its currently set up, for the NVIDIA part, the `mkDefault` in 
https://github.com/NixOS/nixos-hardware/blob/0099253ad0b5283f06ffe31cf010af3f9ad7837d/common/gpu/nvidia/default.nix#L4

Makes tools like `nvidia-smi` and co. dissapear from the shell's path. Removing it brings them back.