### PR TITLE
starfive visionfive2: Increase mtd0 partition to fit spl

### DIFF
--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -21,4 +21,9 @@
 
   hardware.deviceTree.name =
     lib.mkDefault "starfive/jh7110-starfive-visionfive-2-v1.3b.dtb";
+
+  hardware.deviceTree.overlays = [{
+    name = "qspi-patch";
+    dtsFile = ./qspi-patch.dts;
+  }];
 }

--- a/starfive/visionfive/v2/qspi-patch.dts
+++ b/starfive/visionfive/v2/qspi-patch.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+/ {
+    compatible = "starfive,jh7110";
+    fragment@0 {
+        target = <&qspi>;
+        __overlay__ {
+            nor_flash: flash@0 {
+                partitions {
+                    spl@0 {
+                        reg = <0x0 0x40000>;
+                    };
+                };
+            };
+        };
+    };
+};


### PR DESCRIPTION
###### Description of changes
This fixes the issue that the SPL is larger than the flash partition. This simply increases the partition to fit the slightly larger SPL.
This depends on #630.
Related PR upstream https://github.com/starfive-tech/linux/pull/99.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

