### PR TITLE
lenovo/thinkpad/t440p: force load thinkpad_acpi

### DIFF
--- a/lenovo/thinkpad/t440p/default.nix
+++ b/lenovo/thinkpad/t440p/default.nix
@@ -7,7 +7,7 @@
   ];
 
   boot = {
-    extraModprobeConfig = lib.mkDefault ''
+    extraModprobeConfig = ''
       options bbswitch use_acpi_to_detect_card_state=1
       options thinkpad_acpi force_load=1 fan_control=1
     '';

--- a/lenovo/thinkpad/t440p/default.nix
+++ b/lenovo/thinkpad/t440p/default.nix
@@ -9,6 +9,7 @@
   boot = {
     extraModprobeConfig = lib.mkDefault ''
       options bbswitch use_acpi_to_detect_card_state=1
+      options thinkpad_acpi force_load=1 fan_control=1
     '';
     # TODO: probably enable tcsd? Is this line necessary?
     kernelModules = [ "tpm-rng" ];


### PR DESCRIPTION
thinkpad_acpi doesn't load automatically on corebooted Lenovo ThinkPads T440p (but works fine if force_loaded).

###### Description of changes

Changed `thinkpad_acpi` module options to `force_load=1 fan_control=1`. Doesn't affect users with stock firmware.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

