### PR TITLE
[FocusGen1M2] Disable TPM interrupt due to upstream bug

### DIFF
--- a/focus/m2/gen1/default.nix
+++ b/focus/m2/gen1/default.nix
@@ -11,6 +11,10 @@
 
   boot.initrd.availableKernelModules = [ "xhci_pci" "ahci" "nvme" "usb_storage" "sd_mod" "rtsx_pci_sdmmc" ];
   boot.kernelModules = [ "kvm-intel" ];
+  boot.kernelParams = [
+    "tpm_tis.interrupts=0" # Upstream bug: https://bugzilla.kernel.org/show_bug.cgi?id=204121
+    # without this, kacpid worker thread consumes 100% cpu on kernels 5.15.111 and up
+  ];
   boot.blacklistedKernelModules = [ "i2c_nvidia_gpu" ];
 
   hardware.nvidia.modesetting.enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes

On older kernels up to 5.15.111 I was seeing this message:
```
[Firmware Bug]: TPM interrupt not working, polling instead

[    3.356315] irq 31: nobody cared (try booting with the "irqpoll" option)
```
Since, apart from that there was no other issues I ignored it.

After 5.15.111 kacpid worker thread started to consume 100% CPU. 
Disabling pooling fixes that issue. 

Upstream bug:
https://bugzilla.kernel.org/show_bug.cgi?id=204121

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

