### PR TITLE
raspberry-pi/4/dtmerge: fix application of overlays

### DIFF
--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -24,26 +24,24 @@ with lib; (base: overlays': stdenvNoCC.mkDerivation {
       # skip incompatible and non-matching overlays
       if [[ ! "$dtbCompat" =~ "$overlayCompat" ]]; then
         echo "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
-        continue
-      fi
-      ${optionalString ((o.filter or null) != null) ''
-      if [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]; then
-        echo "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
-        continue
-      fi
+      elif ${if ((o.filter or null) == null) then "false" else ''
+        [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]
       ''}
+      then
+        echo "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
+      else
+        echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
+        mv "$dtb"{,.in}
 
-      echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
-      mv "$dtb"{,.in}
+        # dtmerge requires a .dtbo ext for dtbo files, otherwise it adds it to the given file implicitly
+        dtboWithExt="$TMPDIR/$(basename "${o.dtboFile}").dtbo"
+        cp -r ${o.dtboFile} "$dtboWithExt"
 
-      # dtmerge requires a .dtbo ext for dtbo files, otherwise it adds it to the given file implicitly
-      dtboWithExt="$TMPDIR/$(basename "${o.dtboFile}").dtbo"
-      cp -r ${o.dtboFile} "$dtboWithExt"
+        dtmerge "$dtb.in" "$dtb" "$dtboWithExt"
 
-      dtmerge "$dtb.in" "$dtb" "$dtboWithExt"
-
-      echo "ok"
-      rm "$dtb.in" "$dtboWithExt"
+        echo "ok"
+        rm "$dtb.in" "$dtboWithExt"
+      fi
       '')}
 
     done'';


### PR DESCRIPTION
###### Description of changes
Ported over from https://github.com/NixOS/nixpkgs/pull/205595

Previously whenever an overlay was found to be incompatible with a base device tree blob, the entire base dtb would be skipped in favor of processing the next one. This had the unfortunate effect where overlays would not fully be applied if any incompatibility was found. For example, this is an issue with build device trees specific for one flavor of raspberry pi if the overlay was not compatible _everywhere_.

The solution is to forego the `continue` keyword if an overlay is in compatible and instead use a compound conditional statement to skip incompatible overlays but continue trying to apply it to any remaining dtbs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

