### PR TITLE
p14s: do not include acpi_backlight on newer kernel versions

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen2/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen2/default.nix
@@ -1,6 +1,4 @@
-
-{ lib, pkgs, ... }:
-
+{ lib, pkgs, config, ... }:
 {
   imports = [
     ../../../../../common/pc/laptop/acpi_call.nix
@@ -9,8 +7,9 @@
   # For suspending to RAM, set Config -> Power -> Sleep State to "Linux" in EFI.
 
   # amdgpu.backlight=0 makes the backlight work
-  # acpi_backlight=none allows the backlight save/load systemd service to work.
-  boot.kernelParams = ["amdgpu.backlight=0" "acpi_backlight=none"];
+  # acpi_backlight=none allows the backlight save/load systemd service to work on older kernel versions
+  boot.kernelParams = [ "amdgpu.backlight=0" ] ++ lib.optional (lib.versionOlder config.boot.kernelPackages.kernel.version "6.1.6") "acpi_backlight=none";
+
 
   # Wifi support
   hardware.firmware = [ pkgs.rtw89-firmware ];


### PR DESCRIPTION
###### Description of changes

Please test @itc-ger


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

