### PR TITLE
Fix copy-paste typo: "CONFIG_" prefix in structuredExtraConfig patches

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.0.17/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.0.17/patches.nix
@@ -11,28 +11,28 @@
       #
       # Surface Aggregator Module
       #
-      CONFIG_SURFACE_AGGREGATOR = module;
-      CONFIG_SURFACE_AGGREGATOR_ERROR_INJECTION = no;
-      CONFIG_SURFACE_AGGREGATOR_BUS = yes;
-      CONFIG_SURFACE_AGGREGATOR_CDEV = module;
-      CONFIG_SURFACE_AGGREGATOR_HUB = module;
-      CONFIG_SURFACE_AGGREGATOR_REGISTRY = module;
-      CONFIG_SURFACE_AGGREGATOR_TABLET_SWITCH = module;
+      SURFACE_AGGREGATOR = module;
+      SURFACE_AGGREGATOR_ERROR_INJECTION = no;
+      SURFACE_AGGREGATOR_BUS = yes;
+      SURFACE_AGGREGATOR_CDEV = module;
+      SURFACE_AGGREGATOR_HUB = module;
+      SURFACE_AGGREGATOR_REGISTRY = module;
+      SURFACE_AGGREGATOR_TABLET_SWITCH = module;
 
-      CONFIG_SURFACE_ACPI_NOTIFY = module;
-      CONFIG_SURFACE_DTX = module;
-      CONFIG_SURFACE_PLATFORM_PROFILE = module;
+      SURFACE_ACPI_NOTIFY = module;
+      SURFACE_DTX = module;
+      SURFACE_PLATFORM_PROFILE = module;
 
-      CONFIG_SURFACE_HID = module;
-      CONFIG_SURFACE_KBD = module;
+      SURFACE_HID = module;
+      SURFACE_KBD = module;
 
-      CONFIG_BATTERY_SURFACE = module;
-      CONFIG_CHARGER_SURFACE = module;
+      BATTERY_SURFACE = module;
+      CHARGER_SURFACE = module;
 
       #
       # Surface Hotplug
       #
-      CONFIG_SURFACE_HOTPLUG = module;
+      SURFACE_HOTPLUG = module;
 
       #
       # IPTS touchscreen
@@ -40,39 +40,39 @@
       # This only enables the user interface for IPTS data.
       # For the touchscreen to work, you need to install iptsd.
       #
-      CONFIG_MISC_IPTS = module;
+      MISC_IPTS = module;
 
       #
       # Cameras: IPU3
       #
-      CONFIG_VIDEO_DW9719 = module;
-      CONFIG_VIDEO_IPU3_IMGU = module;
-      CONFIG_VIDEO_IPU3_CIO2 = module;
-      CONFIG_CIO2_BRIDGE = yes;
-      CONFIG_INTEL_SKL_INT3472 = module;
-      CONFIG_REGULATOR_TPS68470 = module;
-      CONFIG_COMMON_CLK_TPS68470 = module;
+      VIDEO_DW9719 = module;
+      VIDEO_IPU3_IMGU = module;
+      VIDEO_IPU3_CIO2 = module;
+      CIO2_BRIDGE = yes;
+      INTEL_SKL_INT3472 = module;
+      REGULATOR_TPS68470 = module;
+      COMMON_CLK_TPS68470 = module;
 
       #
       # Cameras: Sensor drivers
       #
-      CONFIG_VIDEO_OV5693 = module;
-      CONFIG_VIDEO_OV7251 = module;
-      CONFIG_VIDEO_OV8865 = module;
+      VIDEO_OV5693 = module;
+      VIDEO_OV7251 = module;
+      VIDEO_OV8865 = module;
 
       #
       # ALS Sensor for Surface Book 3, Surface Laptop 3, Surface Pro 7
       #
-      CONFIG_APDS9960 = module;
+      APDS9960 = module;
 
       #
       # Other Drivers
       #
-      CONFIG_INPUT_SOC_BUTTON_ARRAY = module;
-      CONFIG_SURFACE_3_POWER_OPREGION = module;
-      CONFIG_SURFACE_PRO3_BUTTON = module;
-      CONFIG_SURFACE_GPE = module;
-      CONFIG_SURFACE_BOOK1_DGPU_SWITCH = module;
+      INPUT_SOC_BUTTON_ARRAY = module;
+      SURFACE_3_POWER_OPREGION = module;
+      SURFACE_PRO3_BUTTON = module;
+      SURFACE_GPE = module;
+      SURFACE_BOOK1_DGPU_SWITCH = module;
     };
   }
   {


### PR DESCRIPTION

###### Description of changes

Fix copy-paste typo: "CONFIG_" prefix in structuredExtraConfig patches
- Unintentional typo, due to copy-paste from linux-surface upstream config


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

