### PR TITLE
deciso/dec: init, tested with DEC2750

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                  | `<nixos-hardware/asus/zephyrus/ga503>`             |
 | [Asus TUF FX504GD](asus/fx504gd)                                    | `<nixos-hardware/asus/fx504gd>`                    |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                | `<nixos-hardware/beagleboard/pocketbeagle>`        |
+| [Deciso DEC series](deciso/dec)                                     | `<nixos-hardware/deciso/dec>`                      |
 | [Dell G3 3779](dell/g3/3779)                                        | `<nixos-hardware/dell/g3/3779>`                    |
 | [Dell Inspiron 5509](dell/inspiron/5509)                            | `<nixos-hardware/dell/inspiron/5509>`              |
 | [Dell Inspiron 5515](dell/inspiron/5515)                            | `<nixos-hardware/dell/inspiron/5515>`              |

--- a/deciso/dec/default.nix
+++ b/deciso/dec/default.nix
@@ -1,0 +1,3 @@
+{
+  boot.kernelParams = [ "console=ttyS0,115200n8" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
+      deciso-dec = import ./deciso/dec;
       dell-e7240 = import ./dell/e7240;
       dell-g3-3779 = import ./dell/g3/3779;
       dell-inspiron-5509 = import ./dell/inspiron/5509;


### PR DESCRIPTION
###### Description of changes

Enables serial console output and getty for the headless [Deciso DEC2750](https://shop.opnsense.com/product/dec2750-opnsense-rack-security-appliance/). The unit ships stock with opnsense but I was able to install NixOS without much trouble after applying roughly this patch to build preconfigured install media.

Since all of the DEC series have a console port with a USB-to-serial chip built in I figure it is probably fine to name this `deciso/dec` rather than `deciso/dec2750`, but I don't have strong feelings on the topic either.

```
[matt@routnerr-3:~]$ neofetch 
          ▗▄▄▄       ▗▄▄▄▄    ▄▄▄▖            matt@routnerr-3 
          ▜███▙       ▜███▙  ▟███▛            --------------- 
           ▜███▙       ▜███▙▟███▛             OS: NixOS 23.05.2064.53657afe297 (Stoat) x86_64 
            ▜███▙       ▜██████▛              Host: Deciso B.V. NetBoard-A10 Gen.3 
     ▟█████████████████▙ ▜████▛     ▟▙        Kernel: 6.1.38 
    ▟███████████████████▙ ▜███▙    ▟██▙       Uptime: 14 hours, 23 mins 
           ▄▄▄▄▖           ▜███▙  ▟███▛       Packages: 608 (nix-system) 
          ▟███▛             ▜██▛ ▟███▛        Shell: bash 5.2.15 
         ▟███▛               ▜▛ ▟███▛         Terminal: /dev/pts/1 
▟███████████▛                  ▟██████████▙   CPU: AMD Ryzen Embedded V1500B (8) @ 2.200GHz 
▜██████████▛                  ▟███████████▛   Memory: 615MiB / 7905MiB 
      ▟███▛ ▟▙               ▟███▛
     ▟███▛ ▟██▙             ▟███▛                                     
    ▟███▛  ▜███▙           ▝▀▀▀▀                                      
    ▜██▛    ▜███▙ ▜██████████████████▛
     ▜▛     ▟████▙ ▜████████████████▛
           ▟██████▙       ▜███▙
          ▟███▛▜███▙       ▜███▙
         ▟███▛  ▜███▙       ▜███▙
         ▝▀▀▀    ▀▀▀▀▘       ▀▀▀▘
```
```
Welcome to minicom 2.8

OPTIONS: I18n 
Compiled on Jan  1 1980, 00:00:00.
Port /dev/ttyUSB0, 18:38:49

Press CTRL-A Z for help on special keys

<<< Welcome to NixOS 23.05.2064.53657afe297 (x86_64) - ttyS0 >>>

Run 'nixos-help' for the NixOS manual.

routnerr-3 login: 
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

