### PR TITLE
Add support for GA402

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See code for all available configurations.
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                    | `<nixos-hardware/apple/macbook-pro/14-1>`          |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                      | `<nixos-hardware/asus/rog-strix/g733qs>`           |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                  | `<nixos-hardware/asus/zephyrus/ga401>`             |
+| [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                  | `<nixos-hardware/asus/zephyrus/ga402>`             |
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                  | `<nixos-hardware/asus/zephyrus/ga503>`             |
 | [Asus TUF FX504GD](asus/fx504gd)                                    | `<nixos-hardware/asus/fx504gd>`                    |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                | `<nixos-hardware/beagleboard/pocketbeagle>`        |

--- a/asus/zephyrus/ga402/default.nix
+++ b/asus/zephyrus/ga402/default.nix
@@ -1,0 +1,20 @@
+{ ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/laptop/ssd
+  ];
+
+  services = {
+    asusd.enable = true;
+  };
+
+  boot = {
+    kernelParams = [ "pcie_aspm.policy=powersupersave" "acpi.prefer_microsoft_dsm_guid=1" ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       asus-fx504gd = import ./asus/fx504gd;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;
+      asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
       dell-e7240 = import ./dell/e7240;


### PR DESCRIPTION
###### Description of changes

This PR add the support for the ASUS Zephyrus G14 402 models.
This hardware  needs the asusd package that shall be merged from https://github.com/NixOS/nixpkgs/pull/201081.

@K900 as requested I tag you here for review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

