### PR TITLE
added 16IRX8H Lenovo Legion 7i Pro (2023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ See code for all available configurations.
 | [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                | `<nixos-hardware/lenovo/legion/16ach6h>`           |
 | [Lenovo Legion 5 Pro 16ach6h (Hybrid)](lenovo/legion/16ach6h/hybrid)| `<nixos-hardware/lenovo/legion/16ach6h/hybrid>`    |
 | [Lenovo Legion 5 Pro 16ach6h (Nvidia)](lenovo/legion/16ach6h/nvidia)| `<nixos-hardware/lenovo/legion/16ach6h/nvidia>`    |
+| [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)       | `<nixos-hardware/lenovo/legion/16irx8h>`           |
 | [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                     | `<nixos-hardware/lenovo/legion/15ich>`             |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                | `<nixos-hardware/lenovo/thinkpad/e14/amd>`         |
 | [Lenovo ThinkPad E14 (Intel)](lenovo/thinkpad/e14/intel)            | `<nixos-hardware/lenovo/thinkpad/e14/intel>`       |

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
       lenovo-legion-16ach6h-hybrid = import ./lenovo/legion/16ach6h/hybrid;
       lenovo-legion-16ach6h-nvidia = import ./lenovo/legion/16ach6h/nvidia;
       lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
+      lenovo-legion-16irx8h = import ./lenovo/legion/16irx8h;
       lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;
       lenovo-thinkpad = import ./lenovo/thinkpad;
       lenovo-thinkpad-e14-amd = import ./lenovo/thinkpad/e14/amd;

--- a/lenovo/legion/16irx8h/default.nix
+++ b/lenovo/legion/16irx8h/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: {
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+    ../../../common/hidpi.nix
+  ];
+
+  boot.initrd.kernelModules = ["nvidia"];
+  boot.extraModulePackages = [config.boot.kernelPackages.lenovo-legion-module config.boot.kernelPackages.nvidia_x11];
+
+  hardware = {
+    nvidia = {
+      modesetting.enable = lib.mkDefault true;
+      powerManagement.enable = lib.mkDefault true; #
+      #
+      prime = {
+        intelBusId = "PCI:00:02:0";
+        nvidiaBusId = "PCI:01:00:0";
+      };
+    };
+  };
+
+  # Cooling management
+  services.thermald.enable = lib.mkDefault true;
+
+  # √(2560² + 1600²) px / 16 in ≃ 189 dpi
+  services.xserver.dpi = 189;
+}

--- a/lenovo/legion/16irx8h/default.nix
+++ b/lenovo/legion/16irx8h/default.nix
@@ -18,7 +18,7 @@
   hardware = {
     nvidia = {
       modesetting.enable = lib.mkDefault true;
-      powerManagement.enable = lib.mkDefault true; #
+      powerManagement.enable = lib.mkDefault true;
       #
       prime = {
         intelBusId = "PCI:00:02:0";


### PR DESCRIPTION
###### Description of changes
added 16IRX8H Lenovo Legion 7i Pro (2023)
nvidia is disabled as hyprland fails and that is what i use in my system. if there are specific request i can test more. 

Tested on my own flake with referencing my own nixos-hardware fork locally. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

