### PR TITLE
starfive visionfive2: update kernel to 6.5.0-rc1

### DIFF
--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -4,7 +4,7 @@
     supportedFilesystems =
       lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
     consoleLogLevel = lib.mkDefault 7;
-    kernelPackages = lib.mkDefault (pkgs.callPackage ./linux-6.4.nix {
+    kernelPackages = lib.mkDefault (pkgs.callPackage ./linux-6.5.nix {
       inherit (config.boot) kernelPatches;
     });
 

--- a/starfive/visionfive/v2/linux-6.5.nix
+++ b/starfive/visionfive/v2/linux-6.5.nix
@@ -1,7 +1,7 @@
 { lib, callPackage, linuxPackagesFor, kernelPatches, ... }:
 
 let
-  modDirVersion = "6.4.0";
+  modDirVersion = "6.5.0-rc1";
   linuxPkg = { lib, fetchFromGitHub, buildLinux, ... }@args:
     buildLinux (args // {
       version = "${modDirVersion}-starfive-visionfive2";
@@ -9,8 +9,8 @@ let
       src = fetchFromGitHub {
         owner = "starfive-tech";
         repo = "linux";
-        rev = "e5a381c51d624ffd8784db908a58ae227d0608a4";
-        sha256 = "sha256-gg3+2ITdnpo49UmySiAJnk47STW1I7kF7fsKGBVayRE=";
+        rev = "64a6c57ec372c44d0f25416c9614657e274fccff";
+        hash = "sha256-ZOCCj/VyUZa36+q6sUnE+qA0FcNCFnQjIUils0hBb28=";
       };
 
       inherit modDirVersion;


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

