### PR TITLE
common/nvidia disable: Remove `lib.mkDefault`

### DIFF
--- a/common/gpu/nvidia/disable.nix
+++ b/common/gpu/nvidia/disable.nix
@@ -1,15 +1,15 @@
-{ lib, ... }:
+{ ... }:
 
 {
   # This runs only intel/amdgpu igpus and nvidia dgpus do not drain power.
 
   ##### disable nvidia, very nice battery life.
-  boot.extraModprobeConfig = lib.mkDefault ''
+  boot.extraModprobeConfig = ''
     blacklist nouveau
     options nouveau modeset=0
   '';
   
-  services.udev.extraRules = lib.mkDefault ''
+  services.udev.extraRules = ''
     # Remove NVIDIA USB xHCI Host Controller devices, if present
     ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{power/control}="auto", ATTR{remove}="1"
 
@@ -22,5 +22,5 @@
     # Remove NVIDIA VGA/3D controller devices
     ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", ATTR{power/control}="auto", ATTR{remove}="1"
   '';
-  boot.blacklistedKernelModules = lib.mkDefault [ "nouveau" "nvidia" "nvidia_drm" "nvidia_modeset" ];
+  boot.blacklistedKernelModules = [ "nouveau" "nvidia" "nvidia_drm" "nvidia_modeset" ];
 }


### PR DESCRIPTION
###### Description of changes

Adjust Nvidia disable module to match with CONTRIBUTING.md guidelines. Specifically to remove lib.mkDefault on options we would want to allow merging user config with.

Another PR performing this change treewide may be beneficial.

Related to #691 

Fixes #607 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

