### PR TITLE
macbookpro 3,1: init

### DIFF
--- a/apple/macbook-pro/3-1/README.wiki
+++ b/apple/macbook-pro/3-1/README.wiki
@@ -1,0 +1,5 @@
+= Apple MacBook Pro 3,1 =
+
+This laptop is a weird one. It has an nVidia 8600M GT, which is supported in driver 340, which is (at the moment) marked as broken because OpenGL is broken with it. Nouveau doesn't work either, as it fails to pull the firmware from the GPU to turn it on.
+
+That said, the rest of it all just... works.

--- a/apple/macbook-pro/3-1/default.nix
+++ b/apple/macbook-pro/3-1/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ../.
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # TODO: Change this to make Nouveau work if anyone ever figures out why it's broken.
+  boot.kernelParams = [ "nomodeset" ];
+}


### PR DESCRIPTION
###### Description of changes
Added what's needed to make the MacBook Pro 3,1 17" that I have work. (If anyone happens to know how to make Nouveau agree with this device, I'd love to know.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

