### PR TITLE
common/gpu/intel/opencl: add opencl

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -1,5 +1,10 @@
 { config, lib, pkgs, ... }:
-
+let 
+  selectPackages = pkgs: with pkgs; [
+    intel-media-driver
+    vaapiIntel
+  ];
+in
 {
   boot.initrd.kernelModules = [ "i915" ];
 
@@ -7,9 +12,6 @@
     VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
   };
 
-  hardware.opengl.extraPackages = with pkgs; [
-    vaapiIntel
-    libvdpau-va-gl
-    intel-media-driver
-  ];
+  hardware.opengl.extraPackages = selectPackages pkgs;
+  hardware.opengl.extraPackages32 = selectPackages (pkgs.driversi686Linux);
 }

--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -6,11 +6,15 @@ let
   ];
 in
 {
+  imports = [ ./opencl.nix ];
+
   boot.initrd.kernelModules = [ "i915" ];
 
   environment.variables = {
     VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
   };
+
+  hardware.intel.opencl.enable = lib.mkDefault true;
 
   hardware.opengl.extraPackages = selectPackages pkgs;
   hardware.opengl.extraPackages32 = selectPackages (pkgs.driversi686Linux);

--- a/common/gpu/intel/opencl.nix
+++ b/common/gpu/intel/opencl.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+{
+  options.hardware.intel.opencl.enable = lib.mkEnableOption (lib.mkDoc
+    "intel opencl runtime (Install icd for Intel GPUs)"
+  );
+
+  config = lib.mkIf config.hardware.intel.opencl.enable {
+    hardware.opengl.extraPackages = with pkgs; [ 
+      intel-compute-runtime
+      intel-ocl
+    ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Updates intel libraries as per https://github.com/NixOS/nixpkgs/pull/205648
Adds module for intel opencl currently only supporting GPU

It is possible to add CPU OpenCL support, but only using an older version of the driver: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=intel-opencl-runtime


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

