### PR TITLE
framework: Clarify 13th Gen Intel Core support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ See code for all available configurations.
 | [Dell XPS 17 9700, nvidia](dell/xps/17-9700/nvidia)                 | `<nixos-hardware/dell/xps/17-9700/nvidia>`         |
 | [Dell XPS 17 9710, intel only](dell/xps/17-9710/intel)              | `<nixos-hardware/dell/xps/17-9710/intel>`          |
 | [Dell XPS E7240](dell/e7240)                                        | `<nixos-hardware/dell/e7240>`                      |
-| [Framework](framework)                                              | `<nixos-hardware/framework>`                       |
+| [Framework 11th Gen Intel Core](framework)                          | `<nixos-hardware/framework>`                       |
 | [Framework 12th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
+| [Framework 13th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [Focus M2 Gen 1](focus/m2/gen1)                                     | `<nixos-hardware/focus/m2/gen1>`                   |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |

--- a/framework/13th-gen-intel/README.md
+++ b/framework/13th-gen-intel/README.md
@@ -13,5 +13,3 @@ Then run
 ```sh
  $ sudo fwupdmgr update
 ```
-
-- [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop.ADL.BIOS.firmware)

--- a/framework/13th-gen-intel/default.nix
+++ b/framework/13th-gen-intel/default.nix
@@ -1,0 +1,7 @@
+{ lib, pkgs, ... }: {
+  imports = [
+    # Same config as 12th Gen. The chipsets and mainboard are similar enough
+    # that no separate configuration is needed.
+    ../12th-gen-intel
+  ];
+}

--- a/framework/README.md
+++ b/framework/README.md
@@ -1,4 +1,4 @@
-# [Framework Laptop](https://frame.work/)
+# [Framework Laptop 13](https://frame.work/)
 
 ## Updating Firmware
 


### PR DESCRIPTION
###### Description of changes

Clarify 13th Gen Intel Core support. The chipsets and mainboard are similar
enough that no separate configuration is needed.