### PR TITLE
Add common-cpus amd-kvm and intel-kvm

### DIFF
--- a/common/cpu/amd/kvm.nix
+++ b/common/cpu/amd/kvm.nix
@@ -1,0 +1,4 @@
+{
+  imports = [ ./. ];
+  boot.kernelModules = [ "kvm-amd" ];
+}

--- a/common/cpu/intel/kvm.nix
+++ b/common/cpu/intel/kvm.nix
@@ -1,0 +1,4 @@
+{
+  imports = [ ./. ];
+  boot.kernelModules = [ "kvm-intel" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -156,8 +156,10 @@
       tuxedo-infinitybook-v4 = import ./tuxedo/infinitybook/v4;
 
       common-cpu-amd = import ./common/cpu/amd;
+      common-cpu-amd-kvm = import ./common/cpu/amd/kvm.nix;
       common-cpu-amd-pstate = import ./common/cpu/amd/pstate.nix;
       common-cpu-intel = import ./common/cpu/intel;
+      common-cpu-intel-kvm = import ./common/cpu/intel/kvm.nix;
       common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only.nix;
       common-cpu-intel-kaby-lake = import ./common/cpu/intel/kaby-lake;
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;


### PR DESCRIPTION
###### Description of changes

This PR adds support for two additional common-cpu variants: `common-cpu-amd-kvm` and `common-cpu-intel-kvm`.

I currently carry these in my personal NixOS flake though I assume others may also wish to enable the relevant `kvm` module for their CPU type in a convenient way. I'll admit that it's extremely trivial for someone to set this in their own configuration which may be why these `kvm` variants do not already exist, and it saves me 3 lines in my config.

###### Things done

- [:heavy_check_mark:] Tested the changes in your own NixOS Configuration
- [:heavy_check_mark:] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input