### PR TITLE
Add Support for Lenovo Y530-15ICH

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ See code for all available configurations.
 | [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                | `<nixos-hardware/lenovo/legion/16ach6h>`           |
 | [Lenovo Legion 5 Pro 16ach6h (Hybrid)](lenovo/legion/16ach6h/hybrid)| `<nixos-hardware/lenovo/legion/16ach6h/hybrid>`    |
 | [Lenovo Legion 5 Pro 16ach6h (Nvidia)](lenovo/legion/16ach6h/nvidia)| `<nixos-hardware/lenovo/legion/16ach6h/nvidia>`    |
+| [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                     | `<nixos-hardware/lenovo/legion/15ich>`             |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                | `<nixos-hardware/lenovo/thinkpad/e14/amd>`         |
 | [Lenovo ThinkPad E14 (Intel)](lenovo/thinkpad/e14/intel)            | `<nixos-hardware/lenovo/thinkpad/e14/intel>`       |
 | [Lenovo ThinkPad E470](lenovo/thinkpad/e470)                        | `<nixos-hardware/lenovo/thinkpad/e470>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
       lenovo-legion-16ach6h-hybrid = import ./lenovo/legion/16ach6h/hybrid;
       lenovo-legion-16ach6h-nvidia = import ./lenovo/legion/16ach6h/nvidia;
       lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
+      lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;
       lenovo-thinkpad = import ./lenovo/thinkpad;
       lenovo-thinkpad-e14-amd = import ./lenovo/thinkpad/e14/amd;
       lenovo-thinkpad-e14-intel = import ./lenovo/thinkpad/e14/intel;

--- a/lenovo/legion/15ich/README.md
+++ b/lenovo/legion/15ich/README.md
@@ -1,0 +1,18 @@
+## Setup at the time of testing
+```
+$ nix-info -m
+ - system: `"x86_64-linux"`
+ - host os: `Linux 5.15.90, NixOS, 22.11 (Raccoon), 22.11.2058.ce20e9ebe19`
+ - multi-user?: `yes`
+ - sandbox: `yes`
+ - version: `nix-env (Nix) 2.11.1`
+ - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixos` 
+ ```
+ ```
+ $ lspci
+...
+00:02.0 VGA compatible controller: Intel Corporation CoffeeLake-H GT2 [UHD Graphics 630]
+...
+01:00.0 VGA compatible controller: NVIDIA Corporation GP107M [GeForce GTX 1050 Ti Mobile] (rev a1)
+...
+```

--- a/lenovo/legion/15ich/default.nix
+++ b/lenovo/legion/15ich/default.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+    ../../../common/pc/laptop/hdd
+  ];
+
+  hardware = {
+    nvidia = {
+      modesetting.enable = lib.mkDefault true;
+      powerManagement.enable = lib.mkDefault true;
+
+      prime = {
+        intelBusId = "PCI:0:2:0";
+        nvidiaBusId = "PCI:1:0:0";
+      };
+    };
+  };
+
+  services.thermald.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes

Adding hardware support for the Lenovo Legion Y530-15ICH. My specific configuration has the Core i7-8750H with a 4GB 1050Ti. 

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I have tested this by importing the nixos-hardware repo as a submodule of my configuration repo and updating files as required. I will be leaving this as draft until I am confident everything works as intended, though I see no current issues. 
