### PR TITLE
16ach6h: Add tags for Dual-Direct GFX (DDG) specialisation

### DIFF
--- a/lenovo/legion/16ach6h/default.nix
+++ b/lenovo/legion/16ach6h/default.nix
@@ -4,7 +4,8 @@
   imports = [ ./hybrid ];
 
   specialisation.ddg.configuration = {
-    # This specialisation is for the case where "DDG" (A hardware feature that can enable in bios) is enabled, since the amd igpu is blocked at hardware level and the built-in display is directly connected to the dgpu, we no longer need the amdgpu and prime configuration.
+    # This specialisation is for the case where "DDG" (Dual-Direct GFX, A hardware feature that can enable in bios) is enabled, since the amd igpu is blocked at hardware level and the built-in display is directly connected to the dgpu, we no longer need the amdgpu and prime configuration.
+    system.nixos.tags = [ "Dual-Direct-GFX-Mode" ];
     services.xserver.videoDrivers = [ "nvidia" ]; # This will override services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" "nvidia" ];
     hardware.nvidia.prime.offload.enable = false;
   };


### PR DESCRIPTION
###### Description of changes
16ach6h: Add `system.nixos.tags` for Dual-Direct GFX (DDG) specialisation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

