### PR TITLE
nxp-imx8: drop kernel overlay

### DIFF
--- a/nxp/common/modules.nix
+++ b/nxp/common/modules.nix
@@ -1,12 +1,8 @@
 { pkgs, lib, ... }: {
-  nixpkgs.overlays = [
-    (import ./overlay.nix)
-  ];
-
   nixpkgs.hostPlatform = "aarch64-linux";
 
   boot = {
-    kernelPackages = pkgs.linuxPackagesFor pkgs.linux_imx8;
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/linux-imx8.nix { });
     kernelParams = [ "console=ttyLP0,115200n8" ];
     loader.grub.enable = lib.mkDefault true;
     initrd.includeDefaultModules = lib.mkForce false;

--- a/nxp/common/overlay.nix
+++ b/nxp/common/overlay.nix
@@ -1,3 +1,0 @@
-final: prev: {
-  linux_imx8 = final.callPackage ./bsp/linux-imx8.nix { pkgs = final; };
-}

--- a/nxp/imx8qm-mek/default.nix
+++ b/nxp/imx8qm-mek/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, ... }:
 
 {
   nixpkgs.overlays = [
@@ -10,7 +10,7 @@
   ];
 
   boot.loader.grub.extraFiles = {
-    "imx8qm-mek.dtb" = "${pkgs.linux_imx8}/dtbs/freescale/imx8qm-mek.dtb";
+    "imx8qm-mek.dtb" = "${pkgs.callPackage ../common/bsp/linux-imx8.nix { }}/dtbs/freescale/imx8qm-mek.dtb";
   };
 
   hardware.deviceTree = {


### PR DESCRIPTION
With overlays one cannot re-use nixpkgs across different machines, which is a performance issues. In this instance it's not really needed. Also each overlay is an expensive copy of all top-level packages.

###### Description of changes

cc @unbel13ver


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

