### PR TITLE
Added Asus Zephyrus GA502

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See code for all available configurations.
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                      | `<nixos-hardware/asus/rog-strix/g733qs>`           |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                  | `<nixos-hardware/asus/zephyrus/ga401>`             |
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                  | `<nixos-hardware/asus/zephyrus/ga402>`             |
+| [Asus ROG Zephyrus G15 GA502](asus/zephyrus/ga502)                  | `<nixos-hardware/asus/zephyrus/ga502>`             |
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                  | `<nixos-hardware/asus/zephyrus/ga503>`             |
 | [Asus TUF FX504GD](asus/fx504gd)                                    | `<nixos-hardware/asus/fx504gd>`                    |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                | `<nixos-hardware/beagleboard/pocketbeagle>`        |

--- a/asus/zephyrus/ga502/default.nix
+++ b/asus/zephyrus/ga502/default.nix
@@ -1,0 +1,21 @@
+{ ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  hardware.nvidia.prime = {
+    amdgpuBusId = "PCI:6:0:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+
+  # fixes mic mute button
+  services.udev.extraHwdb = ''
+    evdev:name:*:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:*
+     KEYBOARD_KEY_ff31007c=f20
+  '';
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;
+      asus-zephyrus-ga502 = import ./asus/zephyrus/ga502;
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
       dell-e7240 = import ./dell/e7240;


### PR DESCRIPTION
###### Description of changes
Added a configuration specific for the Asus Zephyrus GA502. My AMD card is on PCI:6:0:0 and the Nvidia card is on PCI:1:0:0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

