### PR TITLE
star64: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See code for all available configurations.
 | [Panasonic Let's Note CF-LX4 ](panasonic/letsnote/cf-lx4)           | `<nixos-hardware/panasonic/letsnote/cf-lx4>`       |
 | [PC Engines APU](pcengines/apu)                                     | `<nixos-hardware/pcengines/apu>`                   |
 | [PINE64 Pinebook Pro](pine64/pinebook-pro/)                         | `<nixos-hardware/pine64/pinebook-pro>`             |
+| [PINE64 STAR64](pine64/star64/)                                     | `<nixos-hardware/pine64/star64>`                   |
 | [Purism Librem 13v3](purism/librem/13v3)                            | `<nixos-hardware/purism/librem/13v3>`              |
 | [Purism Librem 15v3](purism/librem/13v3)                            | `<nixos-hardware/purism/librem/15v3>`              |
 | [Raspberry Pi 2](raspberry-pi/2)                                    | `<nixos-hardware/raspberry-pi/2>`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
       onenetbook-4 = import ./onenetbook/4;
       pcengines-apu = import ./pcengines/apu;
       pine64-pinebook-pro = import ./pine64/pinebook-pro;
+      pine64-star64 = import ./pine64/star64;
       purism-librem-13v3 = import ./purism/librem/13v3;
       purism-librem-15v3 = import ./purism/librem/15v3;
       raspberry-pi-2 = import ./raspberry-pi/2;

--- a/pine64/star64/README.md
+++ b/pine64/star64/README.md
@@ -1,0 +1,120 @@
+# Creating a SD-Image
+
+Create and configure the `flake.nix` file:
+
+``` nix
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
+
+
+  outputs = { self, nixpkgs, nixos-hardware, flake-utils, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "riscv64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSupportedSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in {
+      packages = forAllSupportedSystems (system: rec {
+        default = sd-image;
+        sd-image = (import "${nixpkgs}/nixos" {
+          configuration =
+            { config, ... }: {
+              imports = [
+                "${nixos-hardware}/pine64/star64/sd-image.nix"
+                # or, for a system like an installation media:
+                #"${nixos-hardware}/pine64/star64/sd-image-installer.nix"
+              ];
+
+              system.stateVersion = "23.05";
+              networking.useDHCP = true;
+              services.openssh.enable = true;
+
+              users.users.nixos = {
+                isNormalUser = true;
+                extraGroups = [ "wheel" ];
+              };
+              security.sudo.wheelNeedsPassword = false;
+              # Set a password
+              users.users.nixos.initialPassword = "nixos";
+              # OR add your public ssh key
+              #users.users.nixos.openssh.authorizedKeys.keys = [ "ssh-rsa ..." ];
+
+              sdImage.compressImage = false;
+
+              # Set if cross compiling
+              #nixpkgs.crossSystem = {
+              #  config = "riscv64-unknown-linux-gnu";
+              #  system = "riscv64-linux";
+              #};
+
+              # Additional configuration goes here
+            };
+          inherit system;
+        }).config.system.build.sdImage;
+      });
+    };
+}
+```
+
+Build the sd image.
+
+``` sh
+nix build .#
+```
+
+## Additional configuration
+
+### 8GB memory
+
+If your board has 8GB of RAM add the following to your config:
+
+``` nix
+hardware.deviceTree.overlays = [{
+  name = "8GB-patch";
+  dtsFile =
+    "${nixos-hardware}/pine64/star64/star64-8GB.dts";
+}];
+```
+
+# Updating the bootloader
+
+## SD-Card
+
+Install the firmware update script
+
+``` nix
+environment.systemPackages = [
+  (pkgs.callPackage
+    "${nixos-hardware}/pine64/star64/firmware.nix"
+    { }).updater-sd
+];
+```
+
+Then run as root
+
+``` sh
+star64-firmware-update-sd
+```
+
+## SPI Flash
+
+Install the firmware update script
+
+``` nix
+environment.systemPackages = [
+  (pkgs.callPackage
+    "${nixos-hardware}/pine64/star64/firmware.nix"
+    { }).updater-flash
+];
+```
+
+Then run as root
+
+``` sh
+star64-firmware-update-flash
+```

--- a/pine64/star64/default.nix
+++ b/pine64/star64/default.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }: {
+  nixpkgs.overlays = [(self: super: {
+    makeModulesClosure = x: super.makeModulesClosure (x // {
+      allowMissing = true;
+    });
+  })];
+
+  # Somehow ttyS0 doesn't get enabled by default
+  systemd.services."serial-getty@ttyS0".enable = lib.mkDefault true;
+  systemd.services."serial-getty@ttyS0".wantedBy = lib.mkDefault [ "getty.target" ];
+
+  boot = {
+    # Force no ZFS (from nixos/modules/profiles/base.nix) until updated to kernel 6.0
+    # TODO still valid for star64?
+    supportedFilesystems =
+      lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
+    consoleLogLevel = lib.mkDefault 7;
+    kernelPackages = lib.mkDefault (pkgs.callPackage ./linux-5.15.nix {
+      inherit (config.boot) kernelPatches;
+    });
+
+    kernelParams =
+      lib.mkDefault [ "console=tty0" "console=ttyS0,115200n8" "earlycon=sbi" ];
+
+    initrd.availableKernelModules = [ "dw_mmc_starfive" ];
+
+    # Ethernet. The module gets forced m due to other modules even though
+    # it's marked y in defconfig.
+    kernelModules = [ "dwmac-starfive-plat" ];
+
+    loader = {
+      grub.enable = lib.mkDefault false;
+      generic-extlinux-compatible.enable = lib.mkDefault true;
+    };
+  };
+
+  hardware.deviceTree.name =
+    lib.mkDefault "starfive/jh7110-pine64-star64.dtb";
+}

--- a/pine64/star64/firmware.nix
+++ b/pine64/star64/firmware.nix
@@ -1,0 +1,78 @@
+{ callPackage, pkgsBuildHost, runCommand, writeText, writeShellApplication
+, stdenv, dtc, mtdutils, coreutils }:
+let
+  uboot = callPackage ./uboot.nix { };
+  opensbi = callPackage ./opensbi.nix {
+    withPayload = "${uboot}/u-boot.bin";
+    withFDT = "${uboot}/pine64_star64.dtb";
+  };
+  spl-tool = pkgsBuildHost.callPackage ./spl-tool.nix { };
+  its-file = writeText "star64-uboot-fit-image.its" ''
+    /dts-v1/;
+
+    / {
+      description = "U-boot-spl FIT image for JH7110 Star64";
+      #address-cells = <2>;
+
+      images {
+        firmware {
+          description = "u-boot";
+          data = /incbin/("${opensbi}/share/opensbi/lp64/generic/firmware/fw_payload.bin");
+          type = "firmware";
+          arch = "riscv";
+          os = "u-boot";
+          load = <0x0 0x40000000>;
+          entry = <0x0 0x40000000>;
+          compression = "none";
+        };
+      };
+
+      configurations {
+        default = "config-1";
+
+        config-1 {
+          description = "U-boot-spl FIT config for JH7110 Star64";
+          firmware = "firmware";
+        };
+      };
+    };
+  '';
+in rec {
+  inherit opensbi uboot;
+  spl = stdenv.mkDerivation {
+    name = "pine64-star64-spl";
+    depsBuildBuild = [ spl-tool ];
+    phases = [ "installPhase" ];
+    installPhase = ''
+      mkdir -p $out/share/pine64-star64/
+      ln -s ${uboot}/u-boot-spl.bin .
+      spl_tool -c -f ./u-boot-spl.bin
+      cp u-boot-spl.bin.normal.out $out/share/pine64-star64/spl.bin
+    '';
+  };
+  uboot-fit-image = stdenv.mkDerivation {
+    name = "pine64-star64-uboot-fit-image";
+    nativeBuildInputs = [ dtc ];
+    phases = [ "installPhase" ];
+    installPhase = ''
+      mkdir -p $out/share/pine64-star64/
+      ${uboot}/mkimage -f ${its-file} -A riscv -O u-boot -T firmware $out/share/pine64-star64/star64_fw_payload.img
+    '';
+  };
+  updater-flash = writeShellApplication {
+    name = "star64-firmware-update-flash";
+    runtimeInputs = [ mtdutils ];
+    text = ''
+      flashcp -v ${spl}/share/pine64-star64/spl.bin /dev/mtd0
+      flashcp -v ${uboot-fit-image}/share/pine64-star64/star64_fw_payload.img /dev/mtd1
+    '';
+  };
+  updater-sd = writeShellApplication {
+    name = "star64-firmware-update-sd";
+    runtimeInputs = [ ];
+    text = ''
+      dd if=${spl}/share/pine64-star64/spl.bin of=/dev/mmcblk0p1 conv=fsync
+      dd if=${uboot-fit-image}/share/pine64-star64/star64_fw_payload.img of=/dev/mmcblk0p2 conv=fsync
+    '';
+  };
+}

--- a/pine64/star64/irq-desc-to-data.patch
+++ b/pine64/star64/irq-desc-to-data.patch
@@ -1,0 +1,24 @@
+diff --git a/drivers/rtc/rtc-starfive.c b/drivers/rtc/rtc-starfive.c
+index 895960ff0..d567cf876 100644
+--- a/drivers/rtc/rtc-starfive.c
++++ b/drivers/rtc/rtc-starfive.c
+@@ -575,7 +575,7 @@ static int sft_rtc_probe(struct platform_device *pdev)
+ 	struct device *dev = &pdev->dev;
+ 	struct sft_rtc *srtc;
+ 	struct rtc_time tm;
+-	struct irq_desc *desc;
++	struct irq_data *data;
+ 	int ret;
+ 
+ 	srtc = devm_kzalloc(dev, sizeof(*srtc), GFP_KERNEL);
+@@ -640,8 +640,8 @@ static int sft_rtc_probe(struct platform_device *pdev)
+ 	srtc->rtc_dev->ops = &starfive_rtc_ops;
+ 	device_init_wakeup(dev, true);
+ 
+-	desc = irq_to_desc(srtc->rtc_irq);
+-	irq_desc_get_chip(desc)->flags = IRQCHIP_SKIP_SET_WAKE;
++	data = irq_get_irq_data(srtc->rtc_irq);
++	irq_data_get_irq_chip(data)->flags = IRQCHIP_SKIP_SET_WAKE;
+ 
+ 	/* Always use 24-hour mode and keep the RTC values */
+ 	sft_rtc_set_mode(srtc, RTC_HOUR_MODE_24H);

--- a/pine64/star64/linux-5.15.nix
+++ b/pine64/star64/linux-5.15.nix
@@ -1,0 +1,238 @@
+{ lib, callPackage, linuxPackagesFor, kernelPatches, fetchpatch, ... }:
+
+let
+  modDirVersion = "5.15.115";
+  linuxPkg = { lib, fetchFromGitHub, buildLinux, ... }@args:
+    buildLinux (args // {
+      version = "${modDirVersion}-fishwaldo-star64";
+
+      src = fetchFromGitHub {
+        owner = "Fishwaldo";
+        repo = "Star64_linux";
+        rev = "765947eacb2408a3a232cbe8093bf28a991f3c35"; # Star64_devel branch
+        hash = "sha256-2Gbk2BsC9LCcXfXfgzJiPdEap90Y0Fl6Fz9TvIIbmB8=";
+      };
+
+      inherit modDirVersion;
+      defconfig = "pine64_star64_defconfig";
+      kernelPatches = [
+         { patch = fetchpatch {
+             url = "https://github.com/torvalds/linux/commit/215bebc8c6ac438c382a6a56bd2764a2d4e1da72.diff";
+             hash = "sha256-1ZqmVOkgcDBRkHvVRPH8I5G1STIS1R/l/63PzQQ0z0I=";
+             includes = ["security/keys/dh.c"];
+           };
+         }
+         { patch = fetchpatch {
+             url = "https://github.com/starfive-tech/linux/pull/108/commits/9ae8cb751c4d1fd2146b279a8e67887590e9d07a.diff";
+             hash = "sha256-EY0lno+HkY5mradBUPII3qqu0xh+BVQRzveCQcaht0M=";
+           };
+         }
+         { patch = ./pl330-name-collision.patch; }
+         { patch = ./irq-desc-to-data.patch; }
+      ] ++ kernelPatches;
+
+      structuredExtraConfig = with lib.kernel; {
+        # A ton of stuff just does not build. We disable it all.
+        # Most of it is not important except drm.
+        # https://github.com/starfive-tech/linux/issues/79
+
+        # Removed files, re-added to the makefile by accident in
+        # https://github.com/Fishwaldo/Star64_linux/commit/cd96097d17a494974dfc5e9909476145ab4f09f5
+        CRYPTO_RMD128 = no;
+        CRYPTO_RMD256 = no;
+        CRYPTO_RMD320 = no;
+        CRYPTO_TGR192 = no;
+        CRYPTO_SALSA20 = no;
+
+        CRYPTO_SM4 = no; # modpost: undefined stuff
+        CRYPTO_DEV_CCREE = no; # reverse dep of CRYPTO_SM4
+        NLS_CODEPAGE_949 = no;
+        VIDEO_OV5640 = no; # conflicts with starfive VIN_SENSOR_OV5640
+
+        DRM_IMG = no;
+        DRM_IMG_ROGUE = no;
+        DRM_VERISILICON = no;
+
+        # brute force disable drm
+        CEC_CORE = no;
+        CEC_NOTIFIER = no;
+        DRM = no;
+        DRM_MIPI_DBI = no;
+        DRM_MIPI_DSI = no;
+        DRM_DP_AUX_BUS = no;
+        DRM_DP_AUX_CHARDEV = lib.mkForce no;
+        DRM_KMS_HELPER = no;
+        DRM_FBDEV_EMULATION = no;
+        DRM_LOAD_EDID_FIRMWARE = lib.mkForce no;
+        DRM_TTM = no;
+        DRM_VRAM_HELPER = no;
+        DRM_TTM_HELPER = no;
+        DRM_GEM_CMA_HELPER = no;
+        DRM_KMS_CMA_HELPER = no;
+        DRM_GEM_SHMEM_HELPER = no;
+        DRM_SCHED = no;
+        DRM_I2C_CH7006 = no;
+        DRM_I2C_SIL164 = no;
+        DRM_I2C_NXP_TDA998X = no; # https://github.com/starfive-tech/linux/pull/86
+        DRM_I2C_NXP_TDA9950 = no;
+        DRM_KOMEDA = no;
+        DRM_RADEON = no;
+        DRM_AMDGPU = no;
+        DRM_AMDGPU_SI = lib.mkForce no;
+        DRM_AMDGPU_CIK = lib.mkForce no;
+        DRM_AMDGPU_USERPTR = lib.mkForce no;
+        DRM_AMD_DC = no;
+        DRM_AMD_DC_HDCP = lib.mkForce no;
+        DRM_AMD_DC_SI = lib.mkForce no;
+        DRM_NOUVEAU = no;
+        NOUVEAU_LEGACY_CTX_SUPPORT = no;
+        DRM_NOUVEAU_BACKLIGHT = no;
+        DRM_VGEM = no;
+        DRM_VKMS = no;
+        DRM_UDL = no;
+        DRM_AST = no;
+        DRM_MGAG200 = no;
+        DRM_RCAR_DW_HDMI = no;
+        DRM_QXL = no;
+        DRM_VIRTIO_GPU = no;
+        DRM_PANEL = no;
+        DRM_PANEL_ABT_Y030XX067A = no;
+        DRM_PANEL_ARM_VERSATILE = no;
+        DRM_PANEL_ASUS_Z00T_TM5P5_NT35596 = no;
+        DRM_PANEL_BOE_HIMAX8279D = no;
+        DRM_PANEL_BOE_TV101WUM_NL6 = no;
+        DRM_PANEL_DSI_CM = no;
+        DRM_PANEL_LVDS = no;
+        DRM_PANEL_SIMPLE = no;
+        DRM_PANEL_ELIDA_KD35T133 = no;
+        DRM_PANEL_FEIXIN_K101_IM2BA02 = no;
+        DRM_PANEL_FEIYANG_FY07024DI26A30D = no;
+        DRM_PANEL_ILITEK_IL9322 = no;
+        DRM_PANEL_ILITEK_ILI9341 = no;
+        DRM_PANEL_ILITEK_ILI9881C = no;
+        DRM_PANEL_INNOLUX_EJ030NA = no;
+        DRM_PANEL_INNOLUX_P079ZCA = no;
+        DRM_PANEL_JDI_LT070ME05000 = no;
+        DRM_PANEL_KHADAS_TS050 = no;
+        DRM_PANEL_KINGDISPLAY_KD097D04 = no;
+        DRM_PANEL_LEADTEK_LTK050H3146W = no;
+        DRM_PANEL_LEADTEK_LTK500HD1829 = no;
+        DRM_PANEL_SAMSUNG_LD9040 = no;
+        DRM_PANEL_LG_LB035Q02 = no;
+        DRM_PANEL_LG_LG4573 = no;
+        DRM_PANEL_NEC_NL8048HL11 = no;
+        DRM_PANEL_NOVATEK_NT35510 = no;
+        DRM_PANEL_NOVATEK_NT36672A = no;
+        DRM_PANEL_NOVATEK_NT39016 = no;
+        DRM_PANEL_MANTIX_MLAF057WE51 = no;
+        DRM_PANEL_OLIMEX_LCD_OLINUXINO = no;
+        DRM_PANEL_ORISETECH_OTM8009A = no;
+        DRM_PANEL_OSD_OSD101T2587_53TS = no;
+        DRM_PANEL_PANASONIC_VVX10F034N00 = no;
+        DRM_PANEL_RASPBERRYPI_TOUCHSCREEN = no;
+        DRM_PANEL_RAYDIUM_RM67191 = no;
+        DRM_PANEL_RAYDIUM_RM68200 = no;
+        DRM_PANEL_RONBO_RB070D30 = no;
+        DRM_PANEL_SAMSUNG_ATNA33XC20 = no;
+        DRM_PANEL_SAMSUNG_DB7430 = no;
+        DRM_PANEL_SAMSUNG_S6D16D0 = no;
+        DRM_PANEL_SAMSUNG_S6E3HA2 = no;
+        DRM_PANEL_SAMSUNG_S6E63J0X03 = no;
+        DRM_PANEL_SAMSUNG_S6E63M0 = no;
+        DRM_PANEL_SAMSUNG_S6E63M0_SPI = no;
+        DRM_PANEL_SAMSUNG_S6E63M0_DSI = no;
+        DRM_PANEL_SAMSUNG_S6E88A0_AMS452EF01 = no;
+        DRM_PANEL_SAMSUNG_S6E8AA0 = no;
+        DRM_PANEL_SAMSUNG_SOFEF00 = no;
+        DRM_PANEL_SEIKO_43WVF1G = no;
+        DRM_PANEL_SHARP_LQ101R1SX01 = no;
+        DRM_PANEL_SHARP_LS037V7DW01 = no;
+        DRM_PANEL_SHARP_LS043T1LE01 = no;
+        DRM_PANEL_SITRONIX_ST7701 = no;
+        DRM_PANEL_SITRONIX_ST7703 = no;
+        DRM_PANEL_SITRONIX_ST7789V = no;
+        DRM_PANEL_SONY_ACX565AKM = no;
+        DRM_PANEL_TDO_TL070WSH30 = no;
+        DRM_PANEL_TPO_TD028TTEC1 = no;
+        DRM_PANEL_TPO_TD043MTEA1 = no;
+        DRM_PANEL_TPO_TPG110 = no;
+        DRM_PANEL_TRULY_NT35597_WQXGA = no;
+        DRM_PANEL_VISIONOX_RM69299 = no;
+        DRM_PANEL_WIDECHIPS_WS2401 = no;
+        DRM_PANEL_XINPENG_XPP055C272 = no;
+        DRM_BRIDGE = no;
+        DRM_PANEL_BRIDGE = no;
+        DRM_CDNS_DSI = no;
+        DRM_CHIPONE_ICN6211 = no;
+        DRM_CHRONTEL_CH7033 = no;
+        DRM_DISPLAY_CONNECTOR = no;
+        DRM_LONTIUM_LT8912B = no;
+        DRM_LONTIUM_LT9611 = no;
+        DRM_LONTIUM_LT9611UXC = no;
+        DRM_ITE_IT66121 = no;
+        DRM_LVDS_CODEC = no;
+        DRM_MEGACHIPS_STDPXXXX_GE_B850V3_FW = no;
+        DRM_NWL_MIPI_DSI = no;
+        DRM_NXP_PTN3460 = no;
+        DRM_PARADE_PS8622 = no;
+        DRM_PARADE_PS8640 = no;
+        DRM_SIL_SII8620 = no;
+        DRM_SII902X = no;
+        DRM_SII9234 = no;
+        DRM_SIMPLE_BRIDGE = no;
+        DRM_THINE_THC63LVD1024 = no;
+        DRM_TOSHIBA_TC358762 = no;
+        DRM_TOSHIBA_TC358764 = no;
+        DRM_TOSHIBA_TC358767 = no;
+        DRM_TOSHIBA_TC358768 = no;
+        DRM_TOSHIBA_TC358775 = no;
+        DRM_TI_TFP410 = no;
+        DRM_TI_SN65DSI83 = no;
+        DRM_TI_SN65DSI86 = no;
+        DRM_TI_TPD12S015 = no;
+        DRM_ANALOGIX_ANX6345 = no;
+        DRM_ANALOGIX_ANX78XX = no;
+        DRM_ANALOGIX_DP = no;
+        DRM_ANALOGIX_ANX7625 = no;
+        DRM_I2C_ADV7511 = no;
+        DRM_I2C_ADV7511_CEC = no;
+        DRM_CDNS_MHDP8546 = no;
+        DRM_DW_HDMI = no;
+        DRM_DW_HDMI_AHB_AUDIO = no;
+        DRM_DW_HDMI_I2S_AUDIO = no;
+        DRM_DW_HDMI_CEC = no;
+        DRM_ETNAVIV = no;
+        DRM_ETNAVIV_THERMAL = no;
+        DRM_MXS = no;
+        DRM_MXSFB = no;
+        DRM_ARCPGU = no;
+        DRM_BOCHS = no;
+        DRM_CIRRUS_QEMU = no;
+        DRM_GM12U320 = no;
+        TINYDRM_HX8357D = no;
+        TINYDRM_ILI9225 = no;
+        TINYDRM_ILI9341 = no;
+        TINYDRM_ILI9486 = no;
+        TINYDRM_MI0283QT = no;
+        TINYDRM_REPAPER = no;
+        TINYDRM_ST7586 = no;
+        TINYDRM_ST7735R = no;
+        DRM_GUD = no;
+        DRM_LEGACY = no;
+        DRM_TDFX = no;
+        DRM_R128 = no;
+        DRM_MGA = no;
+        DRM_VIA = no;
+        DRM_SAVAGE = no;
+        VIDEOMODE_HELPERS = no;
+        SND_PCM_ELD = no;
+        SND_PCM_IEC958 = no;
+        SND_HDA_COMPONENT = no;
+        SND_SOC_HDMI_CODEC = no;
+        VIRTIO_DMA_SHARED_BUFFER = no;
+      };
+
+      extraMeta.branch = "Star64_devel";
+    } // (args.argsOverride or { }));
+
+in lib.recurseIntoAttrs (linuxPackagesFor (callPackage linuxPkg { }))

--- a/pine64/star64/opensbi.nix
+++ b/pine64/star64/opensbi.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, withPlatform ? "generic"
+, withPayload ? null
+, withFDT ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "opensbi";
+  version = "1.3-git-2868f26";
+
+  src = fetchFromGitHub {
+    owner = "riscv-software-src";
+    repo = "opensbi";
+    rev = "2868f26131308ff345382084681ea89c5b0159f1";
+    hash = "sha256-E+nVFLSpH6lQ2nVmMlVRTr7qYRVY0ULW7gUvAyTr90I=";
+  };
+
+  postPatch = ''
+    patchShebangs ./scripts
+  '';
+
+  nativeBuildInputs = [ python3 ];
+
+  installFlags = [
+    "I=$(out)"
+  ];
+
+  makeFlags = [
+    "PLATFORM=${withPlatform}"
+    "FW_TEXT_START=0x40000000"
+  ] ++ lib.optionals (withPayload != null) [
+    "FW_PAYLOAD_PATH=${withPayload}"
+  ] ++ lib.optionals (withFDT != null) [
+    "FW_FDT_PATH=${withFDT}"
+  ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+}

--- a/pine64/star64/pl330-name-collision.patch
+++ b/pine64/star64/pl330-name-collision.patch
@@ -1,0 +1,40 @@
+diff --git a/drivers/dma/pl330.c b/drivers/dma/pl330.c
+index 110de8a60058..0a01256ef9e4 100644
+--- a/drivers/dma/pl330.c
++++ b/drivers/dma/pl330.c
+@@ -1050,7 +1050,7 @@ static bool _trigger(struct pl330_thread *thrd)
+ 	return true;
+ }
+ 
+-static bool _start(struct pl330_thread *thrd)
++static bool _dma_start(struct pl330_thread *thrd)
+ {
+ 	switch (_state(thrd)) {
+ 	case PL330_STATE_FAULT_COMPLETING:
+@@ -1702,7 +1702,7 @@ static int pl330_update(struct pl330_dmac *pl330)
+ 			thrd->req_running = -1;
+ 
+ 			/* Get going again ASAP */
+-			_start(thrd);
++			_dma_start(thrd);
+ 
+ 			/* For now, just make a list of callbacks to be done */
+ 			list_add_tail(&descdone->rqd, &pl330->req_done);
+@@ -2089,7 +2089,7 @@ static void pl330_tasklet(struct tasklet_struct *t)
+ 	} else {
+ 		/* Make sure the PL330 Channel thread is active */
+ 		spin_lock(&pch->thread->dmac->lock);
+-		_start(pch->thread);
++		_dma_start(pch->thread);
+ 		spin_unlock(&pch->thread->dmac->lock);
+ 	}
+ 
+@@ -2107,7 +2107,7 @@ static void pl330_tasklet(struct tasklet_struct *t)
+ 			if (power_down) {
+ 				pch->active = true;
+ 				spin_lock(&pch->thread->dmac->lock);
+-				_start(pch->thread);
++				_dma_start(pch->thread);
+ 				spin_unlock(&pch->thread->dmac->lock);
+ 				power_down = false;
+ 			}

--- a/pine64/star64/sd-image-installer.nix
+++ b/pine64/star64/sd-image-installer.nix
@@ -1,0 +1,11 @@
+{ modulesPath, ... }:
+{
+  imports = [
+    "${modulesPath}/profiles/installation-device.nix"
+    ./sd-image.nix
+  ];
+
+  # The installation media is also the installation target,
+  # so we don't want to provide the installation configuration.nix.
+  installer.cloneConfig = false;
+}

--- a/pine64/star64/sd-image.nix
+++ b/pine64/star64/sd-image.nix
@@ -1,0 +1,52 @@
+{ config, pkgs, lib, modulesPath, ... }:
+
+let firmware = pkgs.callPackage ./firmware.nix { };
+in {
+  imports = [
+    "${modulesPath}/profiles/base.nix"
+    "${modulesPath}/installer/sd-card/sd-image.nix"
+    ./default.nix
+  ];
+
+  sdImage = {
+    imageName =
+      "${config.sdImage.imageBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}-pine64-star64.img";
+
+    # Overridden by postBuildCommands
+    populateFirmwareCommands = "";
+
+    firmwarePartitionOffset = 4;
+    firmwareSize = 4;
+
+    postBuildCommands = ''
+      # preserve root partition
+      eval $(partx $img -o START,SECTORS --nr 2 --pairs)
+
+      # increase image size for gpt backup header
+      truncate -s '+2M' $img
+
+      sfdisk $img <<EOF
+          label: gpt
+          unit: sectors
+          sector-size: 512
+
+          start=4096, size=4096, type=2E54B353-1271-4842-806F-E436D6AF6985
+          start=8192, size=8192, type=5B193300-FC78-40CD-8002-E86C45580B47
+          start=$START, size=$SECTORS, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, attrs="LegacyBIOSBootable"
+      EOF
+
+      eval $(partx $img -o START,SECTORS --nr 1 --pairs)
+      dd conv=notrunc if=${firmware.spl}/share/pine64-star64/spl.bin of=$img seek=$START count=$SECTORS
+
+      eval $(partx $img -o START,SECTORS --nr 2 --pairs)
+      dd conv=notrunc if=${firmware.uboot-fit-image}/share/pine64-star64/star64_fw_payload.img of=$img seek=$START count=$SECTORS
+    '';
+
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
+    '';
+  };
+
+  environment.systemPackages = [ firmware.updater-flash ];
+}

--- a/pine64/star64/spl-tool.nix
+++ b/pine64/star64/spl-tool.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec{
+  pname = "spi_tool";
+  version = "unstable-2023-04-14";
+  src = fetchFromGitHub {
+    owner = "starfive-tech";
+    repo = "Tools";
+    rev = "693661d4ba314424f76c06da1bbb799e9b534c9f";
+    hash = "sha256-POWwpIIPnquJs/bpC3Pn94skua3SZvyfICPBglO7HnU=";
+    sparseCheckout = [ "spl_tool" ];
+  };
+  sourceRoot = "source/spl_tool";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp spl_tool $out/bin
+  '';
+}

--- a/pine64/star64/star64-8GB.dts
+++ b/pine64/star64/star64-8GB.dts
@@ -1,0 +1,11 @@
+/dts-v1/;
+/plugin/;
+/ {
+	compatible = "pine64,star64", "starfive,jh7110";
+	fragment@0 {
+		target-path = "/memory@40000000";
+		__overlay__ {
+			reg = <0x0 0x40000000 0x2 0x0>;
+		};
+	};
+};

--- a/pine64/star64/uboot.nix
+++ b/pine64/star64/uboot.nix
@@ -1,0 +1,20 @@
+{ fetchFromGitHub, buildUBoot }:
+
+buildUBoot rec {
+  version = "3.0.4";
+
+  src = fetchFromGitHub {
+    owner = "Fishwaldo";
+    repo = "u-boot";
+    rev = "172b47f62039605d6806fa96bd403c21cda28996"; # Star64 branch
+    hash = "sha256-UBPTLbSjDdL6NPUrAdsWcL28QSyiY/5oA+iqxl9dEGY=";
+  };
+
+  defconfig = "pine64_star64_defconfig";
+  filesToInstall = [
+    "u-boot.bin"
+    "arch/riscv/dts/pine64_star64.dtb"
+    "spl/u-boot-spl.bin"
+    "tools/mkimage"
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Mostly based on the visionfive 2 config.
No GPU yet.

Sample image built directly on the board: https://app.cachix.org/api/v1/cache/fgaz/serve/hj72i7znp0rvc4dxs2xslw6b3ik3wifb/sd-image/nixos-sd-image-23.11pre-git-riscv64-linux-pine64-star64.img.zst (8GB RAM, user/pw: nixos)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

