### PR TITLE
microsoft-surface: upgrade kernel 6.1.6 to 6.1.18

### DIFF
--- a/microsoft/surface/common/kernel/default.nix
+++ b/microsoft/surface/common/kernel/default.nix
@@ -7,7 +7,7 @@ in {
   imports = [
     ./linux-5.19.17
     ./linux-6.0.17
-    ./linux-6.1.6
+    ./linux-6.1.18
   ];
 
   options.microsoft-surface.kernelVersion = mkOption {

--- a/microsoft/surface/common/kernel/linux-6.1.18/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.1.18/default.nix
@@ -8,7 +8,7 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.1.6";
+  version = "6.1.18";
   extraMeta.branch = "6.1";
   patchDir = repos.linux-surface + "/patches/${extraMeta.branch}";
   kernelPatches = pkgs.callPackage ./patches.nix {
@@ -20,17 +20,17 @@ let
     inherit version extraMeta kernelPatches;
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-      sha256 = "sha256-Pk2OVh2lcDogWujXsr7WxcZPxCme68v9IEgeY7V9XuM=";
+      sha256 = "sha256-hCrBXv8Ob7DBUP34P09qr2tMEjnc+MFOIidiDsCuFB4=";
     };
   };
 
 
 in {
   options.microsoft-surface.kernelVersion = mkOption {
-    type = types.enum [ "6.1.6" ];
+    type = types.enum [ "6.1.18" ];
   };
 
-  config = mkIf (cfg.kernelVersion == "6.1.6") {
+  config = mkIf (cfg.kernelVersion == "6.1.18") {
     boot = {
       inherit kernelPackages;
     };

--- a/microsoft/surface/common/kernel/linux-6.1.18/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.1.18/patches.nix
@@ -37,6 +37,11 @@
       SURFACE_HOTPLUG = module;
 
       #
+      # Intel Touch Host Controller
+      #
+      HID_ITHC = module;
+
+      #
       # IPTS touchscreen
       #
       # This only enables the user interface for IPTS data.
@@ -94,31 +99,47 @@
     patch = patchDir + "/0004-ipts.patch";
   }
   {
-    name = "ms-surface/0005-surface-sam";
-    patch = patchDir + "/0005-surface-sam.patch";
+    name = "ms-surface/0005-ithc";
+    patch = patchDir + "/0005-ithc.patch";
   }
   {
-    name = "ms-surface/0006-surface-sam-over-hid";
-    patch = patchDir + "/0006-surface-sam-over-hid.patch";
+    name = "ms-surface/0006-surface-sam";
+    patch = patchDir + "/0006-surface-sam.patch";
   }
   {
-    name = "ms-surface/0007-surface-button";
-    patch = patchDir + "/0007-surface-button.patch";
+    name = "ms-surface/0007-surface-sam-over-hid";
+    patch = patchDir + "/0007-surface-sam-over-hid.patch";
   }
   {
-    name = "ms-surface/0008-surface-typecover";
-    patch = patchDir + "/0008-surface-typecover.patch";
+    name = "ms-surface/0008-surface-button";
+    patch = patchDir + "/0008-surface-button.patch";
   }
   {
-    name = "ms-surface/0009-cameras";
-    patch = patchDir + "/0009-cameras.patch";
+    name = "ms-surface/0009-surface-typecover";
+    patch = patchDir + "/0009-surface-typecover.patch";
   }
   {
-    name = "ms-surface/0010-amd-gpio";
-    patch = patchDir + "/0010-amd-gpio.patch";
+    name = "ms-surface/0010-surface-shutdown";
+    patch = patchDir + "/0010-surface-shutdown.patch";
   }
   {
-    name = "ms-surface/0011-rtc";
-    patch = patchDir + "/0011-rtc.patch";
+    name = "ms-surface/0011-surface-gpe";
+    patch = patchDir + "/0011-surface-gpe.patch";
+  }
+  {
+    name = "ms-surface/0012-cameras";
+    patch = patchDir + "/0012-cameras.patch";
+  }
+  {
+    name = "ms-surface/0013-amd-gpio";
+    patch = patchDir + "/0013-amd-gpio.patch";
+  }
+  {
+    name = "ms-surface/0014-rtc";
+    patch = patchDir + "/0014-rtc.patch";
+  }
+  {
+    name = "ms-surface/0015-intel-thread-director";
+    patch = patchDir + "/0015-intel-thread-director.patch";
   }
 ]

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "91240ac43dfdfb3e68bbc604def84685a218fab9";
-    sha256 = "sha256-Jf7tthFWj67Esjx+/ZwG7BYlN7zWS26e1TbsznNxE9Q=";
+    rev = "efe7ddadd4aad3d1a6531334fe086931ec8640a1";
+    sha256 = "sha256-WgJHLY4vU4lsZ6M0hOng8TMVRALxQeSwQM4QX6DzrbI=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:

--- a/microsoft/surface/surface-go/default.nix
+++ b/microsoft/surface/surface-go/default.nix
@@ -17,7 +17,7 @@ in {
     ../../../common/cpu/intel/kaby-lake
   ];
 
-  microsoft-surface.kernelVersion = "6.1.6";
+  microsoft-surface.kernelVersion = "6.1.18";
 
   boot.kernelParams = [
     "i915.enable_rc6=1"


### PR DESCRIPTION
###### Description of changes

Update version 6.1 of the linux-surface kernel to 6.1.18.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

