### PR TITLE
Remove override of WiFi module for Dell XPS 15 7590

### DIFF
--- a/dell/xps/15-7590/default.nix
+++ b/dell/xps/15-7590/default.nix
@@ -25,23 +25,4 @@
 
   # This will save you money and possibly your life!
   services.thermald.enable = lib.mkDefault true;
-
-  # The 48.ucode causes the Killer wifi card to crash.
-  # The iwlfwifi-cc-a0-46.ucode works perfectly
-  nixpkgs.overlays = [
-    (_self: super: {
-      firmwareLinuxNonfree = super.firmwareLinuxNonfree.overrideAttrs (_old: {
-        src = super.fetchgit {
-          url =
-            "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
-          rev = "bf13a71b18af229b4c900b321ef1f8443028ded8";
-          sha256 = "1dcaqdqyffxiadx420pg20157wqidz0c0ca5mrgyfxgrbh6a4mdj";
-        };
-        postInstall = ''
-          rm $out/lib/firmware/iwlwifi-cc-a0-48.ucode
-        '';
-        outputHash = "0dq48i1cr8f0qx3nyq50l9w9915vhgpwmwiw3b4yhisbc3afyay4";
-      });
-    })
-  ];
 }


### PR DESCRIPTION
###### Description of changes

Looks like it's no longer needed as of today.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

