### PR TITLE
Add amdvlk and opencl options to amdgpu & Fix proton crash when Dual-Direct GFX enabled for lenovo legion 16ach6h

### DIFF
--- a/lenovo/legion/16ach6h/default.nix
+++ b/lenovo/legion/16ach6h/default.nix
@@ -7,6 +7,12 @@
     # This specialisation is for the case where "DDG" (Dual-Direct GFX, A hardware feature that can enable in bios) is enabled, since the amd igpu is blocked at hardware level and the built-in display is directly connected to the dgpu, we no longer need the amdgpu and prime configuration.
     system.nixos.tags = [ "Dual-Direct-GFX-Mode" ];
     services.xserver.videoDrivers = [ "nvidia" ]; # This will override services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" "nvidia" ];
-    hardware.nvidia.prime.offload.enable = false;
+    hardware = {
+      nvidia.prime.offload.enable = false;
+      amdgpu = {
+        amdvlk = false;
+        opencl = false;
+      };
+    };
   };
 }

--- a/lenovo/legion/16ach6h/nvidia/default.nix
+++ b/lenovo/legion/16ach6h/nvidia/default.nix
@@ -3,5 +3,11 @@
 {
   imports = [ ../hybrid ];
   services.xserver.videoDrivers = [ "nvidia" ]; # This will override services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" "nvidia" ];
-  hardware.nvidia.prime.offload.enable = false;
+  hardware = {
+    nvidia.prime.offload.enable = false;
+    amdgpu = {
+      amdvlk = false;
+      opencl = false;
+    };
+  };
 }

--- a/lenovo/legion/16ach6h/nvidia/default.nix
+++ b/lenovo/legion/16ach6h/nvidia/default.nix
@@ -3,6 +3,19 @@
 {
   imports = [ ../hybrid ];
   services.xserver.videoDrivers = [ "nvidia" ]; # This will override services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" "nvidia" ];
+  # When I play the game through proton, I found that in the case of Dual-Direct GFX
+  # enabled (dGPU disabled), proton will crash directly. But in the case of hybrid,
+  # the game runs fine with or without nvidia-offload After investigation, this is
+  # because when writing the specialization of Dual-Direct GFX, I did not completely
+  # remove all packages for amd igpu. I only removed amdgpu from
+  # services.xserver.videoDrivers by overriding. This is because the specialization
+  # of nix cannot implement such an operation as canceling an import. In the end, if
+  # it is enabled in Dual-Direct GFX In the absence of amd igpu, the amdvlk package
+  # caused the proton to crash. In order to solve this problem, I add the option of
+  # whether to enable amdvlk to the configuration file of amd gpu, and open it by
+  # default, and turn it off in specialization, so as to delete amdvlk package and
+  # other packages for amd igpu in specialization. At the same time, I also added an
+  # option to amdgpu's opencl runtime.
   hardware = {
     nvidia.prime.offload.enable = false;
     amdgpu = {


### PR DESCRIPTION
###### Description of changes
When I play the game through proton, I found that in the case of Dual-Direct GFX enabled (dGPU disabled), proton will crash directly
But in the case of hybrid, the game runs fine with or without `nvidia-offload`
After investigation, this is because when writing the specialization of Dual-Direct GFX, I did not completely remove all packages for amd igpu. I only removed `amdgpu` from `services.xserver.videoDrivers` by overriding. This is because the specialization of nix cannot implement such an operation as canceling an import. In the end, if it is enabled in Dual-Direct GFX In the absence of amd igpu, the `amdvlk` package caused the proton to crash.
In order to solve this problem, I add the option of whether to enable `amdvlk` to the configuration file of amd gpu, and open it by default, and turn it off in specialization, so as to delete `amdvlk` package and other packages for amd igpu in specialization.
At the same time, I also added an option to amdgpu's opencl runtime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

