### PR TITLE
common/gpu/amd: use modesetting driver by default

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -17,7 +17,7 @@
 
   config = lib.mkMerge [
     {
-      services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" ];
+      services.xserver.videoDrivers = lib.mkDefault [ "modesetting" ];
 
       hardware.opengl = {
         driSupport = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes

Follows upstream nixpkgs, see https://github.com/NixOS/nixpkgs/pull/218437

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

