### PR TITLE
gpd/p2-max: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ See code for all available configurations.
 | [Framework 12th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
+| [GPD P2 Max](gpd/p2-max)                                            | `<nixos-hardware/gpd/p2-max>`                      |
 | [GPD Pocket 3](gpd/pocket-3)                                        | `<nixos-hardware/gpd/pocket-3>`                    |
 | [GPD WIN 2](gpd/win-2)                                              | `<nixos-hardware/gpd/win-2>`                       |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
       friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;
+      gpd-p2-max = import ./gpd/p2-max;
       gpd-pocket-3 = import ./gpd/pocket-3;
       gpd-win-2 = import ./gpd/win-2;
       hp-elitebook-2560p = import ./hp/elitebook/2560p;

--- a/gpd/p2-max/default.nix
+++ b/gpd/p2-max/default.nix
@@ -1,0 +1,11 @@
+{lib, ...}: {
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+    ../../common/cpu/intel
+    ../../common/cpu/intel/kaby-lake
+  ];
+
+  # HiDPI settings
+  hardware.video.hidpi.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes

Module for the [GPD P2 Max](https://liliputing.com/first-look-gpd-p2-max-8-9-inch-mini-laptop/) ultrabook with Intel Kaby Lake m3-8100Y CPU


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

