### PR TITLE
treewide: unset hardware.video.hidpi

### DIFF
--- a/common/hidpi.nix
+++ b/common/hidpi.nix
@@ -1,0 +1,12 @@
+{ lib, pkgs, ... }:
+let
+  # This option is removed from NixOS 23.05 and up
+  nixosVersion = lib.versions.majorMinor lib.version;
+  config = if lib.versionOlder nixosVersion "23.05" then {
+    hardware.video.hidpi.enable = lib.mkDefault true;
+  } else {
+    # Just set the console font, don't mess with the font settings
+    console.font = lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz";
+    console.earlySetup = lib.mkDefault true;
+  };
+in config

--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,7 @@
       common-gpu-nvidia = import ./common/gpu/nvidia/prime.nix;
       common-gpu-nvidia-nonprime = import ./common/gpu/nvidia;
       common-gpu-nvidia-disable = import ./common/gpu/nvidia/disable.nix;
+      common-hidpi = import ./common/hidpi.nix;
       common-pc = import ./common/pc;
       common-pc-hdd = import ./common/pc/hdd;
       common-pc-laptop = import ./common/pc/laptop;

--- a/gpd/p2-max/default.nix
+++ b/gpd/p2-max/default.nix
@@ -1,11 +1,9 @@
-{lib, ...}: {
+{
   imports = [
     ../../common/pc/laptop
     ../../common/pc/laptop/ssd
     ../../common/cpu/intel
     ../../common/cpu/intel/kaby-lake
+    ../../common/hidpi.nix
   ];
-
-  # HiDPI settings
-  hardware.video.hidpi.enable = lib.mkDefault true;
 }

--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -5,6 +5,7 @@ in
 	imports = [
 		../../common/pc/laptop
 		../../common/pc/laptop/ssd
+    ../../common/hidpi.nix
 	];
 
   # Necessary kernel modules
@@ -34,7 +35,6 @@ in
 	};
 
 	# More HiDPI settings
-	hardware.video.hidpi.enable = true;
 	services.xserver.dpi = 280;
 
 	# Necessary for audio support on the 1195G7 model


### PR DESCRIPTION
###### Description of changes

Seems like we can't agree on what the "good" settings are.

For older NixOS versions this is largely a no-op anyway.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

