### PR TITLE
Patch kernel for HP envy x360 ey0xxx speakers

### DIFF
--- a/hp/envy/x360/ey0xxx/default.nix
+++ b/hp/envy/x360/ey0xxx/default.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+with lib;
+{
+  config = {
+      boot.kernelPatches = [
+        {
+          name = "hp-envy-x360-ey0xxx-speaker";
+          patch = ./speaker.patch;
+        }
+      ];
+  };
+}

--- a/hp/envy/x360/ey0xxx/speaker.patch
+++ b/hp/envy/x360/ey0xxx/speaker.patch
@@ -1,0 +1,27 @@
+diff --git a/sound/pci/hda/cs35l41_hda.c b/sound/pci/hda/cs35l41_hda.c
+index 129bffb431c22..21d8c2de128ff 100644
+--- a/sound/pci/hda/cs35l41_hda.c
++++ b/sound/pci/hda/cs35l41_hda.c
+@@ -1156,7 +1156,8 @@ static int cs35l41_no_acpi_dsd(struct cs35l41_hda *cs35l41, struct device *physd
+ 	hw_cfg->valid = true;
+ 	put_device(physdev);
+ 
+-	if (strncmp(hid, "CLSA0100", 8) == 0) {
++	if ((strncmp(hid, "CLSA0100", 8) == 0) ||
++	    (strncmp(hid, "CSC3551", 7) == 0)) {
+ 		hw_cfg->bst_type = CS35L41_EXT_BOOST_NO_VSPK_SWITCH;
+ 	} else if (strncmp(hid, "CLSA0101", 8) == 0) {
+ 		hw_cfg->bst_type = CS35L41_EXT_BOOST;
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index 8a57636f622e9..e7053cbc6bb6e 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -9179,6 +9179,7 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x103c, 0x83b9, "HP Spectre x360", ALC269_FIXUP_HP_MUTE_LED_MIC3),
+ 	SND_PCI_QUIRK(0x103c, 0x841c, "HP Pavilion 15-CK0xx", ALC269_FIXUP_HP_MUTE_LED_MIC3),
+ 	SND_PCI_QUIRK(0x103c, 0x8497, "HP Envy x360", ALC269_FIXUP_HP_MUTE_LED_MIC3),
++	SND_PCI_QUIRK(0x103c, 0x8a31, "HP ENVY x360 2-in-1 Laptop 15-ey0xxx", ALC287_FIXUP_CS35L41_I2C_2),
+ 	SND_PCI_QUIRK(0x103c, 0x84da, "HP OMEN dc0019-ur", ALC295_FIXUP_HP_OMEN),
+ 	SND_PCI_QUIRK(0x103c, 0x84e7, "HP Pavilion 15", ALC269_FIXUP_HP_MUTE_LED_MIC3),
+ 	SND_PCI_QUIRK(0x103c, 0x8519, "HP Spectre x360 15-df0xxx", ALC285_FIXUP_HP_SPECTRE_X360),
+-- 


### PR DESCRIPTION
###### Description of changes
The speakers on this laptop don't work out of the box, needs a kernel patch. 



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

