### PR TITLE
lenovo-z: remove hardware.video.hidpi.enable

### DIFF
--- a/lenovo/thinkpad/z/default.nix
+++ b/lenovo/thinkpad/z/default.nix
@@ -13,7 +13,6 @@
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;
   hardware.trackpoint.device = lib.mkDefault "TPPS/2 Elan TrackPoint";
-  hardware.video.hidpi.enable = lib.mkDefault true;
 
   services.fprintd.enable = lib.mkDefault true;
 


### PR DESCRIPTION
Follows up to nixos-hardware merge request:
https://github.com/NixOS/nixos-hardware/pull/588

Which follows up nixpkgs merge request:
https://github.com/NixOS/nixpkgs/pull/222689


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

