### PR TITLE
ga402: remove useless kernel flags

### DIFF
--- a/asus/zephyrus/ga402/default.nix
+++ b/asus/zephyrus/ga402/default.nix
@@ -18,8 +18,4 @@
        KEYBOARD_KEY_ff31007c=f20
     '';
   };
-
-  boot = {
-    kernelParams = [ "pcie_aspm.policy=powersupersave" "acpi.prefer_microsoft_dsm_guid=1" ];
-  };
 }


### PR DESCRIPTION
###### Description of changes

I previously added those flags but it was an error. The `acpi.prefer_micosoft_dsm_guide` was handled correctly by the kernel when they fixed the fan behaviour and the `pcie_aspm.policy` shall be handled by scripts or tools like TLP.  


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

