### PR TITLE
Lenovo legion 7i 16ithg6: add hidpi settings

### DIFF
--- a/lenovo/legion/16ithg6/default.nix
+++ b/lenovo/legion/16ithg6/default.nix
@@ -6,6 +6,7 @@
     ../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../../common/hidpi.nix
   ];
 
   # Specify bus id of Nvidia and Intel graphics.
@@ -16,4 +17,7 @@
 
   # Cooling management
   services.thermald.enable = lib.mkDefault true;
+
+  # √(2560² + 1600²) px / 16 in ≃ 189 dpi
+  services.xserver.dpi = 189;
 }


### PR DESCRIPTION
###### Description of changes

Sets the dpi to a value taken from: https://www.notebookcheck.net/Lenovo-Legion-7-16ITHg6-82K600AFGE.604143.0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

