### PR TITLE
XPS 9560: Remove `lib.mkDefault` on mergable options

### DIFF
--- a/dell/xps/15-9560/default.nix
+++ b/dell/xps/15-9560/default.nix
@@ -15,9 +15,9 @@
 
 
  ##### bumblebee working, needs reboot to take affect and to use it run: optirun "<application>"
- services.xserver.videoDrivers = lib.mkDefault [ "intel" "nvidia" ];
- boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "bbswitch" ];
- boot.extraModulePackages = lib.mkDefault [ pkgs.linuxPackages.nvidia_x11 ];
+ services.xserver.videoDrivers = [ "intel" "nvidia" ];
+ boot.blacklistedKernelModules = [ "nouveau" "bbswitch" ];
+ boot.extraModulePackages = [ pkgs.linuxPackages.nvidia_x11 ];
  hardware.bumblebee.enable = lib.mkDefault true;
  hardware.bumblebee.pmMethod = lib.mkDefault "none";
 

--- a/dell/xps/15-9560/xps-common.nix
+++ b/dell/xps/15-9560/xps-common.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 
 {
-  boot.kernelParams = lib.mkDefault [ "acpi_rev_override" ];
+  boot.kernelParams = [ "acpi_rev_override" ];
 
   # This will save you money and possibly your life!
   services.thermald.enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes

Adjust XPS 9560 module to match with CONTRIBUTING.md guidelines. Specifically to remove `lib.mkDefault` on options we would want to allow merging user config with.

Related to #607 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

