### PR TITLE
t14s,p14s: remove rtw89-firmware

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen2/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen2/default.nix
@@ -12,7 +12,7 @@
 
 
   # Wifi support
-  hardware.firmware = [ pkgs.rtw89-firmware ];
+  hardware.firmware = lib.mkIf (lib.versionOlder pkgs.linux-firmware.version "20230210") [ pkgs.rtw89-firmware ];
 
   # For mainline support of rtw89 wireless networking
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;

--- a/lenovo/thinkpad/t14s/amd/gen1/default.nix
+++ b/lenovo/thinkpad/t14s/amd/gen1/default.nix
@@ -6,7 +6,7 @@
     ../.
   ];
   # Wifi support
-  hardware.firmware = [ pkgs.rtw89-firmware ];
+  hardware.firmware = lib.mkIf (lib.versionOlder pkgs.linux-firmware.version "20230210") [ pkgs.rtw89-firmware ];
 
   # For mainline support of rtw89 wireless networking
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;


### PR DESCRIPTION
###### Description of changes

The package was removed in https://github.com/NixOS/nixpkgs/pull/217196 and is now present in linux-firmware.

cc @lovesegfault @QuantMint, should we guard this against some version check? I'm not sure what exactly is needed for wifi to work: is having a 5.16+ kernel enough or would people *also* need a 20230210+ linux-firmware?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

