### PR TITLE
lenovo 16ach6h: add amd cpu pstate

### DIFF
--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../../../common/cpu/amd
+    ../../../../common/cpu/amd/pstate.nix
     ../../../../common/gpu/amd
     ../../../../common/gpu/nvidia/prime.nix
     ../../../../common/pc/laptop


### PR DESCRIPTION
###### Description of changes
lenovo 16ach6h: add amd cpu pstate


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

