### PR TITLE
raspberry-pi."4": update poe hat overlay to work with newer kernel

### DIFF
--- a/raspberry-pi/4/backlight.nix
+++ b/raspberry-pi/4/backlight.nix
@@ -16,8 +16,9 @@ in
     hardware.deviceTree = {
       overlays = [
         # This overlay was originally taken from:
-        # https://github.com/raspberrypi/linux/blob/rpi-5.15.y/arch/arm/boot/dts/overlays/rpi-backlight-overlay.dts
+        # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-backlight-overlay.dts
         # The only modification made was to change the compatible field to bcm2711
+        # this is the same as for the 5.15.y kernel
         {
           name = "rpi-backlight-overlay";
           dtsText = ''

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -32,7 +32,7 @@
     };
   };
 
-  hardware.deviceTree.filter = "bcm2711-rpi-*.dtb";
+  hardware.deviceTree.filter = lib.mkDefault "bcm2711-rpi-*.dtb";
 
 
   assertions = [

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, config, ... }:
 
 {
   imports = [
@@ -33,6 +33,14 @@
   };
 
   hardware.deviceTree.filter = "bcm2711-rpi-*.dtb";
+
+
+  assertions = [
+    {
+      assertion = (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.1");
+      message = "This version of raspberry pi 4 dts overlays requires a newer kernel version (>=6.1). Please upgrade nixpkgs for this system.";
+    }
+  ];
 
   # Required for the Wireless firmware
   hardware.enableRedistributableFirmware = true;

--- a/raspberry-pi/4/modesetting.nix
+++ b/raspberry-pi/4/modesetting.nix
@@ -31,7 +31,7 @@ in
     hardware.deviceTree = {
       overlays = [
         # Equivalent to:
-        # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/cma-overlay.dts
+        # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/cma-overlay.dts
         {
           name = "rpi4-cma-overlay";
           dtsText = ''
@@ -52,7 +52,7 @@ in
           '';
         }
         # Equivalent to:
-        # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
+        # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
         {
           name = "rpi4-vc4-fkms-v3d-overlay";
           dtsText = ''

--- a/raspberry-pi/4/poe-hat.nix
+++ b/raspberry-pi/4/poe-hat.nix
@@ -27,7 +27,7 @@ in {
             /plugin/;
 
             / {
-              compatible = "brcm,bcm2835";
+              compatible = "brcm,bcm2711";
 
               fragment@0 {
                 target-path = "/";

--- a/raspberry-pi/4/poe-hat.nix
+++ b/raspberry-pi/4/poe-hat.nix
@@ -16,7 +16,7 @@ in {
 
     hardware.deviceTree = {
       overlays = [
-        # Equivalent to: https://github.com/raspberrypi/linux/blob/rpi-5.15.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+        # Equivalent to: https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
         {
           name = "rpi-poe-overlay";
           dtsText = ''
@@ -27,7 +27,7 @@ in {
             /plugin/;
 
             / {
-              compatible = "brcm,bcm2711";
+              compatible = "brcm,bcm2835";
 
               fragment@0 {
                 target-path = "/";
@@ -44,50 +44,59 @@ in {
               fragment@1 {
                 target = <&cpu_thermal>;
                 __overlay__ {
-                  trips {
-                    trip0: trip0 {
-                      temperature = <40000>;
-                      hysteresis = <2000>;
-                      type = "active";
-                    };
-                    trip1: trip1 {
-                      temperature = <45000>;
-                      hysteresis = <2000>;
-                      type = "active";
-                    };
-                    trip2: trip2 {
-                      temperature = <50000>;
-                      hysteresis = <2000>;
-                      type = "active";
-                    };
-                    trip3: trip3 {
-                      temperature = <55000>;
-                      hysteresis = <5000>;
-                      type = "active";
-                    };
-                  };
-                  cooling-maps {
-                    map0 {
-                      trip = <&trip0>;
-                      cooling-device = <&fan 0 1>;
-                    };
-                    map1 {
-                      trip = <&trip1>;
-                      cooling-device = <&fan 1 2>;
-                    };
-                    map2 {
-                      trip = <&trip2>;
-                      cooling-device = <&fan 2 3>;
-                    };
-                    map3 {
-                      trip = <&trip3>;
-                      cooling-device = <&fan 3 4>;
-                    };
-                  };
+                  polling-delay = <2000>; /* milliseconds */
                 };
               };
 
               fragment@2 {
+                target = <&thermal_trips>;
+                __overlay__ {
+                  trip0: trip0 {
+                    temperature = <40000>;
+                    hysteresis = <2000>;
+                    type = "active";
+                  };
+                  trip1: trip1 {
+                    temperature = <45000>;
+                    hysteresis = <2000>;
+                    type = "active";
+                  };
+                  trip2: trip2 {
+                    temperature = <50000>;
+                    hysteresis = <2000>;
+                    type = "active";
+                  };
+                  trip3: trip3 {
+                    temperature = <55000>;
+                    hysteresis = <5000>;
+                    type = "active";
+                  };
+                };
+              };
+
+              fragment@3 {
+                target = <&cooling_maps>;
+                __overlay__ {
+                  map0 {
+                    trip = <&trip0>;
+                    cooling-device = <&fan 0 1>;
+                  };
+                  map1 {
+                    trip = <&trip1>;
+                    cooling-device = <&fan 1 2>;
+                  };
+                  map2 {
+                    trip = <&trip2>;
+                    cooling-device = <&fan 2 3>;
+                  };
+                  map3 {
+                    trip = <&trip3>;
+                    cooling-device = <&fan 3 4>;
+                  };
+                };
+              };
+
+              fragment@4 {
                 target-path = "/__overrides__";
                 params: __overlay__ {
                   poe_fan_temp0 =		<&trip0>,"temperature:0";
@@ -104,7 +113,7 @@ in {
                 };
               };
 
-              fragment@3 {
+              fragment@5 {
                 target = <&firmware>;
                 __overlay__ {
                   fwpwm: pwm {
@@ -114,7 +123,7 @@ in {
                 };
               };
 
-              fragment@4 {
+              fragment@6 {
                 target = <&i2c0>;
                 i2c_bus: __overlay__ {
                   #address-cells = <1>;
@@ -135,14 +144,14 @@ in {
                 };
               };
 
-              fragment@5 {
+              fragment@7 {
                 target = <&i2c0if>;
                 __dormant__ {
                   status = "okay";
                 };
               };
 
-              fragment@6 {
+              fragment@8 {
                 target = <&i2c0mux>;
                 __dormant__ {
                   status = "okay";

--- a/raspberry-pi/4/poe-hat.nix
+++ b/raspberry-pi/4/poe-hat.nix
@@ -13,6 +13,8 @@ in {
 
   config = lib.mkIf cfg.enable {
     hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
+    # doesn't work for the CM module, so we exclude e.g. bcm2711-rpi-cm4.dts
+    hardware.deviceTree.filter = "bcm2711-rpi-4*.dtb";
 
     hardware.deviceTree = {
       overlays = [

--- a/raspberry-pi/4/poe-plus-hat.nix
+++ b/raspberry-pi/4/poe-plus-hat.nix
@@ -29,7 +29,7 @@ in {
             /plugin/;
 
             / {
-              compatible = "brcm,bcm2835";
+              compatible = "brcm,bcm2711";
 
               fragment@0 {
                 target-path = "/";
@@ -181,7 +181,7 @@ in {
             // Overlay for the Raspberry Pi PoE+ HAT.
 
             / {
-              compatible = "brcm,bcm2835";
+              compatible = "brcm,bcm2711";
 
               fragment@10 {
                 target-path = "/";

--- a/raspberry-pi/4/poe-plus-hat.nix
+++ b/raspberry-pi/4/poe-plus-hat.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 
-let 
+let
   cfg = config.hardware.raspberry-pi."4".poe-plus-hat;
 in {
   options.hardware = {
@@ -17,8 +17,8 @@ in {
     hardware.deviceTree = {
       overlays = [
         # Combined equivalent to:
-        # * https://github.com/raspberrypi/linux/blob/rpi-5.15.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
-        # * https://github.com/raspberrypi/linux/blob/rpi-5.15.y/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
+        # * https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+        # * https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
         {
           name = "rpi-poe-plus-overlay";
           dtsText = ''
@@ -29,7 +29,7 @@ in {
             /plugin/;
 
             / {
-              compatible = "brcm,bcm2711";
+              compatible = "brcm,bcm2835";
 
               fragment@0 {
                 target-path = "/";
@@ -46,50 +46,59 @@ in {
               fragment@1 {
                 target = <&cpu_thermal>;
                 __overlay__ {
-                  trips {
-                    trip0: trip0 {
-                      temperature = <40000>;
-                      hysteresis = <2000>;
-                      type = "active";
-                    };
-                    trip1: trip1 {
-                      temperature = <45000>;
-                      hysteresis = <2000>;
-                      type = "active";
-                    };
-                    trip2: trip2 {
-                      temperature = <50000>;
-                      hysteresis = <2000>;
-                      type = "active";
-                    };
-                    trip3: trip3 {
-                      temperature = <55000>;
-                      hysteresis = <5000>;
-                      type = "active";
-                    };
-                  };
-                  cooling-maps {
-                    map0 {
-                      trip = <&trip0>;
-                      cooling-device = <&fan 0 1>;
-                    };
-                    map1 {
-                      trip = <&trip1>;
-                      cooling-device = <&fan 1 2>;
-                    };
-                    map2 {
-                      trip = <&trip2>;
-                      cooling-device = <&fan 2 3>;
-                    };
-                    map3 {
-                      trip = <&trip3>;
-                      cooling-device = <&fan 3 4>;
-                    };
-                  };
+                  polling-delay = <2000>; /* milliseconds */
                 };
               };
 
               fragment@2 {
+                target = <&thermal_trips>;
+                __overlay__ {
+                  trip0: trip0 {
+                    temperature = <40000>;
+                    hysteresis = <2000>;
+                    type = "active";
+                  };
+                  trip1: trip1 {
+                    temperature = <45000>;
+                    hysteresis = <2000>;
+                    type = "active";
+                  };
+                  trip2: trip2 {
+                    temperature = <50000>;
+                    hysteresis = <2000>;
+                    type = "active";
+                  };
+                  trip3: trip3 {
+                    temperature = <55000>;
+                    hysteresis = <5000>;
+                    type = "active";
+                  };
+                };
+              };
+
+              fragment@3 {
+                target = <&cooling_maps>;
+                __overlay__ {
+                  map0 {
+                    trip = <&trip0>;
+                    cooling-device = <&fan 0 1>;
+                  };
+                  map1 {
+                    trip = <&trip1>;
+                    cooling-device = <&fan 1 2>;
+                  };
+                  map2 {
+                    trip = <&trip2>;
+                    cooling-device = <&fan 2 3>;
+                  };
+                  map3 {
+                    trip = <&trip3>;
+                    cooling-device = <&fan 3 4>;
+                  };
+                };
+              };
+
+              fragment@4 {
                 target-path = "/__overrides__";
                 params: __overlay__ {
                   poe_fan_temp0 =		<&trip0>,"temperature:0";
@@ -106,7 +115,7 @@ in {
                 };
               };
 
-              fragment@3 {
+              fragment@5 {
                 target = <&firmware>;
                 __overlay__ {
                   fwpwm: pwm {
@@ -116,7 +125,7 @@ in {
                 };
               };
 
-              fragment@4 {
+              fragment@6 {
                 target = <&i2c0>;
                 i2c_bus: __overlay__ {
                   #address-cells = <1>;
@@ -137,14 +146,14 @@ in {
                 };
               };
 
-              fragment@5 {
+              fragment@7 {
                 target = <&i2c0if>;
                 __dormant__ {
                   status = "okay";
                 };
               };
 
-              fragment@6 {
+              fragment@8 {
                 target = <&i2c0mux>;
                 __dormant__ {
                   status = "okay";
@@ -172,48 +181,48 @@ in {
             // Overlay for the Raspberry Pi PoE+ HAT.
 
             / {
-                compatible = "brcm,bcm2711";
+              compatible = "brcm,bcm2835";
 
-                fragment@10 {
-                    target-path = "/";
-                    __overlay__ {
-                        rpi_poe_power_supply: rpi-poe-power-supply {
-                            compatible = "raspberrypi,rpi-poe-power-supply";
-                            firmware = <&firmware>;
-                            status = "okay";
-                        };
-                    };
+              fragment@10 {
+                target-path = "/";
+                __overlay__ {
+                  rpi_poe_power_supply: rpi-poe-power-supply {
+                    compatible = "raspberrypi,rpi-poe-power-supply";
+                    firmware = <&firmware>;
+                    status = "okay";
+                  };
                 };
-                fragment@11 {
-                    target = <&poe_mfd>;
-                    __overlay__ {
-                        rpi-poe-power-supply@f2 {
-                            compatible = "raspberrypi,rpi-poe-power-supply";
-                            reg = <0xf2>;
-                            status = "okay";
-                        };
-                    };
+              };
+              fragment@11 {
+                target = <&poe_mfd>;
+                __overlay__ {
+                  rpi-poe-power-supply@f2 {
+                    compatible = "raspberrypi,rpi-poe-power-supply";
+                    reg = <0xf2>;
+                    status = "okay";
+                  };
                 };
+              };
 
-                __overrides__ {
-                    i2c =	<0>, "+5+6",
-                        <&fwpwm>,"status=disabled",
-                        <&rpi_poe_power_supply>,"status=disabled",
-                        <&i2c_bus>,"status=okay",
-                        <&poe_mfd>,"status=okay",
-                        <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-                };
+              __overrides__ {
+                i2c =	<0>, "+5+6",
+                  <&fwpwm>,"status=disabled",
+                  <&rpi_poe_power_supply>,"status=disabled",
+                  <&i2c_bus>,"status=okay",
+                  <&poe_mfd>,"status=okay",
+                  <&fan>,"pwms:0=",<&poe_mfd_pwm>;
+              };
             };
 
             &fan {
-                cooling-levels = <0 32 64 128 255>;
+              cooling-levels = <0 32 64 128 255>;
             };
 
             &params {
-                poe_fan_i2c = <&fwpwm>,"status=disabled",
-                        <&rpi_poe_power_supply>,"status=disabled",
-                        <&poe_mfd>,"status=okay",
-                        <&fan>,"pwms:0=",<&poe_mfd_pwm>;
+              poe_fan_i2c = <&fwpwm>,"status=disabled",
+                      <&rpi_poe_power_supply>,"status=disabled",
+                      <&poe_mfd>,"status=okay",
+                      <&fan>,"pwms:0=",<&poe_mfd_pwm>;
             };
           '';
         }

--- a/raspberry-pi/4/poe-plus-hat.nix
+++ b/raspberry-pi/4/poe-plus-hat.nix
@@ -13,6 +13,8 @@ in {
 
   config = lib.mkIf cfg.enable {
     hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
+    # doesn't work for the CM module, so we exclude e.g. bcm2711-rpi-cm4.dts
+    hardware.deviceTree.filter = "bcm2711-rpi-4*.dtb";
 
     hardware.deviceTree = {
       overlays = [


### PR DESCRIPTION
fixes #626

###### Description of changes

This updates the `poe` dts overlays to work with the newer kernel (6.1) on `nixpkgs` master.

~~I am unsure on how to keep `nixos-hardware` and `nixpkgs` in sync here. I suspect this update will break existing configs which aren't updated to `nixpkgs` master..~~

~~I also haven't tested the updated config on my raspberry pi 4, yet. But the config builds and _should_ work~~

EDIT:

With the assertion this PR should at least warn and not build with an incompatible kernel. 

I have also just tested this PR on my RP4b and the fan of the POE hat works without issues.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input


