### PR TITLE
raspberry-pi/4: fix modesetting on 6.1 kernels

### DIFF
--- a/raspberry-pi/4/modesetting.nix
+++ b/raspberry-pi/4/modesetting.nix
@@ -27,6 +27,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # fixes a crash: https://github.com/raspberrypi/linux/issues/5568
+    # can be removed for >= nixos 23.11: https://github.com/NixOS/nixpkgs/pull/247826
+    boot.kernelParams = [ "kunit.enable=0" ];
+
+    # doesn't work for the CM module, so we exclude e.g. bcm2711-rpi-cm4.dts
+    hardware.deviceTree.filter = "bcm2711-rpi-4*.dtb";
+
     # Configure for modesetting in the device tree
     hardware.deviceTree = {
       overlays = [


### PR DESCRIPTION
###### Description of changes

Fixes #631

This should work with both nixos-23.05 and nixos-unstable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

