### PR TITLE
hardkernel/odroid-hc4: fix fancontrol on 5.15 kernel

### DIFF
--- a/hardkernel/odroid-hc4/default.nix
+++ b/hardkernel/odroid-hc4/default.nix
@@ -1,22 +1,28 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
   # Based on the config from https://www.armbian.com/odroid-hc4/
   hardware.fancontrol = {
     enable = lib.mkDefault true;
-    config = lib.mkDefault ''
+    config = let
+      # According to https://www.armbian.com/odroid-hc4/ the FCFANS line should be removed on kernel 5.15.
+      kernelVersion = config.boot.kernelPackages.kernel.version;
+      needFcFans = lib.versions.majorMinor kernelVersion != "5.15";
+    in lib.mkDefault (''
       INTERVAL=10
       DEVPATH=hwmon0=devices/virtual/thermal/thermal_zone0 hwmon2=devices/platform/pwm-fan
       DEVNAME=hwmon0=cpu_thermal hwmon2=pwmfan
       FCTEMPS=hwmon2/pwm1=hwmon0/temp1_input
+    '' + lib.optionalString needFcFans ''
       FCFANS= hwmon2/pwm1=hwmon2/fan1_input
+    '' + ''
       MINTEMP=hwmon2/pwm1=50
       MAXTEMP=hwmon2/pwm1=60
       MINSTART=hwmon2/pwm1=20
       MINSTOP=hwmon2/pwm1=28
       MINPWM=hwmon2/pwm1=0
       MAXPWM=hwmon2/pwm1=255
-    '';
+    '');
   };
 
   # Linux 5.15 sometimes crash under heavy network usage


### PR DESCRIPTION
###### Description of changes

Source for the fancontrol config mentions that one of the lines should be deleted for the 5.15 kernel.

Fixes #616.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I tested on 5.15 only, sadly couldn't test other versions. I verified that `fancontrol` runs successfully and also that its config file is as expected. Also ran `./tests/run.py '<nixos-hardware/hardkernel/odroid-hc4>'`.