### PR TITLE
common/gpu/intel*: Migrate to common/gpu/intel/* and add disable

### DIFF
--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -1,6 +1,6 @@
 {
   imports = [
     ./cpu-only.nix
-    ../../gpu/intel.nix
+    ../../gpu/intel
   ];
 }

--- a/common/gpu/intel.nix
+++ b/common/gpu/intel.nix
@@ -1,15 +1,11 @@
-{ config, lib, pkgs, ... }:
-
 {
-  boot.initrd.kernelModules = [ "i915" ];
+  imports = [ ./intel ];
 
-  environment.variables = {
-    VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
-  };
+  warnings = [
+    ''
+      DEPRECATED: The <nixos-hardware/common/gpu/intel.nix> module has been deprecated.
 
-  hardware.opengl.extraPackages = with pkgs; [
-    vaapiIntel
-    libvdpau-va-gl
-    intel-media-driver
+      Switch to using <nixos-hardware/common/gpu/intel> instead.
+    ''
   ];
 }

--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  boot.initrd.kernelModules = [ "i915" ];
+
+  environment.variables = {
+    VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
+  };
+
+  hardware.opengl.extraPackages = with pkgs; [
+    vaapiIntel
+    libvdpau-va-gl
+    intel-media-driver
+  ];
+}

--- a/common/gpu/intel/disable.nix
+++ b/common/gpu/intel/disable.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+
+{
+  boot.blacklistedKernelModules = lib.mkDefault [ "i915" ];
+  # KMS will load the module, regardless of blacklisting
+  boot.kernelParams = lib.mkDefault [ "i915.modeset=0" ];
+}

--- a/dell/xps/13-9300/default.nix
+++ b/dell/xps/13-9300/default.nix
@@ -6,7 +6,7 @@ let
 in {
   imports = [
     ../../../common/cpu/intel
-    ../../../common/gpu/intel.nix
+    ../../../common/gpu/intel
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/ssd

--- a/flake.nix
+++ b/flake.nix
@@ -172,7 +172,8 @@
       common-gpu-amd = import ./common/gpu/amd;
       common-gpu-amd-sea-islands = import ./common/gpu/amd/sea-islands;
       common-gpu-amd-southern-islands = import ./common/gpu/amd/southern-islands;
-      common-gpu-intel = import ./common/gpu/intel.nix;
+      common-gpu-intel = import ./common/gpu/intel;
+      common-gpu-intel-disable = import ./common/gpu/intel/disable.nix;
       common-gpu-nvidia = import ./common/gpu/nvidia/prime.nix;
       common-gpu-nvidia-nonprime = import ./common/gpu/nvidia;
       common-gpu-nvidia-disable = import ./common/gpu/nvidia/disable.nix;


### PR DESCRIPTION
###### Description of changes

Recently had to disable the iGPU, but it turns out that even if you blacklist the module it will still get loaded by the KMS subsystem. Added a module that disables both modelled after the nvidia modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

