### PR TITLE
 fixes iptsd not able to find DEVICE

### DIFF
--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -19,7 +19,7 @@ in {
       systemd.services.iptsd = {
         description = "IPTSD";
         path = with pkgs; [ iptsd ];
-        script = "iptsd";
+        script = "iptsd $(iptsd-find-hidraw)";
         wantedBy = [ "multi-user.target" ];
       };
     })


### PR DESCRIPTION
Added "iptsd-find-hidraw" after iptsd command so that it can automatically detech the current device on the system for ipts.

###### Description of changes
When building the system with current iptsd service, it gives error of needing a DEVICE for iptsd.service. This should fix that issue and automatically detech + enable the correct device.

###### Things done
Added $(iptsd-find-hidraw)


- [ x ] Tested the changes in your own NixOS Configuration
- [ x ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input


