### PR TITLE
nxp boards: also test evaluation in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See code for all available configurations.
 | [GPD WIN 2](gpd/win-2)                                              | `<nixos-hardware/gpd/win-2>`                       |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                            | `<nixos-hardware/hp/elitebook/2560p>`              |
+| [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)         | `<nixos-hardware/nxp/imx8qm-mek>`                  |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                               | `<nixos-hardware/intel/nuc/8i7beh>`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)           | `<nixos-hardware/lenovo/ideapad/15arh05>`          |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                          | `<nixos-hardware/lenovo/ideapad/z510>`             |

--- a/tests/build-profile.nix
+++ b/tests/build-profile.nix
@@ -3,6 +3,8 @@
 let
   shim = { config, ... }: {
     boot.loader.systemd-boot.enable = !config.boot.loader.generic-extlinux-compatible.enable && !config.boot.loader.raspberryPi.enable;
+    # we forcefully disable grub here just for testing purposes, even though some profiles might still use grub in the end.
+    boot.loader.grub.enable = false;
 
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/00000000-0000-0000-0000-000000000000";


### PR DESCRIPTION
This was an oversight in https://github.com/NixOS/nixos-hardware/pull/556

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

