### PR TITLE
raspberry-pi/4: don't use an alias for the kernel pkg

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -15,7 +15,7 @@
   ];
 
   boot = {
-    kernelPackages = lib.mkDefault pkgs.linuxPackages_rpi4;
+    kernelPackages = lib.mkDefault pkgs.linuxKernel.packages.linux_rpi4;
     initrd.availableKernelModules = [
       "usbhid"
       "usb_storage"


### PR DESCRIPTION
###### Description of changes

This should allow the rpi4 config to enable when `allowAliases = false` in the
nixpkgs config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

