### PR TITLE
thinkpad-z: move to hidpi module

### DIFF
--- a/lenovo/thinkpad/z/default.nix
+++ b/lenovo/thinkpad/z/default.nix
@@ -7,13 +7,13 @@
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/laptop/ssd
+    ../../../common/hidpi.nix # can be dropped after nixos 23.05
   ];
   # kernel versions prior to 5.18 won't boot
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.18") (lib.mkDefault pkgs.linuxPackages_latest);
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;
   hardware.trackpoint.device = lib.mkDefault "TPPS/2 Elan TrackPoint";
-  hardware.video.hidpi.enable = lib.mkDefault true;
 
   services.fprintd.enable = lib.mkDefault true;
 


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

