### PR TITLE
samsung/np900x3c: drop deprecated synaptics

### DIFF
--- a/samsung/np900x3c/default.nix
+++ b/samsung/np900x3c/default.nix
@@ -1,7 +1,2 @@
 # TODO: use ../../common/pc/laptop
-
-{ lib, ... }:
-
-{
-  services.xserver.synaptics.enable = lib.mkDefault true;
-}
+{}


### PR DESCRIPTION
libinputs is now preferred.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

