### PR TITLE
Adding Dell XPS 13 9333

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See code for all available configurations.
 | [Dell XPS 13 7390](dell/xps/13-7390)                                | `<nixos-hardware/dell/xps/13-7390>`                |
 | [Dell XPS 13 9300](dell/xps/13-9300)                                | `<nixos-hardware/dell/xps/13-9300>`                |
 | [Dell XPS 13 9310](dell/xps/13-9310)                                | `<nixos-hardware/dell/xps/13-9310>`                |
+| [Dell XPS 13 9333](dell/xps/13-9333)                                | `<nixos-hardware/dell/xps/13-9333>`                |
 | [Dell XPS 13 9343](dell/xps/13-9343)                                | `<nixos-hardware/dell/xps/13-9343>`                |
 | [Dell XPS 13 9350](dell/xps/13-9350)                                | `<nixos-hardware/dell/xps/13-9350>`                |
 | [Dell XPS 13 9360](dell/xps/13-9360)                                | `<nixos-hardware/dell/xps/13-9360>`                |

--- a/dell/xps/13-9333/README.wiki
+++ b/dell/xps/13-9333/README.wiki
@@ -1,0 +1,9 @@
+= Dell XPS 13 9300 =
+
+== SSD ==
+
+In the <code>default.nix</code> file, I imported
+<code>../../../common/pc/ssd</code> because my laptop has currently an SSD, but
+I'm not sure if it was the case when I bought it or if I installed it later.
+
+The main updates allow the touchpad to work.

--- a/dell/xps/13-9333/default.nix
+++ b/dell/xps/13-9333/default.nix
@@ -9,7 +9,4 @@
   boot.kernelParams = [ "i8042.nopnp=1" ];
   boot.blacklistedKernelModules = [ "i2c_hid" "i2c_hid_acpi" ];
   boot.kernelModules = [ "synaptics_i2c"];
-
-  # Allows for updating firmware via `fwupdmgr`.
-  services.fwupd.enable = true;
 }

--- a/dell/xps/13-9333/default.nix
+++ b/dell/xps/13-9333/default.nix
@@ -1,0 +1,15 @@
+{ lib, pkgs, ... }: {
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  # Required to allow the touchpad to work
+  boot.kernelParams = [ "i8042.nopnp=1" ];
+  boot.blacklistedKernelModules = [ "i2c_hid" "i2c_hid_acpi" ];
+  boot.kernelModules = [ "synaptics_i2c"];
+
+  # Allows for updating firmware via `fwupdmgr`.
+  services.fwupd.enable = true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
       dell-xps-13-7390 = import ./dell/xps/13-7390;
       dell-xps-13-9300 = import ./dell/xps/13-9300;
       dell-xps-13-9310 = import ./dell/xps/13-9310;
+      dell-xps-13-9333 = import ./dell/xps/13-9333;
       dell-xps-13-9343 = import ./dell/xps/13-9343;
       dell-xps-13-9350 = import ./dell/xps/13-9350;
       dell-xps-13-9360 = import ./dell/xps/13-9360;


### PR DESCRIPTION
###### Adding Dell XPS 13 9333


###### Things done

Note1: In the `default.nix` file, I [imported](https://github.com/ttamttam/nixos-hardware/blob/df6673231f19e091b3202b1815b3531150a49fa8/dell/xps/13-9333/default.nix#L5) 
`../../../common/pc/ssd` because my laptop has currently an SSD, but
I'm not sure if it was the case when I bought it or if I installed it later.

Note2: Not sure about this [line](https://github.com/ttamttam/nixos-hardware/blob/df6673231f19e091b3202b1815b3531150a49fa8/dell/xps/13-9333/default.nix#L14) (`services.fwupd.enable = true;`).

- [ ] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

