### PR TITLE
lenovo legion 7 slim 15ach6: add hidpi settings

### DIFF
--- a/lenovo/legion/15ach6/default.nix
+++ b/lenovo/legion/15ach6/default.nix
@@ -6,6 +6,7 @@ in {
     ../../../common/cpu/amd
     ../../../common/gpu/amd
     ../../../common/gpu/nvidia/prime.nix
+    ../../../common/hidpi.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];
@@ -16,6 +17,9 @@ in {
   };
 
   services.thermald.enable = lib.mkDefault true;
+
+  # √(3840² + 2160²) px / 15.60 in ≃ 282 dpi
+  services.xserver.dpi = 282;
 
   # https://wiki.archlinux.org/title/backlight#Backlight_is_always_at_full_brightness_after_a_reboot_with_amdgpu_driver
   systemd.services.fix-brightness = {


### PR DESCRIPTION
###### Description of changes

Values are taken from <https://www.digitec.ch/en/s1/product/lenovo-legion-slim-7-1560-amd-ryzen-7-5800h-32-gb-1000-gb-ch-notebook-17240001?supplier=406802>

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

