### PR TITLE
lenovo/legion/16ach6h: disable thermald

### DIFF
--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -23,6 +23,4 @@
       };
     };
   };
-
-  services.thermald.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
###### Description of changes

It's for Intel laptops. 16ach6h is not one of them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

