### PR TITLE
cpu/amd/pstate: enable correctly on kernel 6.1+

### DIFF
--- a/common/cpu/amd/pstate.nix
+++ b/common/cpu/amd/pstate.nix
@@ -1,10 +1,22 @@
-{ lib, config, ... }: {
+{ lib, config, ... }: 
+let
+   kver = config.boot.kernelPackages.kernel.version;
+in
+{
   # Enables the amd cpu scaling https://www.kernel.org/doc/html/latest/admin-guide/pm/amd-pstate.html
   # On recent AMD CPUs this can be more energy efficient.
 
   imports = [ ./. ];
-  boot = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "5.17") {
-    kernelParams = [ "initcall_blacklist=acpi_cpufreq_init" ];
-    kernelModules = [ "amd-pstate" ];
-  };
+  boot = lib.mkMerge [
+    (lib.mkIf (
+      (lib.versionAtLeast kver "5.17")
+      && (lib.versionOlder kver "6.1")
+    ) {
+      kernelParams = [ "initcall_blacklist=acpi_cpufreq_init" ];
+      kernelModules = [ "amd-pstate" ];
+    })
+    (lib.mkIf (lib.versionAtLeast kver "6.1") {
+      kernelParams = [ "amd_pstate=passive" ];  
+    })
+  ];
 }


### PR DESCRIPTION
###### Description of changes

There is no separate module now, and a clean option to enable it.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

