### PR TITLE
Add Microchip Icicle-kit board support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ See code for all available configurations.
 | [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                   | `<nixos-hardware/lenovo/yoga/6/13ALC6>`            |
 | [MSI GS60 2QE](msi/gs60)                                            | `<nixos-hardware/msi/gs60>`                        |
 | [MSI GL62/CX62](msi/gl62)                                           | `<nixos-hardware/msi/gl62>`                        |
+| [Micrchip Icicle Kit](microchip/icicle-kit)                         | `<nixos-hardware/microchip/icicle-kit>`            |
 | [Microsoft Surface Go](microsoft/surface/surface-go)                | `<nixos-hardware/microsoft/surface/surface-go>`    |
 | [Microsoft Surface Pro (Intel)](microsoft/surface/surface-pro-intel)| `<nixos-hardware/microsoft/surface/surface-pro-intel>`|
 | [Microsoft Surface Laptop (AMD)](microsoft/surface/surface-laptop-amd)| `<nixos-hardware/microsoft/surface/surface-laptop-amd>`|

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,7 @@
       lenovo-thinkpad-z13 = import ./lenovo/thinkpad/z/z13;
       lenovo-yoga-6-13ALC6 = import ./lenovo/yoga/6/13ALC6;
       letsnote-cf-lx4 = import ./panasonic/letsnote/cf-lx4;
+      microchip-icicle-kit = import ./microchip/icicle-kit;
       microsoft-surface-go = import ./microsoft/surface/surface-go;
       microsoft-surface-pro-intel = import ./microsoft/surface/surface-pro-intel;
       microsoft-surface-laptop-amd = import ./microsoft/surface/surface-laptop-amd;

--- a/microchip/README.md
+++ b/microchip/README.md
@@ -1,0 +1,17 @@
+# Microchip Icicle-kit board support
+
+## 1. Supported devices
+ - [Microchip Icicle Kit](https://www.microchip.com/en-us/development-tool/MPFS-ICICLE-KIT-ES) (**mpfs-icicle-kit**) - device-specific U-boot and Linux kernel, nixos configuration example.
+
+## 2. How to use?
+Currently this overlay is used for generating bootable NixOS SD images.
+
+Code snippet example that enables icicle-kit configuration:
+```
+{ nixos-hardware, }: {
+  system = "aarch64-linux";
+  modules = [
+    nixos-hardware.nixosModules.icicle-kit
+  ];
+}
+```

--- a/microchip/common/bsp/hss-payload-generator.nix
+++ b/microchip/common/bsp/hss-payload-generator.nix
@@ -1,0 +1,50 @@
+{ pkgs, ...}:
+with pkgs;
+stdenv.mkDerivation rec {
+  pname = "hss";
+  version = "v2022.09";
+
+  src = fetchFromGitHub {
+    owner = "polarfire-soc";
+    repo = "hart-software-services";
+    rev = version;
+    sha256 = "sha256-j/nda7//CjJW09zt/YrBy6h+q+VKE5t/ueXxDzwVWQ0=";
+  };
+
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+  ];
+
+  nativeBuildInputs = with buildPackages; [
+    libyaml
+    elfutils
+    openssl
+    zlib
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    substituteInPlace ./tools/hss-payload-generator/Makefile \
+      --replace "/bin/bash" "bash"
+
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C ./tools/hss-payload-generator
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp ./tools/hss-payload-generator/hss-payload-generator $out
+
+    runHook postConfigure
+  '';
+}

--- a/microchip/common/bsp/linux-icicle-kit.nix
+++ b/microchip/common/bsp/linux-icicle-kit.nix
@@ -1,0 +1,69 @@
+{ pkgs, ... } @ args:
+
+with pkgs;
+
+buildLinux (args // rec {
+  version = "5.15.92-linux4microchip+fpga-2023.02";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+  modDirVersion = version;
+
+  defconfig = "mpfs_defconfig";
+
+  kernelPatches = [
+  ];
+
+  autoModules = false;
+
+  extraConfig = ''
+    OF_OVERLAY y
+    OF_CONFIGFS y
+    MFD_SENSEHAT_CORE m
+    INPUT_JOYDEV m
+    INPUT_JOYSTICK y
+    JOYSTICK_SENSEHAT m
+    AUXDISPLAY y
+    SENSEHAT_DISPLAY m
+    HTS221 m
+    IIO_ST_PRESS m
+    IIO_ST_LSM6DSX m
+    IIO_ST_MAGN_3AXIS m
+    POLARFIRE_SOC_DMA_NONCOHERENT y
+    MTD_SPI_NOR_USE_4K_SECTORS n
+    MTD_UBI y
+    MTD_CMDLINE_PARTS y
+    UBIFS_FS y
+    USB_UAS m
+    CRYPTO_TLS m
+    TLS y
+    MD y
+    BLK_DEV_MD m
+    MD_AUTODETECT y
+    MD_RAID0 m
+    MD_RAID1 m
+    MD_RAID10 m
+    MD_RAID456 m
+    DM_VERITY m
+    LOGO y
+    FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+    FB_EFI n
+    EFI_STUB y
+    EFI y
+    VIRTIO y
+    VIRTIO_PCI y
+    VIRTIO_BLK y
+    DRM_VIRTIO_GPU y
+    EXT4_FS y
+    USBIP_CORE m
+    USBIP_VHCI_HCD m
+    USBIP_HOST m
+    USBIP_VUDC m
+  '';
+
+  src = fetchFromGitHub {
+    owner = "linux4microchip";
+    repo = "linux";
+    rev = "360a547daec2a69169be49d3da9cca8b1ecb325f";
+    sha256 = "sha256-ri2d91bHmcFkV2PjwRNho1XQixKttJKoG/qiOdeB01M=";
+  };
+} // (args.argsOverride or { }))

--- a/microchip/common/bsp/patches/0001-Boot-environment-for-Microchip-Iciclle-Kit.patch
+++ b/microchip/common/bsp/patches/0001-Boot-environment-for-Microchip-Iciclle-Kit.patch
@@ -1,0 +1,26 @@
+From 2085960b5dfc7058d572cfb90fa349efe9bacdf2 Mon Sep 17 00:00:00 2001
+From: Ganga Ram <ganga.jaiswal@gmail.com>
+Date: Mon, 24 Apr 2023 10:15:22 +0400
+Subject: [PATCH] Boot environment for Microchip Iciclle Kit
+
+Signed-off-by: Ganga Ram <ganga.jaiswal@gmail.com>
+---
+ include/configs/microchip_mpfs_icicle.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/configs/microchip_mpfs_icicle.h b/include/configs/microchip_mpfs_icicle.h
+index 9ef5425c9f..c8a1f7c9df 100644
+--- a/include/configs/microchip_mpfs_icicle.h
++++ b/include/configs/microchip_mpfs_icicle.h
+@@ -71,6 +71,9 @@
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+	"bootm_size=0x10000000\0" \
+	"scriptaddr=0x8e000000\0" \
++  "kernel_addr_r=0x8e000000\0" \
++  "ramdisk_addr_r=0x90000000\0" \
++  "fdt_addr_r=0x92000000\0" \
+	BOOTENV_DESIGN_OVERLAYS \
+	BOOTENV \
+
+--
+2.39.2

--- a/microchip/common/bsp/uboot.nix
+++ b/microchip/common/bsp/uboot.nix
@@ -1,0 +1,32 @@
+{
+  pkgs, targetBoard, ...
+}:
+
+with pkgs; let
+  payload-generator = pkgs.callPackage ./hss-payload-generator.nix {};
+  payload_config = ./uboot.yaml;
+in
+buildUBoot rec {
+  pname = "uboot";
+  version = "linux4microchip+fpga-2023.02";
+
+  src = fetchFromGitHub {
+    owner = "polarfire-soc";
+    repo = "u-boot";
+    rev = "b356a897b11ef19dcbe7870530f23f3a978c1714";
+    sha256 = "sha256-ouNLnDBeEsaY/xr5tAVBUtLlj0eylWbKdlU+bQ2Ciq4=";
+  };
+
+  extraMakeFlags = [
+          "OPENSBI=${opensbi}/share/opensbi/lp64/generic/firmware/fw_dynamic.bin"
+  ];
+
+  patches = [ ./patches/0001-Boot-environment-for-Microchip-Iciclle-Kit.patch ];
+  defconfig = "${targetBoard}_defconfig";
+  enableParallelBuilding = true;
+  extraMeta.platforms = ["riscv64-linux"];
+  postBuild = ''
+        ${payload-generator}/hss-payload-generator -c ${payload_config} payload.bin
+        '';
+  filesToInstall = [ "payload.bin" ];
+}

--- a/microchip/common/bsp/uboot.yaml
+++ b/microchip/common/bsp/uboot.yaml
@@ -1,0 +1,36 @@
+#
+# HSS Payload Generator - sample configuration file
+#
+
+# First, we can optionally set a name for our image, otherwise one will be created
+# dynamically
+set-name: 'PolarFire-SoC-HSS::U-Boot'
+
+#
+# Next, we'll define the entry point addresses for each hart, as follows:
+#
+hart-entry-points: {u54_1: '0x80200000', u54_2: '0x80200000', u54_3: '0x80200000', u54_4: '0x80200000'}
+
+#
+# Finally, we'll define some payloads (source ELF files) that will be placed at certain
+# regions in memory
+# The payload section is defined with the keyword payloads, and then a number of
+# individual
+# payload descriptors.
+#
+# Each payload has a name (path to its ELF file), an owner-hart, and optionally 1-3
+# secondary-harts.
+#
+# Additionally, it has a privilege mode in which it will start execution.
+#  * Valid privilege modes are PRV_M, PRV_S and PRV_U.
+#
+#
+# In the following example:
+#  * test/u-boot-icicle-kit-es-2020.10-r0.bin is the Das U-Boot bootloader (binary +
+#    concatenated DTB), and it runs on U54_1, U54_2 and U54_4.
+#    It expects to start in PRV_S.
+#
+# Case only matters for the ELF path names, not the keywords.
+#
+payloads:
+  u-boot.bin: {exec-addr: '0x80200000', owner-hart: u54_1, secondary-hart: u54_2, secondary-hart: u54_3, secondary-hart: u54_4, priv-mode: prv_s}

--- a/microchip/common/modules.nix
+++ b/microchip/common/modules.nix
@@ -1,0 +1,11 @@
+{ pkgs, lib, ... }: {
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  boot = {
+    kernelPackages = pkgs.linuxPackagesFor pkgs.linux-icicle-kit;
+    initrd.includeDefaultModules = lib.mkForce false;
+  };
+
+}

--- a/microchip/common/modules.nix
+++ b/microchip/common/modules.nix
@@ -1,10 +1,6 @@
 { pkgs, lib, ... }: {
-  nixpkgs.overlays = [
-    (import ./overlay.nix)
-  ];
-
   boot = {
-    kernelPackages = pkgs.linuxPackagesFor pkgs.linux-icicle-kit;
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/linux-icicle-kit.nix { });
     initrd.includeDefaultModules = lib.mkForce false;
   };
 

--- a/microchip/common/overlay.nix
+++ b/microchip/common/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  linux-icicle-kit = final.callPackage ./bsp/linux-icicle-kit.nix { pkgs = final; boot = prev.uboot-icicle-kit; };
+}

--- a/microchip/common/overlay.nix
+++ b/microchip/common/overlay.nix
@@ -1,3 +1,0 @@
-final: prev: {
-  linux-icicle-kit = final.callPackage ./bsp/linux-icicle-kit.nix { pkgs = final; boot = prev.uboot-icicle-kit; };
-}

--- a/microchip/icicle-kit/default.nix
+++ b/microchip/icicle-kit/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, lib, ... }:
+
+{
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  imports = [
+    ../common/modules.nix
+  ];
+
+  hardware.deviceTree = {
+    name = "microchip/mpfs-icicle-kit.dtb";
+  };
+}

--- a/microchip/icicle-kit/overlay.nix
+++ b/microchip/icicle-kit/overlay.nix
@@ -1,0 +1,3 @@
+final: _prev: {
+  uboot-icicle-kit = final.callPackage ./../common/bsp/uboot.nix { pkgs = final; targetBoard = "microchip_mpfs_icicle";};
+}


### PR DESCRIPTION
* Uses Linux kernel released by Microchip
  - https://github.com/linux4microchip/linux.git
  - Ver: v5.15   Tag: linux4microchip+fpga-2023.02
* Uses UBoot released by Microchip
  - Ver: uboot-2022-01 Tag: linux4microchip+fpga-2023.02

To generate NixOS sd image for MICROCHIP icicle-kit refer:
  https://github.com/tiiuae/ghaf.git

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [y] Tested the changes in your own NixOS Configuration
- [y] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

