### PR TITLE
amdlvk cleanup

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -29,8 +29,6 @@
     })
     (lib.mkIf config.hardware.amdgpu.amdvlk {
       hardware.opengl.extraPackages = with pkgs; [
-        rocm-opencl-icd
-        rocm-opencl-runtime
         amdvlk
       ];
 

--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -8,9 +8,7 @@
   };
   options.hardware.amdgpu.amdvlk = lib.mkEnableOption (lib.mdDoc 
     "use amdvlk drivers instead mesa radv drivers"
-  ) // {
-    default = true;
-  };
+  );
   options.hardware.amdgpu.opencl = lib.mkEnableOption (lib.mdDoc 
     "rocm opencl runtime (Install rocm-opencl-icd and rocm-opencl-runtime)"
   ) // {
@@ -39,8 +37,6 @@
       hardware.opengl.extraPackages32 = with pkgs; [
         driversi686Linux.amdvlk
       ];
-      
-      environment.variables.AMD_VULKAN_ICD = lib.mkDefault "RADV";
     })
     (lib.mkIf config.hardware.amdgpu.opencl {
       hardware.opengl.extraPackages = with pkgs; [


### PR DESCRIPTION
###### Description of changes
Disable install of amdvlk by default, don't set `AMD_VULKAN_ICD ="RADV"` when enabling amdvlk, and don't install OpenCL when enabling amdvlk.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

