### PR TITLE
change default pstate mode for AMD cpus

### DIFF
--- a/common/cpu/amd/pstate.nix
+++ b/common/cpu/amd/pstate.nix
@@ -1,6 +1,6 @@
-{ lib, config, ... }: 
+{ lib, config, ... }:
 let
-   kver = config.boot.kernelPackages.kernel.version;
+  kver = config.boot.kernelPackages.kernel.version;
 in
 {
   # Enables the amd cpu scaling https://www.kernel.org/doc/html/latest/admin-guide/pm/amd-pstate.html
@@ -8,15 +8,25 @@ in
 
   imports = [ ./. ];
   boot = lib.mkMerge [
-    (lib.mkIf (
-      (lib.versionAtLeast kver "5.17")
-      && (lib.versionOlder kver "6.1")
-    ) {
-      kernelParams = [ "initcall_blacklist=acpi_cpufreq_init" ];
-      kernelModules = [ "amd-pstate" ];
-    })
-    (lib.mkIf (lib.versionAtLeast kver "6.1") {
-      kernelParams = [ "amd_pstate=passive" ];  
+    (lib.mkIf
+      (
+        (lib.versionAtLeast kver "5.17")
+        && (lib.versionOlder kver "6.1")
+      )
+      {
+        kernelParams = [ "initcall_blacklist=acpi_cpufreq_init" ];
+        kernelModules = [ "amd-pstate" ];
+      })
+    (lib.mkIf
+      (
+        (lib.versionAtLeast kver "6.1")
+        && (lib.versionOlder kver "6.3")
+      )
+      {
+        kernelParams = [ "amd_pstate=passive" ];
+      })
+    (lib.mkIf (lib.versionAtLeast kver "6.3") {
+      kernelParams = [ "amd_pstate=active" ];
     })
   ];
 }


### PR DESCRIPTION
###### Description of changes

AMD pstate now supports the active mode which is more efficient for power management.
This is active from linux 6.3 kernel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

