### PR TITLE
lenovo-thinkpad-x1-6th-gen: swap throttled with thermald

### DIFF
--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -17,5 +17,5 @@
   # See also https://certification.ubuntu.com/catalog/component/input/5313/input%3ATPPS/2ElanTrackPoint/
   hardware.trackpoint.device = "TPPS/2 Elan TrackPoint";
 
-  services.throttled.enable = lib.mkDefault true;
+  services.thermald.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
###### Description of changes

According to https://wiki.archlinux.org/title/Lenovo_ThinkPad_X1_Carbon_(Gen_6)#Using_thermald, using newer thermald + newer kernel (which we have since 22.11) should be enough to workaround the throttling issue. `thermald` comes from intel and it seems to be better maintained than `throttled`, so I propose we switch to that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

