### PR TITLE
Add settings for AMD Raphael iGPU

### DIFF
--- a/common/cpu/amd/raphael/igpu.nix
+++ b/common/cpu/amd/raphael/igpu.nix
@@ -1,0 +1,15 @@
+{ lib, pkgs, ... }: 
+
+{
+  # Disables scatter/gather which was introduced with kernel version 6.2
+  # It produces completely white or flashing screens when enabled while using the iGPU of Ryzen 7000-series CPUs (Raphael)
+
+  imports = [ ../. ];
+
+  boot = lib.mkMerge [
+    (lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") {
+      kernelPackages = pkgs.linuxPackages_latest;
+      kernelParams = lib.mkMerge [["amdgpu.sg_display=0"]];  
+    })
+  ];
+}

--- a/common/cpu/amd/raphael/igpu.nix
+++ b/common/cpu/amd/raphael/igpu.nix
@@ -9,7 +9,7 @@
   boot = lib.mkMerge [
     (lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") {
       kernelPackages = pkgs.linuxPackages_latest;
-      kernelParams = lib.mkMerge [["amdgpu.sg_display=0"]];  
+      kernelParams = ["amdgpu.sg_display=0"];  
     })
   ];
 }

--- a/common/cpu/amd/raphael/igpu.nix
+++ b/common/cpu/amd/raphael/igpu.nix
@@ -1,6 +1,7 @@
 { lib, pkgs, ... }: 
 
 {
+  # Sets the kernel version to the latest kernel to make the usage of the iGPU possible if your kernel version is too old
   # Disables scatter/gather which was introduced with kernel version 6.2
   # It produces completely white or flashing screens when enabled while using the iGPU of Ryzen 7000-series CPUs (Raphael)
 
@@ -10,6 +11,10 @@
     (lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") {
       kernelPackages = pkgs.linuxPackages_latest;
       kernelParams = ["amdgpu.sg_display=0"];  
+    })
+
+    (lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.2") {
+      kernelParams = ["amdgpu.sg_display=0"];
     })
   ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -168,6 +168,7 @@
 
       common-cpu-amd = import ./common/cpu/amd;
       common-cpu-amd-pstate = import ./common/cpu/amd/pstate.nix;
+      common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
       common-cpu-intel = import ./common/cpu/intel;
       common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only.nix;
       common-cpu-intel-kaby-lake = import ./common/cpu/intel/kaby-lake;


### PR DESCRIPTION
###### Description of changes

Adds settings that are necessary to be able to use the iGPU of AMD Raphael CPUs (Ryzen 7000-series).

Additional info:
- Ryzen 7000-series iGPU support came with 5.18 (afaik)
- Lowest, currently available LTS kernel with the needed support is 6.1, which works perfectly fine
- The latest LTS kernel is 6.2, which needs an additional kernel parameter to disable scatter/gather because it results in completely white or flashing screens (scatter/gather was introduced with 6.2)
- The current release candidates of 6.3 also need this parameter

Since I don't think it's sensible to use a specific version (in this case 6.1) I would rather just use the latest kernel and add the necessary parameter. Especially since 6.3 still needs it too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

