### PR TITLE
starfive visionfive2: Add firmware update script.

### DIFF
--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -83,3 +83,31 @@ hardware.deviceTree.overlays = [{
     "${nixos-hardware}/starfive/visionfive/v2/visionfive-2-v1.2a-8GB.dts";
 }];
 ```
+# Updating the bootloader
+## SD-Card
+Install the firmware update script
+``` nix
+environment.systemPackages = [
+  (pkgs.callPackage
+    "${nixos-hardware}/starfive/visionfive/v2/firmware.nix"
+    { }).updater-sd
+];
+```
+Then run as root
+``` sh
+visionfive2-firmware-update-sd
+```
+## SPI Flash
+Install the firmware update script
+``` nix
+environment.systemPackages = [
+  (pkgs.callPackage
+    "${nixos-hardware}/starfive/visionfive/v2/firmware.nix"
+    { }).updater-flash
+];
+```
+Then run as root
+``` sh
+visionfive2-firmware-update-flash
+```
+

--- a/starfive/visionfive/v2/sd-image.nix
+++ b/starfive/visionfive/v2/sd-image.nix
@@ -1,7 +1,6 @@
 { config, pkgs, lib, modulesPath, ... }:
 
-let
-  firmware = pkgs.callPackage ./firmware.nix { };
+let firmware = pkgs.callPackage ./firmware.nix { };
 in {
   imports = [
     "${modulesPath}/profiles/base.nix"
@@ -48,4 +47,6 @@ in {
       ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
     '';
   };
+
+  environment.systemPackages = [ firmware.updater-flash ];
 }


### PR DESCRIPTION
###### Description of changes
Add scripts to update the bootloader on the sd card or the QSPI flash.
The QSPI flash update script will only work when #630 and #646 is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

