### PR TITLE
Fix conflict to https://github.com/NixOS/nixpkgs/commit/2a7130d13a032093f5394ef0961842d1e1928789

### DIFF
--- a/asus/rog-strix/g733qs/default.nix
+++ b/asus/rog-strix/g733qs/default.nix
@@ -22,7 +22,6 @@
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.12") (lib.mkDefault pkgs.linuxPackages_latest);
 
   hardware.nvidia.prime = {
-    offload.enable = lib.mkDefault true;
     amdgpuBusId = "PCI:5:0:0";
     nvidiaBusId = "PCI:1:0:1";
   };

--- a/common/gpu/nvidia/prime.nix
+++ b/common/gpu/nvidia/prime.nix
@@ -16,7 +16,7 @@ in {
   environment.systemPackages = [ nvidia-offload ];
 
   hardware.nvidia.prime = {
-    offload.enable = lib.mkDefault true;
+    offload.enable = lib.mkOverride 990 true;
     # Hardware should specify the bus ID for intel/nvidia devices
   };
 }


### PR DESCRIPTION
###### Description of changes
nixpkgs was updated (https://github.com/NixOS/nixpkgs/commit/2a7130d13a032093f5394ef0961842d1e1928789#diff-28ea4da3a9a595f8bd1a37a555c229f998f3a11b0715ebc5842ba266384eba73R326) and the default value of hardware.nvidia.prime.offload.enable was set to mkDefault reverseSyncCfg.enable;
This conflicted with the value set in prime, so I tried using mkOverride 990 instead. (https://discourse.nixos.org/t/what-does-mkdefault-do-exactly/9028)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

