### PR TITLE
microsoft-surface: update default kernel to 6.1.18

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -10,7 +10,7 @@ in {
     ./surface-control
   ];
 
-  microsoft-surface.kernelVersion = mkDefault "6.0.17";
+  microsoft-surface.kernelVersion = mkDefault "6.1.18";
 
   # Seems to be required to properly enable S0ix "Modern Standby":
   boot.kernelParams = mkDefault [ "mem_sleep_default=deep" ];


### PR DESCRIPTION
###### Description of changes

Update default linux kernel for all surface devices to 6.1.8

The previous versions seem to not compile anymore. It affects at least two other people, see:
- https://github.com/NixOS/nixos-hardware/issues/611
- https://github.com/NixOS/nixos-hardware/issues/658

Updating the kernel to the last version seems to do the trick. This pull request does not change
the code for older versions. They should either be updated to correctly compile or removed with
another pull request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

