### PR TITLE
Enable NVIDIA power management for Dell XPS 7590

### DIFF
--- a/dell/xps/15-7590/nvidia/default.nix
+++ b/dell/xps/15-7590/nvidia/default.nix
@@ -5,11 +5,21 @@
     ../../../../common/gpu/nvidia/prime.nix
   ];
 
-  hardware.nvidia.prime = {
-    # Bus ID of the Intel GPU.
-    intelBusId = lib.mkDefault "PCI:0:2:0";
+  hardware.nvidia = {
+    powerManagement = {
+      # Enable NVIDIA power management.
+      enable = lib.mkDefault true;
+      
+      # Enable dynamic power management.
+      finegrained = lib.mkDefault true;
+    };
 
-    # Bus ID of the NVIDIA GPU.
-    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+    prime = {
+      # Bus ID of the Intel GPU.
+      intelBusId = lib.mkDefault "PCI:0:2:0";
+
+      # Bus ID of the NVIDIA GPU.
+      nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+    };
   };
 }


### PR DESCRIPTION
###### Description of changes

Enable dynamic power management for the NVIDIA GTX 1650 mobile on the Dell XPS 7590. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

