### PR TITLE
Add lib.mkDefault in services.xserver.videoDrivers = [ "amdgpu" ];

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -2,7 +2,7 @@
 
 {
   boot.initrd.kernelModules = [ "amdgpu" ];
-  services.xserver.videoDrivers = [ "amdgpu" ];
+  services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" ];
   
   hardware.opengl.extraPackages = with pkgs; [
     rocm-opencl-icd


### PR DESCRIPTION
I get a very weird problem
There is such a line of code in `common/gpu/nvidia/default.nix`
`services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];`
But in `common/gpu/amd/default.nix` which serves a similar purpose. It is
` services.xserver.videoDrivers = [ "amdgpu" ];`
This means that if you use prime, that is, if you import these two files at the same time, `services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];` will override `services.xserver.videoDrivers = [ "amdgpu" ];`.
Since the parameters provided to mkOverride are not the same, the smaller one is overwritten. So we need to keep them in sync
This issue should cause problems with all configurations using hybrid graphics, as the nvidia proprietary drivers won't be installed, but it doesn't seem to cause the system to completely crash, as nouveau will be automatically installed instead.
I checked the commit record, but it seems that the earliest commit on both sides is like this. It seems to be a very serious and very common problem but no one seems to be trying to fix it. I don’t know if there is any other purpose, but it makes `common/gpu/nvidia/prime.nix` completely useless.


###### Description of changes
Add lib.mkDefault in services.xserver.videoDrivers = [ "amdgpu" ];

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

