### PR TITLE
nxp: imx8: Fix wrong paths to imx-uboot.nix file

### DIFF
--- a/nxp/README.md
+++ b/nxp/README.md
@@ -5,7 +5,9 @@
  - [i.MX8QuadXPlus Multisensory Enablement Kit](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadxplus-multisensory-enablement-kit-mek:MCIMX8QXP-CPU) (**imx8qxp-mek**) - device-specific U-Boot and Linux kernel.
 
 ## 2. How to use
-Currently this NXP overlay is used for generating EFI-bootable NixOS images. [Tow-Boot](https://tow-boot.org/) is used as a bootloader in our case, but U-Boot can also be used.
+Currently this NXP overlay is used for generating EFI-bootable NixOS images.
+I recommend to use [Tow-Boot](https://tow-boot.org/) as a bootloader, but U-Boot from this overlay can also be used.
+U-Boot was tested separately from NixOS.
 
 Code snippet example that enables imx8qm configuration:
 ```

--- a/nxp/common/bsp/imx-uboot.nix
+++ b/nxp/common/bsp/imx-uboot.nix
@@ -18,7 +18,7 @@ with pkgs; let
     ahab = "mx8qmb0-ahab-container.img";
     scfw = "mx8qm-mek-scfw-tcm.bin";
     soc = "QM";
-    patches = [ ../patches/0001-Add-UEFI-boot-on-imx8qm_mek.patch ];
+    patches = [ ../patches/0001-Add-UEFI-boot-for-imx8qm.patch ];
   };
 
   imx8-attrs = if (targetBoard == "imx8qxp") then imx8qxp-attrs

--- a/nxp/imx8qm-mek/default.nix
+++ b/nxp/imx8qm-mek/default.nix
@@ -10,7 +10,7 @@
   ];
 
   boot.loader.grub.extraFiles = {
-      "imx8qm-mek.dtb" = "${pkgs.linux_imx8}/dtbs/freescale/imx8qm-mek.dtb";
+    "imx8qm-mek.dtb" = "${pkgs.linux_imx8}/dtbs/freescale/imx8qm-mek.dtb";
   };
 
   hardware.deviceTree = {

--- a/nxp/imx8qm-mek/overlay.nix
+++ b/nxp/imx8qm-mek/overlay.nix
@@ -1,3 +1,3 @@
-final: _prev: {
-  inherit ( final.callPackage ./bsp/u-boot/imx8/imx-uboot.nix { pkgs = final; targetBoard = "imx8qm"; }) ubootImx8 imx-firmware;
+final: prev: {
+  inherit ( final.callPackage ../common/bsp/imx-uboot.nix { pkgs = final; targetBoard = "imx8qm"; }) ubootImx8 imx-firmware;
 }

--- a/nxp/imx8qxp-mek/overlay.nix
+++ b/nxp/imx8qxp-mek/overlay.nix
@@ -1,3 +1,3 @@
 final: prev: {
-  inherit ( final.callPackage ./bsp/u-boot/imx8/imx-uboot.nix { pkgs = final; targetBoard = "imx8qxp"; }) ubootImx8 imx-firmware;
+  inherit ( final.callPackage ../common/bsp/imx-uboot.nix { pkgs = final; targetBoard = "imx8qxp"; }) ubootImx8 imx-firmware;
 }


### PR DESCRIPTION
In addition, adjust code formatting and improve documentation

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

