### PR TITLE
Update lenovo/thinkpad/p16s/amd/gen1

### DIFF
--- a/lenovo/thinkpad/p16s/amd/gen1/default.nix
+++ b/lenovo/thinkpad/p16s/amd/gen1/default.nix
@@ -1,6 +1,13 @@
 { config, lib, pkgs, ... }:
 
 {
+
+  imports = [
+    ../../../../../common/cpu/amd
+    ../../../../../common/gpu/amd
+    ../../../../../common/pc/laptop/acpi_call.nix
+  ];
+
   # For mainline support of rtw89 wireless networking
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_6_1;
 }


### PR DESCRIPTION
###### Description of changes

- Use linux kernel 6.1
- Import CPU and GPU modules
- Import acpi_call

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

