### PR TITLE
Load acpi_call module only if tlp is being used

### DIFF
--- a/common/pc/laptop/acpi_call.nix
+++ b/common/pc/laptop/acpi_call.nix
@@ -1,9 +1,9 @@
 # acpi_call makes tlp work for newer thinkpads
 
-{ config, ... }:
+{ config, lib, ... }:
 
 {
-  boot = {
+  boot = lib.mkIf config.services.tlp.enable {
     kernelModules = [ "acpi_call" ];
     extraModulePackages = with config.boot.kernelPackages; [ acpi_call ];
   };


### PR DESCRIPTION
power-profiles-daemon cannot use acpi_call. This avoids taining the kernel by installing an unnecessary kernel module.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

