### PR TITLE
treewide: avoid alias usage for intel-vaapi-driver based on nixos version

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -8,7 +8,7 @@
   };
 
   hardware.opengl.extraPackages = with pkgs; [
-    vaapiIntel
+    (if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)
     libvdpau-va-gl
     intel-media-driver
   ];

--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -14,7 +14,10 @@ in
 	# GPU is an Intel Iris Xe, on a “TigerLake” mobile CPU
 	boot.initrd.kernelModules = [ "i915" ];  # Early loading so the passphrase prompt appears on external displays
 	services.xserver.videoDrivers = [ "intel" ];
-	hardware.opengl.extraPackages = with pkgs; [ intel-media-driver vaapiIntel ];
+	hardware.opengl.extraPackages = with pkgs; [
+		intel-media-driver
+		(if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)
+	];
 
 	boot.kernelParams = [
 		# S3 suspend is broken as of Sept. 2022 (screen does not come back properly), use S2


### PR DESCRIPTION
###### Description of changes

Fixes configs with `nixpkgs.config.allowAliases = false` after NixOS/nixpkgs#235202

I couldn't find any prior art in the repo for package aliases based on NixOS version, so let me know if there is a better/more preferred way to handle this

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

