### PR TITLE
star64: remove unused flake input from README

### DIFF
--- a/pine64/star64/README.md
+++ b/pine64/star64/README.md
@@ -8,7 +8,7 @@ Create and configure the `flake.nix` file:
   inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
 
 
-  outputs = { self, nixpkgs, nixos-hardware, flake-utils, ... }:
+  outputs = { self, nixpkgs, nixos-hardware, ... }:
     let
       supportedSystems = [
         "x86_64-linux"


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

