### PR TITLE
Add Hardkernel HC4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ See code for all available configurations.
 | [Microsoft Surface Laptop (AMD)](microsoft/surface/surface-laptop-amd)| `<nixos-hardware/microsoft/surface/surface-laptop-amd>`|
 | [Microsoft Surface Range (Common Modules)](microsoft/surface/common)| `<nixos-hardware/microsoft/surface/common>`        |
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                  | `<nixos-hardware/microsoft/surface-pro/3>`         |
+| [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)          | `<nixos-hardware/hardkernel/odroid-hc4>`           |
 | [Omen en00015p](omen/en00015p)                                      | `<nixos-hardware/omen/en00015p>`                   |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |
 | [Panasonic Let's Note CF-LX4 ](panasonic/letsnote/cf-lx4)           | `<nixos-hardware/panasonic/letsnote/cf-lx4>`       |

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
+      hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
       omen-en00015p = import ./omen/en00015p;
       onenetbook-4 = import ./onenetbook/4;
       pcengines-apu = import ./pcengines/apu;

--- a/hardkernel/odroid-hc4/default.nix
+++ b/hardkernel/odroid-hc4/default.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+
+{
+  # Based on the config from https://www.armbian.com/odroid-hc4/
+  hardware.fancontrol = {
+    enable = lib.mkDefault true;
+    config = lib.mkDefault ''
+      INTERVAL=10
+      DEVPATH=hwmon0=devices/virtual/thermal/thermal_zone0 hwmon2=devices/platform/pwm-fan
+      DEVNAME=hwmon0=cpu_thermal hwmon2=pwmfan
+      FCTEMPS=hwmon2/pwm1=hwmon0/temp1_input
+      FCFANS= hwmon2/pwm1=hwmon2/fan1_input
+      MINTEMP=hwmon2/pwm1=50
+      MAXTEMP=hwmon2/pwm1=60
+      MINSTART=hwmon2/pwm1=20
+      MINSTOP=hwmon2/pwm1=28
+      MINPWM=hwmon2/pwm1=0
+      MAXPWM=hwmon2/pwm1=255
+    '';
+  };
+
+  # Linux 5.15 sometimes crash under heavy network usage
+  systemd.watchdog.runtimeTime = lib.mkDefault "1min";
+
+  hardware.deviceTree.filter = "meson-sm1-odroid-hc4.dtb";
+}


### PR DESCRIPTION
###### Description of changes

I propose to include some specific board options for the Odroid HC4 in nixos-hardware.
I have been successfully using NixOS on my Odroid HC4 since December 2021.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

