### PR TITLE
Add a option to add(or disadd) amdgpu to kernelModule

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -1,23 +1,35 @@
 { config, lib, pkgs, ... }:
 
 {
-  boot.initrd.kernelModules = [ "amdgpu" ];
-  services.xserver.videoDrivers = [ "amdgpu" ];
-  
-  hardware.opengl.extraPackages = with pkgs; [
-    rocm-opencl-icd
-    rocm-opencl-runtime
-    amdvlk
-  ];
-
-  hardware.opengl.extraPackages32 = with pkgs; [
-    driversi686Linux.amdvlk
-  ];
-
-  hardware.opengl = {
-    driSupport = lib.mkDefault true;
-    driSupport32Bit = lib.mkDefault true;
+  options.hardware.amdgpu.loadInInitrd = lib.mkEnableOption (lib.mdDoc 
+    "loading `amdgpu` kernelModule at stage 1. (Add `amdgpu` to `boot.initrd.kernelModules`)"
+  ) // {
+    default = true;
   };
 
-  environment.variables.AMD_VULKAN_ICD = lib.mkDefault "RADV";
+  config = lib.mkMerge [
+    {
+      services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" ];
+  
+      hardware.opengl.extraPackages = with pkgs; [
+        rocm-opencl-icd
+        rocm-opencl-runtime
+        amdvlk
+      ];
+
+      hardware.opengl.extraPackages32 = with pkgs; [
+        driversi686Linux.amdvlk
+      ];
+
+      hardware.opengl = {
+        driSupport = lib.mkDefault true;
+        driSupport32Bit = lib.mkDefault true;
+      };
+
+      environment.variables.AMD_VULKAN_ICD = lib.mkDefault "RADV";
+    }
+    (lib.mkIf config.hardware.amdgpu.loadInInitrd {
+      boot.initrd.kernelModules = [ "amdgpu" ];
+    })
+  ];
 } 


### PR DESCRIPTION
### Add a option to add(or disadd) `amdgpu` to `boot.initrd.kernelModule`
I'm working for make a usable profile for `Lenovo Legion 5 Pro 16ach6h`(The existing version in the repository has a lot of problems, I try to fix it) and I have a problem

This appears to be a Lenovo firmware issue and i try to fix it. This issue still reproducible on BIOS version `GKCN58WW`(22/12/16)
Lenovo Legion 5 Pro is a laptop which support a technology called "DDG" that can allow you switch between discrete graphics mode and hybrid mode (optiums).
In discrete graphics mode, the firmware provides the correct edid and anything works fine, the built-in display work well at 165hz.
But if switch to hybrid mode, the firmware provides a different edid, causing the built-in display only can work at 60hz.
So I extracted the edid file of discrete graphics mode and override the edid that built-in display provide to solve this problem.

**But when i try to override edid use `drm.edid_firmware`, something went wrong**
If i add `amdgpu` to `boot.initrd.kernelModule`, It `drm.edid_firmware` not works. I checked the logs and found
`[drm:drm_load_edid_firmware [drm]] *ERROR* Requesting EDID firmware "edid/edid.bin" failed (err=-2)`
It looks like drm doesn't find the edid file, so I suspect the problem is due to the initrd
So i search on github, and found that the specified file can be packaged into initrd [in this way](https://github.com/zendo/nsworld/blob/e5593711d6296de54a9e5335bbe0c33d8589676a/hosts/yoga/edid.nix#L22)
I did, but I got worse. `amdgpu` kernelModule directly crashed, But nvidia dgpu still works fine. External monitors still work. I check logs again and I found
`04:07:27 systemd-udevd: could not read from '/sys/module/amd64_edac/initstate': No such device`
`04:07:26 kernel: `
`04:07:26 kernel: plymouth-quit.service: Service has no ExecStart=, ExecStop=, or SuccessAction=. Refusing.`
`04:07:26 kernel: amdgpu 0000:06:00.0: amdgpu: Fatal error during GPU init`
`04:07:26 kernel: amdgpu 0000:06:00.0: amdgpu: Fatal error during GPU init`
`04:07:26 kernel: amdgpu 0000:06:00.0: amdgpu: amdgpu_device_ip_init failed`
`04:07:26 kernel: [drm:amdgpu_device_init.cold [amdgpu]] *ERROR* sw_init of IP block <psp> failed -2`
`04:07:26 kernel: [drm:psp_sw_init [amdgpu]] *ERROR* Failed to load psp firmware!`
`04:07:26 kernel: amdgpu 0000:06:00.0: amdgpu: fail to initialize asd microcode`
`04:07:26 kernel: [drm:sdma_v4_0_early_init [amdgpu]] *ERROR* Failed to load sdma firmware!`
It seems that drm or amdgpu has some problem while loading
But if remove amdgpu in boot.initrd.kernelModule (load amdgpu module in stage 2), Everything work fine.
So I think I need someway to remove `amdgpu` in `boot.initrd.kernelModule`
Because Nix is lazy evaluation, there is no way to remove a single element from a list.
So I think we can make an option to decide whether to add it to kernelModule and wrote this pr.
I'm not sure where I should put this option because I can't find any similar situation for reference
Currently I put it in `hardware.amdgpu.loadAtStage1`
And, if there are other ways to solve the above problems, please let me know, thank you


###### Description of changes
Add a option to add(or disadd) amdgpu to kernelModule

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

