### PR TITLE
framework: switch to power-profiles-daemon

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -24,6 +24,9 @@
     options snd-hda-intel model=dell-headset-multi
   '';
 
+  # Less invasive than tlp and should work for frameworks
+  services.power-profiles-daemon.enable = lib.mkDefault true;
+
   # For fingerprint support
   services.fprintd.enable = lib.mkDefault true;
 


### PR DESCRIPTION
###### Description of changes

Apparently a good idea these days instead of using tlp: https://github.com/NixOS/nixos-hardware/pull/669#issuecomment-1632099013

I am mostly confident that all of the frameworks should be supported: https://gitlab.gnome.org/Infrastructure/Mirrors/lorry-mirrors/gitlab_freedesktop_org/hadess/power-profiles-daemon#operations-on-intel-based-machines

cc @K900 @lheckemann

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

