### PR TITLE
Latitude 7430: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See code for all available configurations.
 | [Dell Latitude 3340](dell/latitude/3340)                            | `<nixos-hardware/dell/latitude/3340>`              |
 | [Dell Latitude 3480](dell/latitude/3480)                            | `<nixos-hardware/dell/latitude/3480>`              |
 | [Dell Latitude 5520](dell/latitude/5520)                            | `<nixos-hardware/dell/latitude/5520>`              |
+| [Dell Latitude 7430](dell/latitude/7430)                            | `<nixos-hardware/dell/latitude/7430>`              |
 | [Dell Latitude 7490](dell/latitude/7490)                            | `<nixos-hardware/dell/latitude/7490>`              |
 | [Dell Poweredge R7515](dell/poweredge/r7515)                        | `<nixos-hardware/dell/poweredge/r7515>`            |
 | [Dell Precision 5530](dell/precision/5530)                          | `<nixos-hardware/dell/precision/5530>`             |

--- a/dell/latitude/7430/default.nix
+++ b/dell/latitude/7430/default.nix
@@ -1,0 +1,21 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  boot.kernelParams = [ 
+    # needed for Intel Iris Xe
+    "i915.force_probe=46a8"
+    "i915.enable_guc=3"
+    "i915.fastboot=1"
+    # needed for keyboard
+    "i8042.dumbkbd=1" 
+    "i8042.nopnp=1" 
+  ];
+
+  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
       dell-latitude-3340 = import ./dell/latitude/3340;
       dell-latitude-3480 = import ./dell/latitude/3480;
       dell-latitude-5520 = import ./dell/latitude/5520;
+      dell-latitude-7430 = import ./dell/latitude/7430;
       dell-latitude-7490 = import ./dell/latitude/7490;
       dell-poweredge-r7515 = import ./dell/poweredge/r7515;
       dell-precision-5530 = import ./dell/precision/5530;


### PR DESCRIPTION
###### Description of changes
Added configuration for the Dell Latitude 7430 laptop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

