### PR TITLE
raspberry-pi/4: dtmerge update

### DIFF
--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -1,5 +1,5 @@
 # modification of nixpkgs deviceTree.applyOverlays to resolve https://github.com/NixOS/nixpkgs/issues/125354
-# https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/device-tree/default.nix
+# derived from https://github.com/NixOS/nixpkgs/blob/916ca8f2b0c208def051f8ea9760c534a40309db/pkgs/os-specific/linux/device-tree/default.nix
 { lib, pkgs, stdenvNoCC, dtc, libraspberrypi }:
 
 with lib; (base: overlays': stdenvNoCC.mkDerivation {
@@ -9,22 +9,42 @@ with lib; (base: overlays': stdenvNoCC.mkDerivation {
     overlays = toList overlays';
   in ''
     mkdir -p $out
-    cd ${base}
+    cd "${base}"
     find . -type f -name '*.dtb' -print0 \
-      | xargs -0 cp -v --no-preserve=mode --target-directory $out --parents
-    for dtb in $(find $out -type f -name '*.dtb'); do
-      dtbCompat="$( fdtget -t s $dtb / compatible )"
+      | xargs -0 cp -v --no-preserve=mode --target-directory "$out" --parents
+
+    for dtb in $(find "$out" -type f -name '*.dtb'); do
+      dtbCompat=$(fdtget -t s "$dtb" / compatible 2>/dev/null || true)
+      # skip files without `compatible` string
+      test -z "$dtbCompat" && continue
+
       ${flip (concatMapStringsSep "\n") overlays (o: ''
-      overlayCompat="$( fdtget -t s ${o.dtboFile} / compatible )"
-      # overlayCompat in dtbCompat
-      if [[ "$dtbCompat" =~ "$overlayCompat" ]]; then
-        echo "Applying overlay ${o.name} to $( basename $dtb )"
-        mv $dtb{,.in}
-        cp ${o.dtboFile}{,.dtbo}
-        dtmerge "$dtb.in" "$dtb" ${o.dtboFile}.dtbo;
-        rm $dtb.in ${o.dtboFile}.dtbo
+      overlayCompat="$(fdtget -t s "${o.dtboFile}" / compatible)"
+
+      # skip incompatible and non-matching overlays
+      if [[ ! "$dtbCompat" =~ "$overlayCompat" ]]; then
+        echo "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
+        continue
       fi
+      ${optionalString ((o.filter or null) != null) ''
+      if [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]; then
+        echo "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
+        continue
+      fi
+      ''}
+
+      echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
+      mv "$dtb"{,.in}
+
+      # dtmerge requires a .dtbo ext for dtbo files, otherwise it adds it to the given file implicitly
+      dtboWithExt="$TMPDIR/$(basename "${o.dtboFile}").dtbo"
+      cp -r ${o.dtboFile} "$dtboWithExt"
+
+      dtmerge "$dtb.in" "$dtb" "$dtboWithExt"
+
+      echo "ok"
+      rm "$dtb.in" "$dtboWithExt"
       '')}
-    done
-  '';
+
+    done'';
 })


### PR DESCRIPTION
###### Description of changes

Fixes the issue reported in https://github.com/NixOS/nixos-hardware/issues/503 and updates the apply-overlays-dtmerge overlay with the nixpkgs changes made in https://github.com/NixOS/nixpkgs/commit/916ca8f2b0c208def051f8ea9760c534a40309db

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

