### PR TITLE
Add NXP i.MX8 SOC family support.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,7 @@
       microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
+      nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
       omen-en00015p = import ./omen/en00015p;
       onenetbook-4 = import ./onenetbook/4;
       pcengines-apu = import ./pcengines/apu;

--- a/nxp/README.md
+++ b/nxp/README.md
@@ -1,0 +1,18 @@
+# NXP i.MX8 SOC family support
+
+## 1. Supported devices
+ - [i.MX8QuadMax Multisensory Enablement Kit](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadmax-multisensory-enablement-kit-mek:MCIMX8QM-CPU) (**imx8qm-mek**) - device-specific U-boot and Linux kernel, nixos configuration example.
+ - [i.MX8QuadXPlus Multisensory Enablement Kit](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadxplus-multisensory-enablement-kit-mek:MCIMX8QXP-CPU) (**imx8qxp-mek**) - device-specific U-Boot and Linux kernel.
+
+## 2. How to use
+Currently this NXP overlay is used for generating EFI-bootable NixOS images. [Tow-Boot](https://tow-boot.org/) is used as a bootloader in our case, but U-Boot can also be used.
+
+Code snippet example that enables imx8qm configuration:
+```
+{ nixos-hardware, }: {
+  system = "aarch64-linux";
+  modules = [
+    nixos-hardware.nixosModules.imx8qm-mek
+  ];
+}
+```

--- a/nxp/common/bsp/imx-atf.nix
+++ b/nxp/common/bsp/imx-atf.nix
@@ -1,0 +1,22 @@
+{
+  buildArmTrustedFirmware ,
+  targetBoard ,
+  fetchgit ,
+}:
+
+{
+  armTrustedFirmwareiMX8 = buildArmTrustedFirmware rec {
+    src = fetchgit {
+      url = "https://source.codeaurora.org/external/imx/imx-atf";
+      # tag: "lf_v2.6"
+      rev = "c6a19b1a351308cc73443283f6aa56b2eff791b8";
+      sha256 = "sha256-C046MrZBDFuzBdnjuPC2fAGtXzZjTWRrO8nYTf1rjeg=";
+    };
+    platform = targetBoard;
+    enableParallelBuilding = true;
+    # To build with tee.bin use extraMakeFlags = [ "bl31 SPD=opteed" ];
+    extraMakeFlags = [ "PIE_LDFLAGS=--no-warn-rwx-segments LDFLAGS=--no-warn-rwx-segments" "bl31" ];
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = ["build/${targetBoard}/release/bl31.bin"];
+  };
+}

--- a/nxp/common/bsp/imx-firmware.nix
+++ b/nxp/common/bsp/imx-firmware.nix
@@ -1,0 +1,68 @@
+{
+  pkgs ,
+  targetBoard,
+}:
+
+let
+
+  imxurl = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO";
+
+  fwHdmiVersion = "8.16";
+  fwScVersion = "1.13.0";
+  fwSecoVersion = "3.8.6";
+
+  firmwareHdmi = pkgs.fetchurl rec {
+    url = "${imxurl}/firmware-imx-${fwHdmiVersion}.bin";
+    sha256 = "Bun+uxE5z7zvxnlRwI0vjowKFqY4CgKyiGjbZuilER0=";
+    executable = true;
+  };
+
+  firmwareSc = pkgs.fetchurl rec {
+    url = "${imxurl}/imx-sc-firmware-${fwScVersion}.bin";
+    sha256 = "YUaBIVCeOOTvifhiEIbKgyGsLZYufv5rs2isdSrw4dc=";
+    executable = true;
+  };
+
+  firmwareSeco = pkgs.fetchurl rec {
+    url = "${imxurl}/imx-seco-${fwSecoVersion}.bin";
+    sha256 = "eoG19xn283fsP2jP49hD4dIBRwEQqFQ9k3yVWOM8uKQ=";
+    executable = true;
+  };
+
+in
+pkgs.stdenv.mkDerivation rec {
+
+  pname = "imx-firmware";
+  version = "5.15.X_1.0.0-Yocto";
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  sourceRoot = ".";
+
+  unpackPhase = ''
+    ${firmwareHdmi} --auto-accept --force
+    ${firmwareSc} --auto-accept --force
+    ${firmwareSeco} --auto-accept --force
+  '';
+
+  filesToInstall = [
+    "firmware-imx-${fwHdmiVersion}/firmware/hdmi/cadence/dpfw.bin"
+    "firmware-imx-${fwHdmiVersion}/firmware/hdmi/cadence/hdmi?xfw.bin"
+  ] ++ pkgs.lib.optional ( targetBoard == "imx8qm" )
+    ("imx-sc-firmware-${fwScVersion}/mx8qm-mek-scfw-tcm.bin" + " " +
+    "imx-seco-${fwSecoVersion}/firmware/seco/mx8qmb0-ahab-container.img")
+    ++ pkgs.lib.optional ( targetBoard == "imx8qxp" )
+    ("imx-sc-firmware-${fwScVersion}/mx8qx-mek-scfw-tcm.bin" + " " +
+    "imx-seco-${fwSecoVersion}/firmware/seco/mx8qxc0-ahab-container.img");
+
+  installPhase = ''
+    mkdir -p $out
+    cp ${pkgs.lib.concatStringsSep " " filesToInstall} $out
+  '';
+
+  meta = with pkgs.lib; {
+    license = licenses.unfree;
+  };
+}

--- a/nxp/common/bsp/imx-mkimage.nix
+++ b/nxp/common/bsp/imx-mkimage.nix
@@ -1,0 +1,31 @@
+{ pkgs }:
+
+with pkgs;
+pkgs.stdenv.mkDerivation rec {
+  pname = "imx-mkimage";
+  version = "lf-5.15.32-2.0.0";
+
+  src = fetchgit {
+    url = "https://source.codeaurora.org/external/imx/imx-mkimage.git";
+    rev = version;
+    sha256 = "sha256-31pib5DTDPVfiAAoOSzK8HWUlnuiNnfXQIsxbjneMCc=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [
+    git
+  ];
+
+  buildInputs = [
+    git
+    glibc.static
+  ];
+
+  makeFlags = [
+    "bin"
+  ];
+
+  installPhase = ''
+    install -m 0755 mkimage_imx8 $out
+  '';
+}

--- a/nxp/common/bsp/imx-optee-os.nix
+++ b/nxp/common/bsp/imx-optee-os.nix
@@ -1,0 +1,79 @@
+{
+  pkgs,
+}:
+
+let
+
+  pkgsCross = import <nixpkgs> {
+     crossSystem = {
+       config = "aarch64-unknown-linux-gnu";
+     };
+  };
+
+  outdir = "out/arm-plat-imx/core";
+  python3 = pkgs.buildPackages.python3;
+  toolchain = pkgsCross.gcc9Stdenv.cc;
+  binutils = pkgsCross.gcc9Stdenv.cc.bintools.bintools_bin;
+  cpp = pkgs.buildPackages.gcc;
+
+in
+pkgs.stdenv.mkDerivation rec {
+  
+  pname = "imx-optee-os";
+  version = "5.15.32_2.0.0";
+
+  buildInputs = [
+    python3
+  ];
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pycryptodomex
+    pyelftools
+    cryptography
+  ];
+
+  src = fetchGit {
+    url = "https://source.codeaurora.org/external/imx/imx-optee-os.git";
+    ref = "lf-5.15.32_2.0.0";
+  };
+
+  postPatch = ''
+    substituteInPlace scripts/arm32_sysreg.py \
+      --replace '/usr/bin/env python3' '${python3}/bin/python'
+    substituteInPlace scripts/gen_tee_bin.py \
+      --replace '/usr/bin/env python3' '${python3}/bin/python'
+    substituteInPlace scripts/pem_to_pub_c.py \
+      --replace '/usr/bin/env python3' '${python3}/bin/python'
+    substituteInPlace ta/pkcs11/scripts/verify-helpers.sh \
+      --replace '/bin/bash' '${pkgs.bash}/bin/bash'
+    substituteInPlace mk/gcc.mk \
+      --replace "\$(CROSS_COMPILE_\$(sm))objcopy" ${binutils}/bin/${toolchain.targetPrefix}objcopy
+    substituteInPlace mk/gcc.mk \
+      --replace "\$(CROSS_COMPILE_\$(sm))objdump" ${binutils}/bin/${toolchain.targetPrefix}objdump
+    substituteInPlace mk/gcc.mk \
+      --replace "\$(CROSS_COMPILE_\$(sm))nm" ${binutils}/bin/${toolchain.targetPrefix}nm
+    substituteInPlace mk/gcc.mk \
+      --replace "\$(CROSS_COMPILE_\$(sm))readelf" ${binutils}/bin/${toolchain.targetPrefix}readelf
+    substituteInPlace mk/gcc.mk \
+      --replace "\$(CROSS_COMPILE_\$(sm))ar" ${binutils}/bin/${toolchain.targetPrefix}ar
+    substituteInPlace mk/gcc.mk \
+      --replace "\$(CROSS_COMPILE_\$(sm))cpp" ${cpp}/bin/cpp
+  '';
+
+  makeFlags = [
+    "PLATFORM=imx"
+    "PLATFORM_FLAVOR=mx8qmmek"
+    "CFG_ARM64_core=y"
+    "CFG_TEE_TA_LOG_LEVEL=0"
+    "CFG_TEE_CORE_LOG_LEVEL=0"
+    "CROSS_COMPILE=${toolchain}/bin/${toolchain.targetPrefix}"
+    "CROSS_COMPILE64=${toolchain}/bin/${toolchain.targetPrefix}"
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp ${outdir}/tee-raw.bin $out/tee.bin
+  '';
+}

--- a/nxp/common/bsp/imx-uboot.nix
+++ b/nxp/common/bsp/imx-uboot.nix
@@ -1,0 +1,63 @@
+{ pkgs ,
+  targetBoard,
+}:
+
+with pkgs; let
+  inherit buildUBoot;
+
+  imx8qxp-attrs = {
+    atf = "imx8qx";
+    ahab = "mx8qxc0-ahab-container.img";
+    scfw = "mx8qx-mek-scfw-tcm.bin";
+    soc = "QX";
+    patches = [ ../patches/0001-Add-UEFI-boot-for-imx8qxp.patch ];
+  };
+
+  imx8qm-attrs = {
+    atf = "imx8qm";
+    ahab = "mx8qmb0-ahab-container.img";
+    scfw = "mx8qm-mek-scfw-tcm.bin";
+    soc = "QM";
+    patches = [ ../patches/0001-Add-UEFI-boot-on-imx8qm_mek.patch ];
+  };
+
+  imx8-attrs = if (targetBoard == "imx8qxp") then imx8qxp-attrs
+          else if (targetBoard == "imx8qm")  then imx8qm-attrs
+          else {};
+
+  inherit (callPackage ./imx-atf.nix { inherit buildArmTrustedFirmware; targetBoard = imx8-attrs.atf; }) armTrustedFirmwareiMX8;
+  imx-firmware = callPackage ./imx-firmware.nix { inherit pkgs targetBoard; };
+  imx-mkimage = buildPackages.callPackage ./imx-mkimage.nix { inherit pkgs; };
+in {
+  ubootImx8 = buildUBoot {
+    version = "2022.04";
+    src = fetchgit {
+      url = "https://source.codeaurora.org/external/imx/uboot-imx.git";
+      # tag: "lf_v2022.04"
+      rev = "1c881f4da83cc05bee50f352fa183263d7e2622b";
+      sha256 = "sha256-0TS6VH6wq6PwZUq6ekbuLaisZ9LrE0/haU9nseGdiE0=";
+    };
+    BL31 = "${armTrustedFirmwareiMX8}/bl31.bin";
+    patches = imx8-attrs.patches;
+    enableParallelBuilding = true;
+    defconfig = "${targetBoard}_mek_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    preBuildPhases = [ "copyBinaries" ];
+
+    copyBinaries = ''
+      install -m 0644 ${imx-firmware}/${imx8-attrs.ahab} ./ahab-container.img
+      install -m 0644 ${imx-firmware}/${imx8-attrs.scfw} ./${imx8-attrs.scfw}
+      install -m 0644 $BL31 ./u-boot-atf.bin
+    '';
+    postBuild = ''
+      ${imx-mkimage} -commit > head.hash
+      cat u-boot.bin head.hash > u-boot-hash.bin
+      dd if=u-boot-hash.bin of=u-boot-atf.bin bs=1K seek=128
+      ${imx-mkimage} -soc ${imx8-attrs.soc} -rev B0 -append ahab-container.img -c -scfw ${imx8-attrs.scfw} -ap u-boot-atf.bin a35 0x80000000 -out flash.bin
+      '';
+    filesToInstall = [ "flash.bin" ];
+  };
+
+  inherit imx-firmware;
+}
+

--- a/nxp/common/bsp/linux-imx8.nix
+++ b/nxp/common/bsp/linux-imx8.nix
@@ -1,0 +1,49 @@
+{ pkgs, ... } @ args:
+
+with pkgs;
+
+buildLinux (args // rec {
+  version = "5.15.71";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+  modDirVersion = version;
+
+  defconfig = "imx_v8_defconfig";
+
+  kernelPatches = [
+  ];
+
+  autoModules = false;
+
+  extraConfig = ''
+    CRYPTO_TLS m
+    TLS y
+    MD_RAID0 m
+    MD_RAID1 m
+    MD_RAID10 m
+    MD_RAID456 m
+    DM_VERITY m
+    LOGO y
+    FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+    FB_EFI n
+    EFI_STUB y
+    EFI y
+    VIRTIO y
+    VIRTIO_PCI y
+    VIRTIO_BLK y
+    DRM_VIRTIO_GPU y
+    EXT4_FS y
+    USBIP_CORE m
+    USBIP_VHCI_HCD m
+    USBIP_HOST m
+    USBIP_VUDC m
+  '';
+
+  src = fetchFromGitHub {
+    owner = "nxp-imx";
+    repo = "linux-imx";
+    # tag: refs/tags/lf-5.15.71-2.2.0
+    rev = "3313732e9984cb8a6b10a9085c7e18d58e770d56";
+    sha256 = "sha256-PBRiSgjPOq4keiwPOfNOswf1Zzdbn6YOjpOgv4/Oscc=";
+  };
+} // (args.argsOverride or { }))

--- a/nxp/common/modules.nix
+++ b/nxp/common/modules.nix
@@ -1,0 +1,18 @@
+{ pkgs, lib, ... }: {
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  nixpkgs.hostPlatform = "aarch64-linux";
+
+  boot = {
+    kernelPackages = pkgs.linuxPackagesFor pkgs.linux_imx8;
+    kernelParams = [ "console=ttyLP0,115200n8" ];
+    loader.grub.enable = lib.mkDefault true;
+    initrd.includeDefaultModules = lib.mkForce false;
+  };
+
+  disabledModules = [ "profiles/all-hardware.nix" ];
+
+  hardware.deviceTree.enable = true;
+}

--- a/nxp/common/overlay.nix
+++ b/nxp/common/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  linux_imx8 = final.callPackage ./bsp/linux-imx8.nix { pkgs = final; };
+}

--- a/nxp/common/patches/0001-Add-UEFI-boot-for-imx8qm.patch
+++ b/nxp/common/patches/0001-Add-UEFI-boot-for-imx8qm.patch
@@ -1,0 +1,83 @@
+From c2535837ee018bb6336f7043394072aaadcace34 Mon Sep 17 00:00:00 2001
+From: Panu Finnila <panu.finnila@unikie.com>
+Date: Mon, 12 Sep 2022 16:33:16 +0300
+Subject: [PATCH] Add UEFI boot for imx8qm
+
+Signed-off-by: Panu Finnila <panu.finnila@unikie.com>
+---
+ configs/imx8qm_mek_defconfig |  9 ++++++++-
+ include/configs/imx8qm_mek.h | 20 +++++++++++++++++++-
+ 2 files changed, 27 insertions(+), 2 deletions(-)
+
+diff --git a/configs/imx8qm_mek_defconfig b/configs/imx8qm_mek_defconfig
+index 29e9d796a6..1ed6eeee57 100644
+--- a/configs/imx8qm_mek_defconfig
++++ b/configs/imx8qm_mek_defconfig
+@@ -31,7 +31,7 @@ CONFIG_PANIC_HANG=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_BOOTDELAY=3
+ CONFIG_USE_BOOTCOMMAND=y
+-CONFIG_BOOTCOMMAND="mmc dev ${mmcdev}; if mmc rescan; then if run loadbootscript; then run bootscript; else if test ${sec_boot} = yes; then if run loadcntr; then run mmcboot; else run netboot; fi; else if run loadimage; then run mmcboot; else run netboot; fi; fi; fi; else booti ${loadaddr} - ${fdt_addr}; fi"
++CONFIG_BOOTCOMMAND="run loadhdp; hdp load ${hdp_addr}; run distro_bootcmd;"
+ CONFIG_LOG=y
+ CONFIG_BOARD_EARLY_INIT_F=y
+ CONFIG_SPL_BOARD_INIT=y
+@@ -196,3 +196,10 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_SPLASH_SCREEN=y
+ CONFIG_SPLASH_SCREEN_ALIGN=y
+ CONFIG_CMD_BMP=y
++CONFIG_DISTRO_DEFAULTS=y
++CONFIG_CMD_BOOTEFI_SELFTEST=y
++CONFIG_CMD_BOOTEFI=y
++CONFIG_EFI_LOADER=y
++CONFIG_BLK=y
++CONFIG_PARTITIONS=y
++CONFIG_DM_DEVICE_REMOVE=n
+diff --git a/include/configs/imx8qm_mek.h b/include/configs/imx8qm_mek.h
+index ed5c179fc7..ab5b58ec32 100644
+--- a/include/configs/imx8qm_mek.h
++++ b/include/configs/imx8qm_mek.h
+@@ -138,6 +138,22 @@
+ 	"m4boot_0=run loadm4image_0; dcache flush; bootaux ${loadaddr} 0\0" \
+ 	"m4boot_1=run loadm4image_1; dcache flush; bootaux ${loadaddr} 1\0" \
+ 
++#ifdef CONFIG_DISTRO_DEFAULTS
++#define BOOT_TARGET_DEVICES(func) \
++       func(MMC, mmc, 1) \
++       func(MMC, mmc, 0)
++
++#include <config_distro_bootcmd.h>
++#else
++#define BOOTENV
++#endif
++
++#define MEM_LAYOUT_ENV_SETTINGS \
++       "fdt_addr_r=0x83000000\0" \
++       "kernel_addr_r=0x80200000\0" \
++       "ramdisk_addr_r=0x83100000\0" \
++       "scriptaddr=0x83200000\0" \
++
+ #ifdef CONFIG_NAND_BOOT
+ #define MFG_NAND_PARTITION "mtdparts=gpmi-nand:128m(boot),32m(kernel),16m(dtb),8m(misc),-(rootfs) "
+ #else
+@@ -166,6 +182,8 @@
+ /* Initial environment variables */
+ #define CONFIG_EXTRA_ENV_SETTINGS		\
+ 	CONFIG_MFG_ENV_SETTINGS \
++	MEM_LAYOUT_ENV_SETTINGS \
++	BOOTENV \
+ 	M4_BOOT_ENV \
+ 	XEN_BOOT_ENV \
+ 	JAILHOUSE_ENV\
+@@ -179,7 +197,7 @@
+ 	"cntr_addr=0x98000000\0"			\
+ 	"cntr_file=os_cntr_signed.bin\0" \
+ 	"boot_fdt=try\0" \
+-	FDT_FILE \
++	"fdtfile=imx8qm-mek-hdmi.dtb\0" \
+ 	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
+ 	"mmcpart=1\0" \
+ 	"mmcroot=" CONFIG_MMCROOT " rootwait rw\0" \
+-- 
+2.25.1
+

--- a/nxp/common/patches/0001-Add-UEFI-boot-for-imx8qxp.patch
+++ b/nxp/common/patches/0001-Add-UEFI-boot-for-imx8qxp.patch
@@ -1,0 +1,83 @@
+From 884b162cabdc198121be36bb7ee40922f8689d77 Mon Sep 17 00:00:00 2001
+From: Grigoriy Romanov <grigoriy.romanov@unikie.com>
+Date: Tue, 20 Dec 2022 13:32:03 +0200
+Subject: [PATCH] Add UEFI boot for imx8qxp
+
+Signed-off-by: Grigoriy Romanov <grigoriy.romanov@unikie.com>
+---
+ configs/imx8qxp_mek_defconfig |  9 ++++++++-
+ include/configs/imx8qxp_mek.h | 20 +++++++++++++++++++-
+ 2 files changed, 27 insertions(+), 2 deletions(-)
+
+diff --git a/configs/imx8qxp_mek_defconfig b/configs/imx8qxp_mek_defconfig
+index eda9d2cc00..e498ca1d5b 100644
+--- a/configs/imx8qxp_mek_defconfig
++++ b/configs/imx8qxp_mek_defconfig
+@@ -32,7 +32,7 @@ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_BOOTDELAY=3
+ CONFIG_USE_BOOTCOMMAND=y
+-CONFIG_BOOTCOMMAND="mmc dev ${mmcdev}; if mmc rescan; then if run loadbootscript; then run bootscript; else if test ${sec_boot} = yes; then if run loadcntr; then run mmcboot; else run netboot; fi; else if run loadimage; then run mmcboot; else run netboot; fi; fi; fi; else booti ${loadaddr} - ${fdt_addr}; fi"
++CONFIG_BOOTCOMMAND="run distro_bootcmd;"
+ CONFIG_LOG=y
+ CONFIG_BOARD_EARLY_INIT_F=y
+ CONFIG_SPL_BOARD_INIT=y
+@@ -194,3 +194,10 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_SPLASH_SCREEN=y
+ CONFIG_SPLASH_SCREEN_ALIGN=y
+ CONFIG_CMD_BMP=y
++CONFIG_DISTRO_DEFAULTS=y
++CONFIG_CMD_BOOTEFI_SELFTEST=y
++CONFIG_CMD_BOOTEFI=y
++CONFIG_EFI_LOADER=y
++CONFIG_BLK=y
++CONFIG_PARTITIONS=y
++CONFIG_DM_DEVICE_REMOVE=n
+diff --git a/include/configs/imx8qxp_mek.h b/include/configs/imx8qxp_mek.h
+index 2886a3b99b..7cc89336b7 100644
+--- a/include/configs/imx8qxp_mek.h
++++ b/include/configs/imx8qxp_mek.h
+@@ -52,6 +52,22 @@
+ #define AHAB_ENV "sec_boot=no\0"
+ #endif
+
++#ifdef CONFIG_DISTRO_DEFAULTS
++#define BOOT_TARGET_DEVICES(func) \
++       func(MMC, mmc, 1) \
++       func(MMC, mmc, 0)
++
++#include <config_distro_bootcmd.h>
++#else
++#define BOOTENV
++#endif
++
++#define MEM_LAYOUT_ENV_SETTINGS \
++       "fdt_addr_r=0x83000000\0" \
++       "kernel_addr_r=0x80200000\0" \
++       "ramdisk_addr_r=0x83100000\0" \
++       "scriptaddr=0x83200000\0" \
++
+ /* Boot M4 */
+ #define M4_BOOT_ENV \
+ 	"m4_0_image=m4_0.bin\0" \
+@@ -108,6 +124,8 @@
+ /* Initial environment variables */
+ #define CONFIG_EXTRA_ENV_SETTINGS		\
+ 	CONFIG_MFG_ENV_SETTINGS \
++    MEM_LAYOUT_ENV_SETTINGS \
++    BOOTENV \
+ 	M4_BOOT_ENV \
+ 	XEN_BOOT_ENV \
+ 	JAILHOUSE_ENV\
+@@ -121,7 +139,7 @@
+ 	"cntr_addr=0x98000000\0"			\
+ 	"cntr_file=os_cntr_signed.bin\0" \
+ 	"boot_fdt=try\0" \
+-	"fdt_file=undefined\0" \
++	"fdtfile=imx8qxp-mek.dtb\0" \
+ 	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
+ 	"mmcpart=1\0" \
+ 	"mmcroot=" CONFIG_MMCROOT " rootwait rw\0" \
+--
+2.34.1
+

--- a/nxp/imx8qm-mek/default.nix
+++ b/nxp/imx8qm-mek/default.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, ... }:
+
+{
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  imports = [
+    ../common/modules.nix
+  ];
+
+  boot.loader.grub.extraFiles = {
+      "imx8qm-mek.dtb" = "${pkgs.linux_imx8}/dtbs/freescale/imx8qm-mek.dtb";
+  };
+
+  hardware.deviceTree = {
+    filter = "imx8qm-*.dtb";
+    name = "imx8qm-mek.dtb";
+  };
+}

--- a/nxp/imx8qm-mek/overlay.nix
+++ b/nxp/imx8qm-mek/overlay.nix
@@ -1,0 +1,3 @@
+final: _prev: {
+  inherit ( final.callPackage ./bsp/u-boot/imx8/imx-uboot.nix { pkgs = final; targetBoard = "imx8qm"; }) ubootImx8 imx-firmware;
+}

--- a/nxp/imx8qxp-mek/overlay.nix
+++ b/nxp/imx8qxp-mek/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  inherit ( final.callPackage ./bsp/u-boot/imx8/imx-uboot.nix { pkgs = final; targetBoard = "imx8qxp"; }) ubootImx8 imx-firmware;
+}


### PR DESCRIPTION
Currently there are two devices supported:
* imx8qm-mek
* imx8qxp-mek

Signed-off-by: Ivan Nikolaenko <ivan.nikolaenko@unikie.com>

###### Description of changes
Changes made in the way it makes very easy to add another mx8-based device or device-specific configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

