### PR TITLE
gpd/win-2: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ See code for all available configurations.
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
 | [GPD Pocket 3](gpd/pocket-3)                                        | `<nixos-hardware/gpd/pocket-3>`                    |
+| [GPD WIN 2](gpd/win-2)                                              | `<nixos-hardware/gpd/win-2>`                       |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                            | `<nixos-hardware/hp/elitebook/2560p>`              |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                               | `<nixos-hardware/intel/nuc/8i7beh>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;
       gpd-pocket-3 = import ./gpd/pocket-3;
+      gpd-win-2 = import ./gpd/win-2;
       hp-elitebook-2560p = import ./hp/elitebook/2560p;
       intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
       lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;

--- a/gpd/win-2/default.nix
+++ b/gpd/win-2/default.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ...}:
+{
+  imports = [
+    ../../common/cpu/intel
+    ../../common/pc/ssd
+    ];
+
+  boot.kernelParams = [
+    "fbcon=rotate:1"
+    "video=eDP-1:panel_orientation=right_side_up"
+  ];
+
+  services.tlp.enable = lib.mkDefault ((lib.versionOlder (lib.versions.majorMinor lib.version) "21.05")
+                                       || !config.services.power-profiles-daemon.enable);
+
+  # Required for grub to properly display the boot menu.
+  boot.loader.grub.gfxmodeEfi = lib.mkDefault "720x1280x32";
+
+}


### PR DESCRIPTION
###### Description of changes

Adds the bare minimums for running NixOS on a GPD WIN 2 without the system being all weird and the display being incorrectly rotated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

