### PR TITLE
lenovo legion 7 slim 15ach6: remove brightness service

### DIFF
--- a/lenovo/legion/15ach6/default.nix
+++ b/lenovo/legion/15ach6/default.nix
@@ -20,28 +20,4 @@ in {
 
   # √(3840² + 2160²) px / 15.60 in ≃ 282 dpi
   services.xserver.dpi = 282;
-
-  # https://wiki.archlinux.org/title/backlight#Backlight_is_always_at_full_brightness_after_a_reboot_with_amdgpu_driver
-  systemd.services.fix-brightness = {
-    before = [
-      "systemd-backlight@backlight:${
-        if lib.versionOlder kernelPackages.kernel.version "5.18" then "amdgpu_bl0" else "nvidia_wmi_ec_backlight"
-      }.service"
-    ];
-    description = "Convert 16-bit brightness values to 8-bit before systemd-backlight applies it";
-    script = ''
-      BRIGHTNESS_FILE="/var/lib/systemd/backlight/${
-        if lib.versionOlder kernelPackages.kernel.version "5.18" then
-          "pci-0000:05:00.0:backlight:amdgpu_bl0"
-        else
-          "platform-PNP0C14:00:backlight:nvidia_wmi_ec_backlight"
-      }"
-      BRIGHTNESS=$(cat "$BRIGHTNESS_FILE")
-      BRIGHTNESS=$(($BRIGHTNESS*255/65535))
-      BRIGHTNESS=''${BRIGHTNESS/.*} # truncating to int, just in case
-      echo $BRIGHTNESS > "$BRIGHTNESS_FILE"
-    '';
-    serviceConfig.Type = "oneshot";
-    wantedBy = [ "multi-user.target" ];
-  };
 }


### PR DESCRIPTION
###### Description of changes

This keeps breaking with kernel patches. There seems to be no real pattern. I'll maintain this myself on my config.

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

