### PR TITLE
Remove rtw89 firmware

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen2/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen2/default.nix
@@ -10,9 +10,8 @@
   # acpi_backlight=none allows the backlight save/load systemd service to work on older kernel versions
   boot.kernelParams = [ "amdgpu.backlight=0" ] ++ lib.optional (lib.versionOlder config.boot.kernelPackages.kernel.version "6.1.6") "acpi_backlight=none";
 
-
   # Wifi support
-  hardware.firmware = [ pkgs.rtw89-firmware ];
+  hardware.firmware = lib.optionals (builtins.tryEval pkgs.rtw89-firmware).success [ pkgs.rtw89-firmware ];
 
   # For mainline support of rtw89 wireless networking
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;

--- a/lenovo/thinkpad/t14s/amd/gen1/default.nix
+++ b/lenovo/thinkpad/t14s/amd/gen1/default.nix
@@ -6,7 +6,7 @@
     ../.
   ];
   # Wifi support
-  hardware.firmware = [ pkgs.rtw89-firmware ];
+  hardware.firmware = lib.optionals (builtins.tryEval pkgs.rtw89-firmware).success [ pkgs.rtw89-firmware ];
 
   # For mainline support of rtw89 wireless networking
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;


### PR DESCRIPTION
###### Description of changes
The rtw89-firmware package have been removed and replaced with a throw, however I didn't just want to remove it in case people have older versions of nixpkgs so I made it conditional if the package evals or not.

With this in place I updated my flake input to use that branch and I can build the system without getting the throw error from this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

