### PR TITLE
Add Starfive Visionfive 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ See code for all available configurations.
 | [Raspberry Pi 4](raspberry-pi/4)                                    | `<nixos-hardware/raspberry-pi/4>`                  |
 | [Samsung Series 9 NP900X3C](samsung/np900x3c)                       | `<nixos-hardware/samsung/np900x3c>`                |
 | [StarFive VisionFive v1](starfive/visionfive/v1)                    | `<nixos-hardware/starfive/visionfive/v1>`          |
+| [StarFive VisionFive 2](starfive/visionfive/v2)                     | `<nixos-hardware/starfive/visionfive/v2>`          |
 | [Supermicro A1SRi-2758F](supermicro/a1sri-2758f)                    | `<nixos-hardware/supermicro/a1sri-2758f>`          |
 | [Supermicro M11SDV-8C-LN4F](supermicro/m11sdv-8c-ln4f)              | `<nixos-hardware/supermicro/m11sdv-8c-ln4f>`       |
 | [Supermicro X10SLL-F](supermicro/x10sll-f)                          | `<nixos-hardware/supermicro/x10sll-f>`             |

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,7 @@
       kobol-helios4 = import ./kobol/helios4;
       samsung-np900x3c = import ./samsung/np900x3c;
       starfive-visionfive-v1 = import ./starfive/visionfive/v1;
+      starfive-visionfive-2 = import ./starfive/visionfive/v2;
       supermicro = import ./supermicro;
       supermicro-a1sri-2758f = import ./supermicro/a1sri-2758f;
       supermicro-m11sdv-8c-ln4f = import ./supermicro/m11sdv-8c-ln4f;

--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -1,0 +1,5 @@
+# Creating SD-Image
+
+``` nix
+
+```

--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -3,9 +3,7 @@
 Create and configure the `flake.nix` file:
 ``` nix
 {
-  # Kernel is broken on riscv64 see https://github.com/NixOS/nixpkgs/issues/225756
-  inputs.nixpkgs.url =
-    "github:nixos/nixpkgs/c3e12e57c3e3d5c84cc500420be4507b3de33e90";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, nixos-hardware, flake-utils }:

--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -5,8 +5,13 @@ Create and configure the `flake.nix` file:
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
+
+  # Some dependencies of this flake are not yet available on non linux systems
+  inputs.systems.url = "github:nix-systems/x86_64-linux";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, nixos-hardware, flake-utils }:
+  inputs.flake-utils.inputs.systems.follows = "systems";
+
+  outputs = { self, nixpkgs, nixos-hardware, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       rec {
         packages.default = packages.sd-image;

--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -1,5 +1,56 @@
-# Creating SD-Image
+# Creating a SD-Image
 
+Create and configure the `flake.nix` file:
 ``` nix
+{
+  # Kernel is broken on riscv64 see https://github.com/NixOS/nixpkgs/issues/225756
+  inputs.nixpkgs.url =
+    "github:nixos/nixpkgs/c3e12e57c3e3d5c84cc500420be4507b3de33e90";
+  inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, nixos-hardware, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      rec {
+        packages.default = packages.sd-image;
+        packages.sd-image = (import "${nixpkgs}/nixos" {
+          configuration =
+            { config, ... }: {
+              imports = [
+                "${nixos-hardware}/starfive/visionfive/v2/sd-image-installer.nix"
+              ];
 
+              # If you want to use ssh set a password
+              # users.users.nixos.password = "super secure password";
+              # OR add your public ssh key
+              # users.users.nixos.openssh.authorizedKeys.keys = [ "ssh-rsa ..." ];
+
+              # AND configure networking
+              # networking.interfaces.end0.useDHCP = true;
+              # networking.interfaces.end1.useDHCP = true;
+
+              # If you have the 2A variant uncomment the following line
+              # hardware.deviceTree.name =
+              #   lib.mkDefault "starfive/jh7110-starfive-visionfive-2-v1.2a.dtb";
+
+              # Additional configuration goes here
+
+              sdImage.compressImage = false;
+
+              nixpkgs.crossSystem = {
+                config = "riscv64-unknown-linux-gnu";
+                system = "riscv64-linux";
+              };
+
+              system.stateVersion = "23.05";
+            };
+          inherit system;
+        }).config.system.build.sdImage;
+      });
+}
+```
+
+Build the sd image.
+
+``` sh
+nix build .#
 ```

--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -5,7 +5,7 @@
       lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
     consoleLogLevel = lib.mkDefault 7;
     kernelPackages =
-      lib.mkDefault (pkgs.callPackage ./linux_6_3.nix { inherit (config.boot) kernelPatches; });
+      lib.mkDefault (pkgs.callPackage ./linux-6.3.nix { inherit (config.boot) kernelPatches; });
 
     kernelParams =
       lib.mkDefault [ "console=tty0" "console=ttyS0,115200n8" "earlycon=sbi" ];

--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -4,15 +4,14 @@
     supportedFilesystems =
       lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
     consoleLogLevel = lib.mkDefault 7;
-    kernelPackages =
-      lib.mkDefault (pkgs.callPackage ./linux-6.3.nix { inherit (config.boot) kernelPatches; });
+    kernelPackages = lib.mkDefault (pkgs.callPackage ./linux-6.3.nix {
+      inherit (config.boot) kernelPatches;
+    });
 
     kernelParams =
       lib.mkDefault [ "console=tty0" "console=ttyS0,115200n8" "earlycon=sbi" ];
 
-    initrd.availableKernelModules = [
-      "dw_mmc_starfive"
-    ];
+    initrd.availableKernelModules = [ "dw_mmc_starfive" ];
 
     loader = {
       grub.enable = lib.mkDefault false;

--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }: {
+  boot = {
+    # Force no ZFS (from nixos/modules/profiles/base.nix) until updated to kernel 6.0
+    supportedFilesystems =
+      lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
+    consoleLogLevel = lib.mkDefault 7;
+    kernelPackages =
+      lib.mkDefault (pkgs.callPackage ./linux_6_3.nix { inherit (config.boot) kernelPatches; });
+
+    kernelParams =
+      lib.mkDefault [ "console=tty0" "console=ttyS0,115200n8" "earlycon=sbi" ];
+
+    initrd.availableKernelModules = [
+      "dw_mmc_starfive"
+    ];
+
+    loader = {
+      grub.enable = lib.mkDefault false;
+      generic-extlinux-compatible.enable = lib.mkDefault true;
+    };
+
+  hardware.deviceTree.name =
+    lib.mkDefault "starfive/jh7110-starfive-visionfive-2-v1.3b.dtb";
+  };
+}

--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -18,8 +18,8 @@
       grub.enable = lib.mkDefault false;
       generic-extlinux-compatible.enable = lib.mkDefault true;
     };
+  };
 
   hardware.deviceTree.name =
     lib.mkDefault "starfive/jh7110-starfive-visionfive-2-v1.3b.dtb";
-  };
 }

--- a/starfive/visionfive/v2/firmware.nix
+++ b/starfive/visionfive/v2/firmware.nix
@@ -1,0 +1,56 @@
+{ callPackage, runCommand, writeText, stdenv, dtc }:
+let
+  uboot = callPackage ./uboot.nix { };
+  opensbi = callPackage ./opensbi.nix {
+    withPayload = "${uboot}/u-boot.bin";
+    withFDT = "${uboot}/starfive_visionfive2.dtb";
+  };
+  spl-tool = callPackage ./spl-tool.nix { };
+  its-file = writeText "visionfive2-uboot-fit-image.its" ''
+    /dts-v1/;
+
+    / {
+      description = "U-boot-spl FIT image for JH7110 VisionFive2";
+      #address-cells = <2>;
+
+      images {
+        firmware {
+          description = "u-boot";
+          data = /incbin/("${opensbi}/share/opensbi/lp64/generic/firmware/fw_payload.bin");
+          type = "firmware";
+          arch = "riscv";
+          os = "u-boot";
+          load = <0x0 0x40000000>;
+          entry = <0x0 0x40000000>;
+          compression = "none";
+        };
+      };
+
+      configurations {
+        default = "config-1";
+
+        config-1 {
+          description = "U-boot-spl FIT config for JH7110 VisionFive2";
+          firmware = "firmware";
+        };
+      };
+    };
+  '';
+in {
+  inherit opensbi uboot;
+  spl = runCommand "starfive-visionfive2-spl" { } ''
+    mkdir -p $out/share/starfive-visionfive2/
+    ln -s ${uboot}/u-boot-spl.bin .
+    ${spl-tool}/bin/spl_tool -c -f ./u-boot-spl.bin
+    cp u-boot-spl.bin.normal.out $out/share/starfive-visionfive2/spl.bin
+  '';
+  uboot-fit-image = stdenv.mkDerivation {
+    name = "starfive-visionfive2-uboot-fit-image";
+    nativeBuildInputs = [ dtc ];
+    phases = [ "installPhase" ];
+    installPhase = ''
+      mkdir -p $out/share/starfive-visionfive2/
+      ${uboot}/mkimage -f ${its-file} -A riscv -O u-boot -T firmware $out/share/starfive-visionfive2/visionfive2_fw_payload.img
+    '';
+  };
+}

--- a/starfive/visionfive/v2/fix-memory-size.patch
+++ b/starfive/visionfive/v2/fix-memory-size.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+index 752bb0b6fd00..93670da6cabd 100644
+--- a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
++++ b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+@@ -30,7 +30,7 @@ cpus {
+ 
+ 	memory@40000000 {
+ 		device_type = "memory";
+-		reg = <0x0 0x40000000 0x1 0x0>;
++		reg = <0x0 0x40000000 0x2 0x0>;
+ 	};
+ 
+ 	thermal-zones {

--- a/starfive/visionfive/v2/linux-6.3.nix
+++ b/starfive/visionfive/v2/linux-6.3.nix
@@ -1,7 +1,7 @@
 { lib, callPackage, linuxPackagesFor, kernelPatches, fetchpatch, ... }:
 
 let
-  modDirVersion = "6.3.0-rc3";
+  modDirVersion = "6.3.0-rc4";
   linuxPkg = { lib, fetchFromGitHub, buildLinux, ... }@args:
     buildLinux (args // {
       version = "${modDirVersion}-starfive-visionfive2";
@@ -9,8 +9,8 @@ let
       src = fetchFromGitHub {
         owner = "starfive-tech";
         repo = "linux";
-        rev = "2a6909fb414dfc72ae391791ec6edc3eedd13e6f";
-        sha256 = "sha256-FeY6N+hk0PTpuIuA1hkcS+B+ozn6iHV6YaRVx1kuYHc=";
+        rev = "a57bdb1d13f93c8fc1b3c668cc74d585bb20f3f8";
+        sha256 = "sha256-jnQnJChIGCyJt+zwGfUTsMhrwmWek/ngIM6Pae6OXuI=";
       };
 
       inherit modDirVersion;

--- a/starfive/visionfive/v2/linux-6.3.nix
+++ b/starfive/visionfive/v2/linux-6.3.nix
@@ -14,7 +14,16 @@ let
       };
 
       inherit modDirVersion;
-      kernelPatches = [{ patch = ./fix-memory-size.patch; }] ++ kernelPatches;
+      kernelPatches = [
+        { patch = ./fix-memory-size.patch; }
+        {
+          patch = fetchpatch {
+            url =
+              "https://github.com/torvalds/linux/commit/d83806c4c0cccc0d6d3c3581a11983a9c186a138.diff";
+            hash = "sha256-xUnEJkzQRIIBF/0GIpS0Cd+h6OdSiJlyva5xwxtleE0=";
+          };
+        }
+      ] ++ kernelPatches;
 
       structuredExtraConfig = with lib.kernel; {
         PL330_DMA = no;

--- a/starfive/visionfive/v2/linux_6_3.nix
+++ b/starfive/visionfive/v2/linux_6_3.nix
@@ -1,0 +1,28 @@
+{ lib, callPackage, linuxPackagesFor, kernelPatches, fetchpatch, ... }:
+
+let
+  modDirVersion = "6.3.0-rc3";
+  linuxPkg = { lib, fetchFromGitHub, buildLinux, ... }@args:
+    buildLinux (args // {
+      version = "${modDirVersion}-starfive-visionfive2";
+
+      src = fetchFromGitHub {
+        owner = "starfive-tech";
+        repo = "linux";
+        rev = "2a6909fb414dfc72ae391791ec6edc3eedd13e6f";
+        sha256 = "sha256-FeY6N+hk0PTpuIuA1hkcS+B+ozn6iHV6YaRVx1kuYHc=";
+      };
+
+      inherit modDirVersion;
+      kernelPatches = [{ patch = ./fix-memory-size.patch; }] ++ kernelPatches;
+
+      structuredExtraConfig = with lib.kernel; {
+        PL330_DMA = no;
+        PINCTRL_STARFIVE_JH7110_SYS = yes;
+        SERIAL_8250_DW = yes;
+      };
+
+      extraMeta.branch = "JH7110_VisionFive2_upstream";
+    } // (args.argsOverride or { }));
+
+in lib.recurseIntoAttrs (linuxPackagesFor (callPackage linuxPkg { }))

--- a/starfive/visionfive/v2/opensbi.nix
+++ b/starfive/visionfive/v2/opensbi.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, withPlatform ? "generic"
+, withPayload ? null
+, withFDT ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "opensbi";
+  version = "1.3-git-2868f26";
+
+  src = fetchFromGitHub {
+    owner = "riscv-software-src";
+    repo = "opensbi";
+    rev = "2868f26131308ff345382084681ea89c5b0159f1";
+    sha256 = "sha256-E+nVFLSpH6lQ2nVmMlVRTr7qYRVY0ULW7gUvAyTr90I=";
+  };
+
+  postPatch = ''
+    patchShebangs ./scripts
+  '';
+
+  nativeBuildInputs = [ python3 ];
+
+  installFlags = [
+    "I=$(out)"
+  ];
+
+  makeFlags = [
+    "PLATFORM=${withPlatform}"
+    "FW_TEXT_START=0x40000000"
+  ] ++ lib.optionals (withPayload != null) [
+    "FW_PAYLOAD_PATH=${withPayload}"
+  ] ++ lib.optionals (withFDT != null) [
+    "FW_FDT_PATH=${withFDT}"
+  ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+}

--- a/starfive/visionfive/v2/sd-image-installer.nix
+++ b/starfive/visionfive/v2/sd-image-installer.nix
@@ -1,0 +1,11 @@
+{ modulesPath, ... }:
+{
+  imports = [
+    "${modulesPath}/profiles/installation-device.nix"
+    ./sd-image.nix
+  ];
+
+  # The installation media is also the installation target,
+  # so we don't want to provide the installation configuration.nix.
+  installer.cloneConfig = false;
+}

--- a/starfive/visionfive/v2/sd-image.nix
+++ b/starfive/visionfive/v2/sd-image.nix
@@ -1,0 +1,51 @@
+{ config, pkgs, lib, modulesPath, ... }:
+
+let
+  firmware = pkgs.callPackage ./firmware.nix { };
+in {
+  imports = [
+    "${modulesPath}/profiles/base.nix"
+    "${modulesPath}/installer/sd-card/sd-image.nix"
+    ./default.nix
+  ];
+
+  sdImage = {
+    imageName =
+      "${config.sdImage.imageBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}-starfive-visionfive2.img";
+
+    # Overridden by postBuildCommands
+    populateFirmwareCommands = "";
+
+    firmwarePartitionOffset = 4;
+    firmwareSize = 4;
+
+    postBuildCommands = ''
+      # preserve root partition
+      eval $(partx $img -o START,SECTORS --nr 2 --pairs)
+
+      # increase image size for gpt backup header
+      truncate -s '+2M' $img
+
+      sfdisk $img <<EOF
+          label: gpt
+          unit: sectors
+          sector-size: 512
+
+          start=4096, size=4096, type=2E54B353-1271-4842-806F-E436D6AF6985
+          start=8192, size=8192, type=5B193300-FC78-40CD-8002-E86C45580B47
+          start=$START, size=$SECTORS, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, attrs="LegacyBIOSBootable"
+      EOF
+
+      eval $(partx $img -o START,SECTORS --nr 1 --pairs)
+      dd conv=notrunc if=${firmware.spl}/share/starfive-visionfive2/spl.bin of=$img seek=$START count=$SECTORS
+
+      eval $(partx $img -o START,SECTORS --nr 2 --pairs)
+      dd conv=notrunc if=${firmware.uboot-fit-image}/share/starfive-visionfive2/visionfive2_fw_payload.img of=$img seek=$START count=$SECTORS
+    '';
+
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
+    '';
+  };
+}

--- a/starfive/visionfive/v2/spl-tool.nix
+++ b/starfive/visionfive/v2/spl-tool.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec{
+  pname = "spi_tool";
+  version = "0x01010101";
+  src = fetchFromGitHub {
+    owner = "starfive-tech";
+    repo = "soft_3rdpart";
+    rev = "cd7b50cd9f9eca66c23ebd19f06a172ce0be591f";
+    sha256 = "sha256-hRmP74gz0Y9KnSwXCjxEiArJE+FonI9rGghZTK54qGs=";
+    sparseCheckout = [ "spl_tool" ];
+  };
+  sourceRoot = "source/spl_tool";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp spl_tool $out/bin
+  '';
+}

--- a/starfive/visionfive/v2/spl-tool.nix
+++ b/starfive/visionfive/v2/spl-tool.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec{
   src = fetchFromGitHub {
     owner = "starfive-tech";
     repo = "soft_3rdpart";
-    rev = "cd7b50cd9f9eca66c23ebd19f06a172ce0be591f";
-    sha256 = "sha256-hRmP74gz0Y9KnSwXCjxEiArJE+FonI9rGghZTK54qGs=";
+    rev = "89ff3396250538548643c3322f74640712b80893";
+    sha256 = "sha256-Ni3pBWKgr4bYJb/uJ+5EbSQl6JwWoO2lZFk2Xpi63IA=";
     sparseCheckout = [ "spl_tool" ];
   };
   sourceRoot = "source/spl_tool";

--- a/starfive/visionfive/v2/uboot.nix
+++ b/starfive/visionfive/v2/uboot.nix
@@ -6,8 +6,8 @@ buildUBoot {
   src = fetchFromGitHub {
     owner = "starfive-tech";
     repo = "u-boot";
-    rev = "688befadf1d337dee3593e6cc0fe1c737cc150bd";
-    sha256 = "sha256-RGADEJRZyuzjblxowdHnhj78eMJBIWnvkwEcpSen5Oo=";
+    rev = "ac0ac696256abf412826d74ee918dd417e207d7b";
+    sha256 = "sha256-cyEMKkTIiET8hnWgD6poZSzfjmRAqUtyRQM0yvNY230=";
   };
 
   defconfig = "starfive_visionfive2_defconfig";

--- a/starfive/visionfive/v2/uboot.nix
+++ b/starfive/visionfive/v2/uboot.nix
@@ -1,0 +1,20 @@
+{ fetchFromGitHub, buildUBoot }:
+
+buildUBoot {
+  version = "2021.10";
+
+  src = fetchFromGitHub {
+    owner = "starfive-tech";
+    repo = "u-boot";
+    rev = "688befadf1d337dee3593e6cc0fe1c737cc150bd";
+    sha256 = "sha256-RGADEJRZyuzjblxowdHnhj78eMJBIWnvkwEcpSen5Oo=";
+  };
+
+  defconfig = "starfive_visionfive2_defconfig";
+  filesToInstall = [
+    "u-boot.bin"
+    "arch/riscv/dts/starfive_visionfive2.dtb"
+    "spl/u-boot-spl.bin"
+    "tools/mkimage"
+  ];
+}


### PR DESCRIPTION
###### Description of changes
This PR add support for Starfive Visionfive 2 development board.
It uses the `JH7110_VisionFive2_upstream` kernel from Starfive. This kernel has support for only a minimal amount of hardware features (no display, ...). The SD-Image works without having to flash a new bootloader :).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I tested the README example.
