### PR TITLE
Fix disabling Nvidia dGPU

### DIFF
--- a/common/gpu/nvidia/disable.nix
+++ b/common/gpu/nvidia/disable.nix
@@ -4,6 +4,23 @@
   # This runs only intel/amdgpu igpus and nvidia dgpus do not drain power.
 
   ##### disable nvidia, very nice battery life.
-  hardware.nvidiaOptimus.disable = lib.mkDefault true;
+  boot.extraModprobeConfig = lib.mkDefault ''
+    blacklist nouveau
+    options nouveau modeset=0
+  '';
+  
+  services.udev.extraRules = lib.mkDefault ''
+    # Remove NVIDIA USB xHCI Host Controller devices, if present
+    ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{power/control}="auto", ATTR{remove}="1"
+
+    # Remove NVIDIA USB Type-C UCSI devices, if present
+    ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{power/control}="auto", ATTR{remove}="1"
+
+    # Remove NVIDIA Audio devices, if present
+    ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{power/control}="auto", ATTR{remove}="1"
+
+    # Remove NVIDIA VGA/3D controller devices
+    ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", ATTR{power/control}="auto", ATTR{remove}="1"
+  '';
   boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" ];
 }


### PR DESCRIPTION
###### Description of changes

Fixed turning off Nvidia dGPU using instructions from [arch wiki](https://wiki.archlinux.org/title/Hybrid_graphics#Using_udev_rules)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

