### PR TITLE
GPD-P3: Remove S2 sleep kernel param, use S3 instead

### DIFF
--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -20,9 +20,6 @@ in
 	];
 
 	boot.kernelParams = [
-		# S3 suspend is broken as of Sept. 2022 (screen does not come back properly), use S2
-		"mem_sleep_default=s2idle"
-
 		# The GPD Pocket3 uses a tablet OLED display, that is mounted rotated 90° counter-clockwise
 		"fbcon=rotate:1" "video=DSI-1:panel_orientation=right_side_up"
 	];


### PR DESCRIPTION
###### Description of changes

It seems S3 works on NixOS without this option now. I have tested this on NixOS 22.11/23.05, without issues.

Removing this option ensures better battery life whilst the UMPC is in sleep mode, and reduces the chances of overheating whilst in transit.

All tests have passed, save for these four:

```shell
The following 4 test(s) failed:
./tests/run.py '<nixos-hardware/raspberry-pi/4>'
./tests/run.py '<nixos-hardware/asus/zephyrus/ga402>'
./tests/run.py '<nixos-hardware/asus/zephyrus/ga401>'
./tests/run.py '<nixos-hardware/lenovo/legion/16irx8h>'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

