### PR TITLE
p14s: Add common/{cpu,gpu}/amd to imports

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen2/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen2/default.nix
@@ -2,6 +2,8 @@
 {
   imports = [
     ../../../../../common/pc/laptop/acpi_call.nix
+    ../../../../../common/cpu/amd
+    ../../../../../common/gpu/amd
   ];
 
   # For suspending to RAM, set Config -> Power -> Sleep State to "Linux" in EFI.


### PR DESCRIPTION
###### Description of changes

This is my first upstream contribution (intend to contribute configs for
my NUC, GPD, and ClockworkPi devices). Essentially, this change
resolves https://github.com/NixOS/nixos-hardware/issues/492, by adding the `common/{cpu,gpu}/amd` Nix fragments to the
`imports` list for the Thinkpad P14s.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I have not been able to test these changes in my own configuration, but I have run the unit tests, which passed, save for the following tests, listed below:

```shell
The following 4 test(s) failed:
./tests/run.py '<nixos-hardware/raspberry-pi/4>'
./tests/run.py '<nixos-hardware/asus/zephyrus/ga402>'
./tests/run.py '<nixos-hardware/asus/zephyrus/ga401>'
./tests/run.py '<nixos-hardware/lenovo/legion/16irx8h>'```