### PR TITLE
feat: add backlight support for rpi4

### DIFF
--- a/raspberry-pi/4/backlight.nix
+++ b/raspberry-pi/4/backlight.nix
@@ -1,0 +1,50 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".backlight;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".backlight = {
+      enable = lib.mkEnableOption ''
+        Enable the backlight support for the Raspberry Pi official Touch Display
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.deviceTree = {
+      overlays = [
+        # This overlay was originally taken from:
+        # https://github.com/raspberrypi/linux/blob/rpi-5.15.y/arch/arm/boot/dts/overlays/rpi-backlight-overlay.dts
+        # The only modification made was to change the compatible field to bcm2711
+        {
+          name = "rpi-backlight-overlay";
+          dtsText = ''
+            /*
+             * Devicetree overlay for mailbox-driven Raspberry Pi DSI Display
+             * backlight controller
+             */
+            /dts-v1/;
+            /plugin/;
+
+            / {
+              compatible = "brcm,bcm2711";
+
+              fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                  rpi_backlight: rpi_backlight {
+                    compatible = "raspberrypi,rpi-backlight";
+                    firmware = <&firmware>;
+                    status = "okay";
+                  };
+                };
+              };
+            };
+          '';
+        }
+      ];
+    };
+  };
+}

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -1,8 +1,9 @@
-{ lib, pkgs, ...}:
+{ lib, pkgs, ... }:
 
 {
   imports = [
     ./audio.nix
+    ./backlight.nix
     ./cpu-revision.nix
     ./dwc2.nix
     ./i2c.nix
@@ -22,6 +23,7 @@
       "vc4"
       "pcie_brcmstb"      # required for the pcie bus to work
       "reset-raspberrypi" # required for vl805 firmware to load
+      "rpi_backlight"     # required for backlight support
     ];
 
     loader = {


### PR DESCRIPTION
This commit adds support for controlling the backlight on the official touch display for the Raspberry Pi 4. Using this overlay, the brightness on the display can be controlled using the following snippet:
```
echo "55" > /sys/class/backlight/rpi_backlight/brightness
```

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

