### PR TITLE
Enable thermald for Dell XPS 15 7590

### DIFF
--- a/dell/xps/15-7590/default.nix
+++ b/dell/xps/15-7590/default.nix
@@ -1,3 +1,5 @@
+{ lib, ... }:
+
 {
   imports = [
     ../../../common/cpu/intel
@@ -20,6 +22,9 @@
 
   # Prevent small EFI partiion from filling up
   boot.loader.grub.configurationLimit = 10;
+
+  # This will save you money and possibly your life!
+  services.thermald.enable = lib.mkDefault true;
 
   # The 48.ucode causes the Killer wifi card to crash.
   # The iwlfwifi-cc-a0-46.ucode works perfectly


### PR DESCRIPTION
###### Description of changes

Enable thermald.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

