### PR TITLE
hp.14-df0023: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ See code for all available configurations.
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                            | `<nixos-hardware/hp/elitebook/2560p>`              |
 | [HP Elitebook 845g9](hp/elitebook/845/g9)                           | `<nixos-hardware/hp/elitebook/845/g9>`             |
+| [HP Notebook 14-df0023](hp/notebook/14-df0023)                      | `<nixos-hardware/hp/notebook/14-df0023>`           |
 | [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)         | `<nixos-hardware/nxp/imx8qm-mek>`                  |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                               | `<nixos-hardware/intel/nuc/8i7beh>`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)           | `<nixos-hardware/lenovo/ideapad/15arh05>`          |

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
       gpd-win-2 = import ./gpd/win-2;
       hp-elitebook-2560p = import ./hp/elitebook/2560p;
       hp-elitebook-845g9 = import ./hp/elitebook/845/g9;
+      hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
       intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
       lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;

--- a/hp/notebook/14-df0023/default.nix
+++ b/hp/notebook/14-df0023/default.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+with lib;
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/cpu/intel/sandy-bridge
+    ../../../common/pc
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/hdd
+    ../../../common/pc/hdd
+  ];
+
+  config = {
+    services.thermald.enable = mkDefault true;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add new hardware configuration for the HP Notebook 14-df0023, my main machine.

Hardware spec: https://support.hp.com/us-en/document/c06166782

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input