### PR TITLE
rename hardware.video.hidpi.enable to fonts.optimizeForVeryHighDPI

### DIFF
--- a/framework/12th-gen-intel/default.nix
+++ b/framework/12th-gen-intel/default.nix
@@ -50,7 +50,7 @@
 
   # HiDPI
   # Leaving here for documentation
-  # hardware.video.hidpi.enable = lib.mkDefault true;
+  # fonts.optimizeForVeryHighDPI = lib.mkDefault true;
 
   # Fix font sizes in X
   # services.xserver.dpi = 200;

--- a/framework/default.nix
+++ b/framework/default.nix
@@ -46,7 +46,7 @@
 
   # HiDPI
   # Leaving here for documentation
-  # hardware.video.hidpi.enable = lib.mkDefault true;
+  # fonts.optimizeForVeryHighDPI = lib.mkDefault true;
 
   # Fix font sizes in X
   # services.xserver.dpi = 200;

--- a/gpd/p2-max/default.nix
+++ b/gpd/p2-max/default.nix
@@ -7,5 +7,5 @@
   ];
 
   # HiDPI settings
-  hardware.video.hidpi.enable = lib.mkDefault true;
+  fonts.optimizeForVeryHighDPI = lib.mkDefault true;
 }

--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -34,7 +34,7 @@ in
 	};
 
 	# More HiDPI settings
-	hardware.video.hidpi.enable = true;
+	fonts.optimizeForVeryHighDPI = true;
 	services.xserver.dpi = 280;
 
 	# Necessary for audio support on the 1195G7 model

--- a/lenovo/thinkpad/z/default.nix
+++ b/lenovo/thinkpad/z/default.nix
@@ -13,7 +13,7 @@
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;
   hardware.trackpoint.device = lib.mkDefault "TPPS/2 Elan TrackPoint";
-  hardware.video.hidpi.enable = lib.mkDefault true;
+  fonts.optimizeForVeryHighDPI = lib.mkDefault true;
 
   services.fprintd.enable = lib.mkDefault true;
 


### PR DESCRIPTION
###### Description of changes
rename `hardware.video.hidpi.enable` to `fonts.optimizeForVeryHighDPI`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

