### PR TITLE
macbook-air-6: remove mba6x_bl kernel module

### DIFF
--- a/apple/macbook-air/6/default.nix
+++ b/apple/macbook-air/6/default.nix
@@ -4,15 +4,11 @@
   imports = [ ../. ];
 
   boot = {
-    extraModulePackages = with config.boot.kernelPackages; [ mba6x_bl ];
-    kernelModules = [ "mba6x_bl" ];
-
     # Divides power consumption by two.
     kernelParams = [ "acpi_osi=" ];
   };
 
   services.xserver.deviceSection = lib.mkDefault ''
-    Option "Backlight" "mba6x_backlight"
     Option "TearFree" "true"
   '';
 }


### PR DESCRIPTION
This does not compile against 6.x Kernel.
This is also no longer necessary for 6.x Kernel.
One can use "acpi_video0" device instead of "mba6x_backlight" device.

###### Description of changes

Remove mba6x_backlight kernel module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

