### PR TITLE
Add configuration for panasonic let's note

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ See code for all available configurations.
 | [Microsoft Surface Range](microsoft/surface)                        | `<nixos-hardware/microsoft/surface>`               |
 | [Omen en00015p](omen/en00015p)                                      | `<nixos-hardware/omen/en00015p>`                   |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |
+| [Panasonic Let's Note CF-LX4 ](panasonic/letsnote/cf-lx4)
 | [PC Engines APU](pcengines/apu)                                     | `<nixos-hardware/pcengines/apu>`                   |
 | [PINE64 Pinebook Pro](pine64/pinebook-pro/)                         | `<nixos-hardware/pine64/pinebook-pro>`             |
 | [Purism Librem 13v3](purism/librem/13v3)                            | `<nixos-hardware/purism/librem/13v3>`              |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See code for all available configurations.
 | [Dell Poweredge R7515](dell/poweredge/r7515)                        | `<nixos-hardware/dell/poweredge/r7515>`            |
 | [Dell Precision 5530](dell/precision/5530)                          | `<nixos-hardware/dell/precision/5530>`             |
 | [Dell XPS 13 7390](dell/xps/13-7390)                                | `<nixos-hardware/dell/xps/13-7390>`                |
+| [Dell XPS 13 9300](dell/xps/13-9300)                                | `<nixos-hardware/dell/xps/13-9300>`                |
 | [Dell XPS 13 9310](dell/xps/13-9310)                                | `<nixos-hardware/dell/xps/13-9310>`                |
 | [Dell XPS 13 9343](dell/xps/13-9343)                                | `<nixos-hardware/dell/xps/13-9343>`                |
 | [Dell XPS 13 9350](dell/xps/13-9350)                                | `<nixos-hardware/dell/xps/13-9350>`                |

--- a/dell/xps/13-9300/README.wiki
+++ b/dell/xps/13-9300/README.wiki
@@ -1,0 +1,20 @@
+= Dell XPS 13 9300 =
+
+== Firmware upgrades ==
+
+Note that this device is supported by [https://fwupd.org/ fwupd].
+To perform firmware upgrades just activate the service
+
+<code>
+services.fwupd.enable = true;
+</code>
+
+Then use <code>fwupdmgr</code> to perform updates.
+
+== Battery drain when sleeping ==
+
+The laptop uses the S2 sleep mode by default instead of S3, which leads to
+draining a lot of battery during sleep.
+
+See https://wiki.archlinux.org/index.php/Dell_XPS_13_(9300)#Power_Management
+and https://bugzilla.kernel.org/show_bug.cgi?id=199689#c3 for reference

--- a/dell/xps/13-9300/default.nix
+++ b/dell/xps/13-9300/default.nix
@@ -10,6 +10,7 @@ in {
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/ssd
+    ../sleep-resume/i2c-designware
   ];
 
   # Force S3 sleep mode. See README.wiki for details.
@@ -26,4 +27,7 @@ in {
 
   # This will save you money and possibly your life!
   services.thermald.enable = mkDefault true;
+
+  # Reloads i2c-designware module after suspend
+  services.sleep-resume.i2c-designware.enable = mkDefault true;
 }

--- a/dell/xps/13-9300/default.nix
+++ b/dell/xps/13-9300/default.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib) mkDefault;
+
+in {
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/intel.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/ssd
+  ];
+
+  # Force S3 sleep mode. See README.wiki for details.
+  boot.kernelParams = [ "mem_sleep_default=deep" ];
+
+  # Touchpad goes over i2c, and the psmouse module interferes with it
+  boot.blacklistedKernelModules = [ "psmouse" ];
+
+  # Includes the Wi-Fi and Bluetooth firmware for the QCA6390.
+  hardware.enableRedistributableFirmware = mkDefault true;
+
+  # Allows for updating firmware via `fwupdmgr`.
+  services.fwupd.enable = mkDefault true;
+
+  # This will save you money and possibly your life!
+  services.thermald.enable = mkDefault true;
+}

--- a/dell/xps/sleep-resume/bluetooth/default.nix
+++ b/dell/xps/sleep-resume/bluetooth/default.nix
@@ -1,0 +1,40 @@
+{config, lib, pkgs, ...}:
+
+let
+  inherit (lib) mkIf mkOption types;
+
+  reloadBtusb = pkgs.writeShellApplication {
+    name = "reload-btusb.sh";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.kmod
+    ];
+    text = ''
+      # Reload Bluetooth after resuming from sleep.
+
+      # Wait up-to 0.5 second for the module to be unloaded:
+      # (It should never take this long)
+      modprobe -r --wait 500 btusb
+
+      # "btusb" sometimes seems to need a little bit of time to settle after unloading:
+      sleep 0.2
+      modprobe btusb
+    '';
+  };
+
+  cfg = config.services.sleep-resume.bluetooth;
+in {
+  options = {
+    services.sleep-resume.bluetooth = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Reload Bluetooth after resuming from sleep";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    powerManagement.resumeCommands = "${reloadBtusb}/bin/reload-btusb.sh";
+  };
+}

--- a/dell/xps/sleep-resume/i2c-designware/default.nix
+++ b/dell/xps/sleep-resume/i2c-designware/default.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf mkOption types;
+
+  reloadDesignware = pkgs.writeShellApplication {
+    name = "reload-i2c-designware.sh";
+    runtimeInputs = [ pkgs.kmod ];
+    text = ''
+      # Reload the i2c Designware driver after resuming from sleep.
+
+      # Wait up-to 0.5 second for each module to be unloaded:
+      # (It should never take this long)
+      modprobe -r --wait 500 i2c_designware_platform
+      modprobe -r --wait 500 i2c_designware_core
+      modprobe -r --wait 500 i2c_hid_acpi
+      modprobe -r --wait 500 i2c_hid
+
+      # Should reload the module dependencies automatically:
+      modprobe i2c_designware_platform
+    '';
+  };
+
+  cfg = config.services.sleep-resume.i2c-designware;
+in {
+  options = {
+    services.sleep-resume.i2c-designware = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Reload the i2c_designware driver after resuming from sleep.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    powerManagement.resumeCommands = "${reloadDesignware}/bin/reload-i2c-designware.sh";
+  };
+}
+
+
+

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
       dell-poweredge-r7515 = import ./dell/poweredge/r7515;
       dell-precision-5530 = import ./dell/precision/5530;
       dell-xps-13-7390 = import ./dell/xps/13-7390;
+      dell-xps-13-9300 = import ./dell/xps/13-9300;
       dell-xps-13-9310 = import ./dell/xps/13-9310;
       dell-xps-13-9343 = import ./dell/xps/13-9343;
       dell-xps-13-9350 = import ./dell/xps/13-9350;

--- a/panasonic/letsnote/cf-lx4/default.nix
+++ b/panasonic/letsnote/cf-lx4/default.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  # Force use of the intel_backlight driver for backlight control.
+  # This allows the backlight save/load systemd service to work.
+  boot.kernelParams = [ "acpi_backlight=video" ];
+}


### PR DESCRIPTION
fixed path to common directory

###### Description of changes

The OS defaults to set acpi_backlight to `vendor`, which doesn't make let'snote backlight to work.

Using this configuration, panasonic users can tweak brightness.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

