### PR TITLE
init morefine-m600

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ See code for all available configurations.
 | [Microsoft Surface Laptop (AMD)](microsoft/surface/surface-laptop-amd)| `<nixos-hardware/microsoft/surface/surface-laptop-amd>`|
 | [Microsoft Surface Range (Common Modules)](microsoft/surface/common)| `<nixos-hardware/microsoft/surface/common>`        |
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                  | `<nixos-hardware/microsoft/surface-pro/3>`         |
+| [Morefine M600](morefine/m600)                                      | `<nixos-hardware/morefine/m600>`                   |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)          | `<nixos-hardware/hardkernel/odroid-hc4>`           |
 | [Omen en00015p](omen/en00015p)                                      | `<nixos-hardware/omen/en00015p>`                   |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |

--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,7 @@
       microsoft-surface-laptop-amd = import ./microsoft/surface/surface-laptop-amd;
       microsoft-surface-common = import ./microsoft/surface/common;
       microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
+      morefine-m600 = import ./morefine/m600;
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;

--- a/morefine/m600/default.nix
+++ b/morefine/m600/default.nix
@@ -1,0 +1,12 @@
+{ lib, pkgs, ...}: {
+  imports = [
+    ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
+    ../../common/gpu/amd
+  ];
+
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  # If the wireless card is not replaced
+  # boot.initrd.availableKernelModules = [ "r8169" ];
+}


### PR DESCRIPTION
The Morefine M600 is an AMD-powered Mini PC

CPU options (all 6000-series mobile):
• R9-6900HX
• R9-6850H
• R7-6850U
• R7-6800H
• R5-6600U

If bought with RAM + HDD, you would be getting DDR5 RAM @ 4800MHz and a NVMe drive, however, it can also be purchased “barebone”.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input (will do when I reboot)
