### PR TITLE
Add LENOVO Yoga 6 13ALC6 82ND

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X280](lenovo/thinkpad/x280)                        | `<nixos-hardware/lenovo/thinkpad/x280>`            |
 | [Lenovo ThinkPad Z Series](lenovo/thinkpad/z)                       | `<nixos-hardware/lenovo/thinkpad/z>`               |
 | [Lenovo ThinkPad Z13](lenovo/thinkpad/z/z13)                        | `<nixos-hardware/lenovo/thinkpad/z/z13>`           |
+| [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                   | `<nixos-hardware/lenovo/yoga/6/13ALC6>`            |
 | [MSI GS60 2QE](msi/gs60)                                            | `<nixos-hardware/msi/gs60>`                        |
 | [MSI GL62/CX62](msi/gl62)                                           | `<nixos-hardware/msi/gl62>`                        |
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                  | `<nixos-hardware/microsoft/surface-pro/3>`         |

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,7 @@
       lenovo-thinkpad-x280 = import ./lenovo/thinkpad/x280;
       lenovo-thinkpad-z = import ./lenovo/thinkpad/z;
       lenovo-thinkpad-z13 = import ./lenovo/thinkpad/z/z13;
+      lenovo-yoga-6-13ALC6 = import ./lenovo/yoga/6/13ALC6;
       microsoft-surface = import ./microsoft/surface;
       microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
       msi-gs60 = import ./msi/gs60;

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -12,8 +12,7 @@
     libvdpau-va-gl
   ];
 
-  # Latest Kernel
-  boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+  boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") pkgs.linuxPackages_latest;
 
   # energy savings
   hardware.bluetooth.powerOnBoot = lib.mkDefault false;

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -12,6 +12,7 @@
     libvdpau-va-gl
   ];
 
+  # latest kernel needed to make wifi work
   boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
 
   # energy savings

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -1,36 +1,24 @@
 { lib, pkgs, ...  }:
 
 {
-  boot.initrd.kernelModules = [ 
-    "amdgpu"
-    "ideapad_laptop"
+  imports = [
+    ../../../thinkpad/yoga.nix
+    ../../../../common/gpu/amd/default.nix
   ];
-  services.xserver.videoDrivers = [ "amdgpu" ];
+
+  boot.initrd.kernelModules = [ "ideapad_laptop" ];
   hardware.opengl.extraPackages = with pkgs; [
-    rocm-opencl-icd
-    rocm-opencl-runtime
-    amdvlk
     vaapiVdpau
     libvdpau-va-gl
   ];
-  hardware.opengl.extraPackages32 = with pkgs; [
-    driversi686Linux.amdvlk
-  ];
-  hardware.opengl = {
-    driSupport = lib.mkDefault true;
-    driSupport32Bit = lib.mkDefault true;
-  };
-  environment.variables.AMD_VULKAN_ICD = lib.mkDefault "RADV";
 
   # Latest Kernel
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
+  # energy savings
   hardware.bluetooth.powerOnBoot = lib.mkDefault false;
   services.power-profiles-daemon.enable = false;
   services.tlp.enable = lib.mkDefault true;
-  # automatic screen orientation, only works in X11
-  hardware.sensor.iio.enable = true;
-  # energy savings
   boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
   powerManagement.enable = lib.mkDefault true;
   powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -1,0 +1,51 @@
+{ lib, pkgs, ...  }:
+
+{
+  boot.initrd.kernelModules = [ 
+    "amdgpu"
+    "ideapad_laptop"
+  ];
+  services.xserver.videoDrivers = [ "amdgpu" ];
+  hardware.opengl.extraPackages = with pkgs; [
+    rocm-opencl-icd
+    rocm-opencl-runtime
+    amdvlk
+    vaapiVdpau
+    libvdpau-va-gl
+  ];
+  hardware.opengl.extraPackages32 = with pkgs; [
+    driversi686Linux.amdvlk
+  ];
+  hardware.opengl = {
+    driSupport = lib.mkDefault true;
+    driSupport32Bit = lib.mkDefault true;
+  };
+  environment.variables.AMD_VULKAN_ICD = lib.mkDefault "RADV";
+
+  # Latest Kernel
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  hardware.bluetooth.powerOnBoot = lib.mkDefault false;
+  services.power-profiles-daemon.enable = false;
+  services.tlp.enable = lib.mkDefault true;
+  # automatic screen orientation, only works in X11
+  hardware.sensor.iio.enable = true;
+  # energy savings
+  boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
+  powerManagement.enable = lib.mkDefault true;
+  powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
+  services.tlp.settings = {
+    # CPU
+    CPU_SCALING_GOVERNOR_ON_BAT="ondemand";
+    CPU_SCALING_GOVERNOR_ON_AC="performance";
+    CPU_BOOST_ON_AC=1;
+    CPU_BOOST_ON_BAT=0;
+    # Stop charging battery at 60%, ideapad_laptop driver required
+    #STOP_CHARGE_THRESH_BAT0=1;
+    # Stop charging battery at 100%
+    STOP_CHARGE_THRESH_BAT0=0;
+    # GPU
+    RADEON_DPM_PERF_LEVEL_ON_AC="auto";
+    RADEON_DPM_PERF_LEVEL_ON_BAT="low";
+  };
+}

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -12,7 +12,7 @@
     libvdpau-va-gl
   ];
 
-  boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") pkgs.linuxPackages_latest;
+  boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
 
   # energy savings
   hardware.bluetooth.powerOnBoot = lib.mkDefault false;

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -16,6 +16,5 @@
   boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
 
   # energy savings
-  hardware.bluetooth.powerOnBoot = lib.mkDefault false;
   boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
 }

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -16,23 +16,5 @@
 
   # energy savings
   hardware.bluetooth.powerOnBoot = lib.mkDefault false;
-  services.power-profiles-daemon.enable = false;
-  services.tlp.enable = lib.mkDefault true;
   boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
-  powerManagement.enable = lib.mkDefault true;
-  powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
-  services.tlp.settings = {
-    # CPU
-    CPU_SCALING_GOVERNOR_ON_BAT="ondemand";
-    CPU_SCALING_GOVERNOR_ON_AC="performance";
-    CPU_BOOST_ON_AC=1;
-    CPU_BOOST_ON_BAT=0;
-    # Stop charging battery at 60%, ideapad_laptop driver required
-    #STOP_CHARGE_THRESH_BAT0=1;
-    # Stop charging battery at 100%
-    STOP_CHARGE_THRESH_BAT0=0;
-    # GPU
-    RADEON_DPM_PERF_LEVEL_ON_AC="auto";
-    RADEON_DPM_PERF_LEVEL_ON_BAT="low";
-  };
 }


### PR DESCRIPTION
~~**Don't merge it, It's done for me but CONTRIBUTING.md is not implemented yet**~~ Ready for Review

###### Description of changes
Add support for the LENOVO Yoga 6 13ALC6 82ND
 Ryzen 7 5700U

###### Things done
* Easy 10 hrs of battery
* Enable or disable charging limit by TLP config or manually, `echo 1 > /sys/bus/platform/drivers/ideapad_acpi/VPC2004:00/conservation_mode`
* Enable hardware video acceleration in Firefox
* Use latest kernel to make wifi and other things work

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

