### PR TITLE
Only create a systemd service config for IPTSd earlier than 1.0

### DIFF
--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkDefault mkEnableOption mkIf mkMerge;
+  inherit (lib) mkDefault mkEnableOption mkIf mkMerge versionOlder;
 
   cfg = config.microsoft-surface.ipts;
 
@@ -16,6 +16,12 @@ in {
     }
 
     (mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = versionOlder iptsd.version "1.0.1";
+          message = "Nixpkgs provides a udev and systemd config after v0.5.1";
+        }
+      ];
       systemd.services.iptsd = {
         description = "IPTSD";
         path = with pkgs; [ iptsd ];

--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -1,9 +1,11 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkDefault mkEnableOption mkIf mkMerge versionOlder;
+  inherit (lib) mkDefault mkEnableOption mkIf mkMerge versionAtLeast;
 
   cfg = config.microsoft-surface.ipts;
+
+  version-includes-systemd-config = versionAtLeast iptsd.version "1.0";
 
 in {
   options.microsoft-surface.ipts = {
@@ -15,19 +17,37 @@ in {
       microsoft-surface.ipts.enable = mkDefault false;
     }
 
-    (mkIf cfg.enable {
-      assertions = [
-        {
-          assertion = versionOlder iptsd.version "1.0.1";
-          message = "Nixpkgs provides a udev and systemd config after v0.5.1";
-        }
-      ];
+    (mkIf (cfg.enable and !version-includes-systemd-config) {
       systemd.services.iptsd = {
         description = "IPTSD";
         path = with pkgs; [ iptsd ];
         script = "iptsd";
         wantedBy = [ "multi-user.target" ];
       };
+    })
+
+    (mkIf (cfg.enable and version-includes-systemd-config) {
+      # TODO:
+      # I'm not convinced I need to add pkgs.iptsd to systemd.packages and services.udev.packages;
+      # just adding it to environment.systemPackages might be good enough?
+      # Looking at be below code, it alread puts the systemd and udev rules into /etc/ :
+      # - https://github.com/NixOS/nixpkgs/blob/ae8bdd2de4c23b239b5a771501641d2ef5e027d0/pkgs/applications/misc/iptsd/default.nix#L46-L52
+
+      # TODO:
+      # "system.packages" only seems to check for ${package}/lib/systemd/systemd-${type} which means
+      # it won't find the iptsd ones, anyway:
+      # - https://github.com/NixOS/nixpkgs/blob/10e51cdc0456f1d5c8a00f026c384f0e81126538/nixos/modules/system/boot/systemd.nix#L467-L473
+      systemd.packages = [
+        pkgs.ipstd
+      ];
+
+      # TODO:
+      # udev.packages does add files from ${package}/etc/udev/rules.d/ but maybe just adding to
+      # environment.systemPackages is good enough?
+      # - https://github.com/NixOS/nixpkgs/blob/10e51cdc0456f1d5c8a00f026c384f0e81126538/nixos/modules/services/hardware/udev.nix#L69-L75
+      services.udev.packages = [
+        pkgs.iptsd
+      ];
     })
   ];
 }

--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -5,7 +5,8 @@ let
 
   cfg = config.microsoft-surface.ipts;
 
-  version-includes-systemd-config = versionAtLeast pkgs.iptsd.version "1.0";
+  iptsd = pkgs.iptsd;
+  version-includes-systemd-config = versionAtLeast iptsd.version "1.0";
 
 in {
   options.microsoft-surface.ipts = {
@@ -20,7 +21,7 @@ in {
     (mkIf (cfg.enable && !version-includes-systemd-config) {
       systemd.services.iptsd = {
         description = "IPTSD";
-        path = with pkgs; [ iptsd ];
+        path = [ iptsd ];
         script = "iptsd";
         wantedBy = [ "multi-user.target" ];
       };
@@ -37,17 +38,13 @@ in {
       # "system.packages" only seems to check for ${package}/lib/systemd/systemd-${type} which means
       # it won't find the iptsd ones, anyway:
       # - https://github.com/NixOS/nixpkgs/blob/10e51cdc0456f1d5c8a00f026c384f0e81126538/nixos/modules/system/boot/systemd.nix#L467-L473
-      systemd.packages = [
-        pkgs.iptsd
-      ];
+      systemd.packages = [ iptsd ];
 
       # TODO:
       # udev.packages does add files from ${package}/etc/udev/rules.d/ but maybe just adding to
       # environment.systemPackages is good enough?
       # - https://github.com/NixOS/nixpkgs/blob/10e51cdc0456f1d5c8a00f026c384f0e81126538/nixos/modules/services/hardware/udev.nix#L69-L75
-      services.udev.packages = [
-        pkgs.iptsd
-      ];
+      services.udev.packages = [ iptsd ];
     })
   ];
 }

--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -5,7 +5,7 @@ let
 
   cfg = config.microsoft-surface.ipts;
 
-  version-includes-systemd-config = versionAtLeast iptsd.version "1.0";
+  version-includes-systemd-config = versionAtLeast pkgs.iptsd.version "1.0";
 
 in {
   options.microsoft-surface.ipts = {
@@ -17,7 +17,7 @@ in {
       microsoft-surface.ipts.enable = mkDefault false;
     }
 
-    (mkIf (cfg.enable and !version-includes-systemd-config) {
+    (mkIf (cfg.enable && !version-includes-systemd-config) {
       systemd.services.iptsd = {
         description = "IPTSD";
         path = with pkgs; [ iptsd ];
@@ -26,7 +26,7 @@ in {
       };
     })
 
-    (mkIf (cfg.enable and version-includes-systemd-config) {
+    (mkIf (cfg.enable && version-includes-systemd-config) {
       # TODO:
       # I'm not convinced I need to add pkgs.iptsd to systemd.packages and services.udev.packages;
       # just adding it to environment.systemPackages might be good enough?
@@ -38,7 +38,7 @@ in {
       # it won't find the iptsd ones, anyway:
       # - https://github.com/NixOS/nixpkgs/blob/10e51cdc0456f1d5c8a00f026c384f0e81126538/nixos/modules/system/boot/systemd.nix#L467-L473
       systemd.packages = [
-        pkgs.ipstd
+        pkgs.iptsd
       ];
 
       # TODO:


### PR DESCRIPTION
###### Description of changes

IPTSd versions before 1.0 didn't include systemd or udev configs, but later ones do.
This PR attempts to only install a systemd service config for the earlier versions, and instead use the configs provided by `iptsd` package.

See #552 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

