### PR TITLE
dell-xps-15-7590: enable fwupd and deep sleep

### DIFF
--- a/dell/xps/15-7590/README.wiki
+++ b/dell/xps/15-7590/README.wiki
@@ -21,27 +21,6 @@ These settings are needed both for booting the final install, and installer itse
 
 * ''Disable Intel hardware RAID and use AHCI instead.'' Intel doesn't seem to provide a working linux driver for this.  (If you just have SSD it's pointless and just slows things down needlessly anyways.)
 
-=== Wifi ===
-~~Wifi does not work with kernels older than 5.1 (firmware not present) or newer~~ (https://bbs.archlinux.org/viewtopic.php?id=247705)
-
-Update: The 48.ucode causes the Killer wifi card to crash. The iwlfwifi-cc-a0-46.ucode works perfectly. 
-default.nix contains an overlay that removes the offending ucode from the linux-firmware bundle.
-To use it one also needs to enable unfree firmware in their own configuration (<code>hardware.enableRedistributableFirmware = true;</code>)
-
-```
-  # Use the systemd-boot EFI boot loader.
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.grub = {
-    device = "nodev";
-    efiSupport = true;
-    efiInstallAsRemovable = true;
-  };
-  boot.loader.efi.canTouchEfiVariables = true;
-  boot.kernelPackages = pkgs.linuxPackages_5_1;
-```
-Disable the `canTouchEfiVariables` after a boot or two to prevent NVRAM wearout.
-
-
 === After installation ===
 
 * ''Add systemd-boot to UEFI boot list.'' The (uneditable anyways) settings mapping drive UUIDs to HD* work fine.
@@ -50,5 +29,15 @@ Disable the `canTouchEfiVariables` after a boot or two to prevent NVRAM wearout.
 
 * ''Update BIOS.'' According to Reddit, this helps with battery life.
 
-=== Troubleshooting ===
+== Firmware updates ==
+
+This device is supported by [https://fwupd.org/ fwupd].
+
+You may use <code>fwupdmgr</code> to perform firmware updates.
+
+== Power management ==
+
+Deep sleep is preferred to the default S2 sleep mode, in order to reduce battery draining during suspend.
+
+See https://wiki.archlinux.org/title/Dell_XPS_15_(7590)
 

--- a/dell/xps/15-7590/default.nix
+++ b/dell/xps/15-7590/default.nix
@@ -7,21 +7,17 @@
     ../../../common/pc/ssd
   ];
 
-  # Set to true for just the first run, then disable it.
-  # boot.loader.efi.canTouchEfiVariables = lib.mkDefault true;
-
-  # Load GPU drivers.
-  # hardware.bumblebee.enable = lib.mkDefault true;
-
-  # High DPI for X users. 175 "looks reasonable" but I didn't do the actual DPI
-  # calculation.
-  # services.xserver.dpi = lib.mkDefault 175;
+  # Force S3 sleep mode. See README.wiki for details.
+  boot.kernelParams = [ "mem_sleep_default=deep" ];
 
   # Earlier font-size setup
   console.earlySetup = true;
 
   # Prevent small EFI partiion from filling up
   boot.loader.grub.configurationLimit = 10;
+
+  # Enable firmware updates via `fwupdmgr`.
+  services.fwupd.enable = lib.mkDefault true;
 
   # This will save you money and possibly your life!
   services.thermald.enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes

- This device supports firmware updates through `fwupd`.
- Prefer deep sleep over s2idle which is inefficient.
- Remove old cruft in the corresponding readme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

