### PR TITLE
Added more blocked Nvidia kernel modules to fix the dGPU not being disabled

### DIFF
--- a/common/gpu/nvidia/disable.nix
+++ b/common/gpu/nvidia/disable.nix
@@ -22,5 +22,5 @@
     # Remove NVIDIA VGA/3D controller devices
     ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", ATTR{power/control}="auto", ATTR{remove}="1"
   '';
-  boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" ];
+  boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" "nvidia_drm" "nvidia_modeset" ];
 }


### PR DESCRIPTION
###### Description of changes
Hello

This is a minor addition to /common/gpu/nvidia/disable.nix which adds more kernel modules to block: `nvidia_drm` and `nvidia_modeset`:
```nix
boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" "nvidia_drm" "nvidia_modeset" ];
```

Today I wanted to fully disable my Nvidia dGPU on an Optimus laptop. I added the setup seen in the current disable.nix to my configuration.nix but it didn't work, my Nvidia dedicated GPU was still active and rampant on power consumption. I added these 2 more modules to the blacklist and this completely fixed the issue and now my dedicated GPU is fully disabled.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

