### PR TITLE
fix: add missing touch-ft5406 export to raspberry-pi config

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -11,6 +11,7 @@
     ./poe-hat.nix
     ./poe-plus-hat.nix
     ./tc358743.nix
+    ./touch-ft5406.nix
     ./pwm0.nix
     ./pkgs-overlays.nix
   ];


### PR DESCRIPTION
###### Description of changes
This option was recently added (in https://github.com/NixOS/nixos-hardware/pull/595), but the option was not exported from the RPi 4 config.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input

