### PR TITLE
Add NVIDIA config for Dell XPS 15 7590

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ See code for all available configurations.
 | [Dell XPS 13 9360](dell/xps/13-9360)                                | `<nixos-hardware/dell/xps/13-9360>`                |
 | [Dell XPS 13 9370](dell/xps/13-9370)                                | `<nixos-hardware/dell/xps/13-9370>`                |
 | [Dell XPS 13 9380](dell/xps/13-9380)                                | `<nixos-hardware/dell/xps/13-9380>`                |
+| [Dell XPS 15 7590, nvidia](dell/xps/15-7590/nvidia)                 | `<nixos-hardware/dell/xps/15-7590/nvidia>`         |
 | [Dell XPS 15 7590](dell/xps/15-7590)                                | `<nixos-hardware/dell/xps/15-7590>`                |
 | [Dell XPS 15 9500, nvidia](dell/xps/15-9500/nvidia)                 | `<nixos-hardware/dell/xps/15-9500/nvidia>`         |
 | [Dell XPS 15 9500](dell/xps/15-9500)                                | `<nixos-hardware/dell/xps/15-9500>`                |

--- a/dell/xps/15-7590/nvidia/default.nix
+++ b/dell/xps/15-7590/nvidia/default.nix
@@ -1,0 +1,15 @@
+{lib, ...}:
+{
+  imports = [
+    ../.
+    ../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  hardware.nvidia.prime = {
+    # Bus ID of the Intel GPU.
+    intelBusId = lib.mkDefault "PCI:0:2:0";
+
+    # Bus ID of the NVIDIA GPU.
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
       dell-xps-13-9370 = import ./dell/xps/13-9370;
       dell-xps-13-9380 = import ./dell/xps/13-9380;
       dell-xps-15-7590 = import ./dell/xps/15-7590;
+      dell-xps-15-7590-nvidia = import ./dell/xps/15-7590/nvidia;
       dell-xps-15-9500 = import ./dell/xps/15-9500;
       dell-xps-15-9500-nvidia = import ./dell/xps/15-9500/nvidia;
       dell-xps-15-9550 = import ./dell/xps/15-9550;


### PR DESCRIPTION
###### Description of changes

Add hardware configuration for the Dell XPS 15 7590 with NVIDIA graphics.

###### Things done

Import the Intel-based config, the common NVIDIA config and add the necessary bus IDs.

Not sure whether we are supposed to add `hardware.nvidia.powerManagement.enable = true;` here or leave it to the user to decide to enable it or not (I did personally). 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

