### PR TITLE
fix: remove rpi_backlight driver from rpi4 config

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -23,7 +23,6 @@
       "vc4"
       "pcie_brcmstb"      # required for the pcie bus to work
       "reset-raspberrypi" # required for vl805 firmware to load
-      "rpi_backlight"     # required for backlight support
     ];
 
     loader = {


### PR DESCRIPTION
###### Description of changes

This commit removes the `rpi_backlight` driver from the list of default raspberry pi 4 kernel drivers. The driver will be loaded by the `raspberry-pi."4".backlight` overlay if it is enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input

