### PR TITLE
apple/t2: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See code for all available configurations.
 | [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                    | `<nixos-hardware/apple/macbook-pro/11-5>`          |
 | [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                    | `<nixos-hardware/apple/macbook-pro/12-1>`          |
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                    | `<nixos-hardware/apple/macbook-pro/14-1>`          |
+| [Apple Macs with a T2 Chip](apple/t2)                               | `<nixos-hardware/apple/t2>`                        |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                      | `<nixos-hardware/asus/rog-strix/g733qs>`           |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                  | `<nixos-hardware/asus/zephyrus/ga401>`             |
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                  | `<nixos-hardware/asus/zephyrus/ga402>`             |

--- a/apple/t2/README.md
+++ b/apple/t2/README.md
@@ -1,0 +1,9 @@
+## NixOS on T2 Macs
+
+This is the `nixos-hardware` module of the [T2 Linux Project](https://t2linux.org).
+
+Overall, most features (WiFi, bluetooth, audio, touchbar, ...) of Macs are supported, [see this page](https://wiki.t2linux.org/state/) for a detailed list of things that work and things that don't/partially work.
+
+Following [this guide](https://wiki.t2linux.org/distributions/nixos/installation/) is the recommended way to install, as it incudes the extra things you have to do on a T2 Mac.
+
+You can consult the [wiki](https://wiki.t2linux.org/) for information specific to T2 Macs.

--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -1,0 +1,55 @@
+{ pkgs, ... }:
+
+let
+  audioFiles = pkgs.fetchFromGitHub {
+    owner = "kekrby";
+    repo = "t2-better-audio";
+    rev = "e46839a28963e2f7d364020518b9dac98236bcae";
+    hash = "sha256-x7K0qa++P1e1vuCGxnsFxL1d9+nwMtZUJ6Kd9e27TFs=";
+  };
+
+  overrideAudioFiles = package: pluginsPath:
+    package.overrideAttrs (new: old: {
+      preConfigurePhases = old.preConfigurePhases or [ ] ++ [ "postPatchPhase" ];
+
+      postPatchPhase = ''
+        cp -r ${audioFiles}/files/{profile-sets,paths} ${pluginsPath}/alsa/mixer/
+      '';
+    });
+in
+{
+  # For keyboard and touchbar
+  boot.kernelPackages = with pkgs; recurseIntoAttrs (linuxPackagesFor (callPackage ./pkgs/linux-t2.nix { }));
+  boot.initrd.kernelModules = [ "apple-bce" ];
+
+  # For audio
+  boot.kernelParams = [ "pcie_ports=compat" "intel_iommu=on" "iommu=pt" ];
+  services.udev.extraRules = builtins.readFile (pkgs.substitute {
+    src = "${audioFiles}/files/91-audio-custom.rules";
+    replacements = [ "--replace" "/usr/bin/sed" "${pkgs.gnused}/bin/sed" ];
+  });
+
+  hardware.pulseaudio.package = overrideAudioFiles pkgs.pulseaudio "src/modules/";
+
+  services.pipewire = rec {
+    package = overrideAudioFiles pkgs.pipewire "spa/plugins/";
+
+    wireplumber.package = pkgs.wireplumber.override {
+      pipewire = package;
+    };
+  };
+
+  # Make sure post-resume.service exists
+  powerManagement.enable = true;
+
+  systemd.services.fix-keyboard-backlight-and-touchbar = {
+    path = [ pkgs.kmod ];
+    serviceConfig.ExecStart = ''${pkgs.systemd}/bin/systemd-inhibit --what=sleep --why="fixing keyboard backlight and touchbar must finish before sleep" --mode=delay ${./fix-keyboard-backlight-and-touchbar.sh}'';
+    serviceConfig.Type = "oneshot";
+    description = "reload touchbar driver and restart upower";
+    # must run at boot (and not too early), and after suspend
+    wantedBy = [ "display-manager.service" "post-resume.target" ];
+    # prevent running before suspend
+    after = [ "post-resume.target" ];
+  };
+}

--- a/apple/t2/fix-keyboard-backlight-and-touchbar.sh
+++ b/apple/t2/fix-keyboard-backlight-and-touchbar.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eux
+
+unload () {
+  if modprobe -r "$1" 2>&1;
+  then echo ok
+  else echo fail
+  fi
+}
+
+wait_unload() {
+  while sleep 1; do
+    output="$(unload "$1")"
+    case "$output" in
+      *is\ in\ use*) :;;
+      *ok*) return 0;;
+      *) echo "modprobe said: $output"; echo giving up; return 1;
+    esac
+  done
+}
+
+wait_unload apple_touchbar
+modprobe apple_touchbar
+
+# After suspend, the inode for the backlight device has changed. This service
+# simply restarts upower to inform it of that change.
+systemctl restart upower.service

--- a/apple/t2/pkgs/linux-t2.nix
+++ b/apple/t2/pkgs/linux-t2.nix
@@ -1,0 +1,46 @@
+{ lib, buildLinux, fetchFromGitHub, fetchurl, ... } @ args:
+
+let
+  patchRepo = fetchFromGitHub {
+    owner = "t2linux";
+    repo = "linux-t2-patches";
+    rev = "c0db79a25bc37dbd0c27636914b3903016a2fc39";
+    hash = "sha256-VILJAK7F0E/8Z3sOzsUpS9dmtpull2XVXQkakZ0UTIA=";
+  };
+
+  version = "6.4";
+  majorVersion = with lib; (elemAt (take 1 (splitVersion version)) 0);
+in
+buildLinux (args // {
+  inherit version;
+
+  pname = "linux-t2";
+  # Snippet from nixpkgs
+  modDirVersion = with lib; "${concatStringsSep "." (take 3 (splitVersion "${version}.0"))}";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v${majorVersion}.x/linux-${version}.tar.xz";
+    hash = "sha256-j6BYjwws7KRMrHeg45ukjJ8AprncaXYcAqXT76yNp/M=";
+  };
+
+  structuredExtraConfig = with lib.kernel; {
+    APPLE_BCE = module;
+    APPLE_GMUX = module;
+    BRCMFMAC = module;
+    BT_BCM = module;
+    BT_HCIBCM4377 = module;
+    BT_HCIUART_BCM = yes;
+    BT_HCIUART = module;
+    HID_APPLE_IBRIDGE = module;
+    HID_APPLE = module;
+    HID_APPLE_MAGIC_BACKLIGHT = module;
+    HID_APPLE_TOUCHBAR = module;
+    HID_SENSOR_ALS = module;
+    SND_PCM = module;
+    STAGING = yes;
+  };
+
+  kernelPatches = lib.attrsets.mapAttrsToList (file: type: { name = file; patch = "${patchRepo}/${file}"; })
+    (lib.attrsets.filterAttrs (file: type: type == "regular" && lib.strings.hasSuffix ".patch" file)
+      (builtins.readDir patchRepo));
+} // (args.argsOverride or {}))

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
       apple-macbook-pro-11-5 = import ./apple/macbook-pro/11-5;
       apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;
       apple-macbook-pro-14-1 = import ./apple/macbook-pro/14-1;
+      apple-t2 = import ./apple/t2;
       asus-battery = import ./asus/battery.nix;
       asus-fx504gd = import ./asus/fx504gd;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;


### PR DESCRIPTION
###### Description of changes

This pull request adds all changes from https://github.com/kekrby/nixos-hardware as well as an update to the most recent kernel and a fix for keyboard backlight not working after suspend, making Apple Intel Macs with the T2 security chip quite usable overall.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
