### PR TITLE
Dell XPS 9560: Add info to README and adjust configuration

### DIFF
--- a/dell/xps/15-9560/README.wiki
+++ b/dell/xps/15-9560/README.wiki
@@ -67,7 +67,7 @@ boot.kernelParams = [ "acpi_rev_override=1" "pcie_aspm=off" "nouveau.modeset=0" 
 
 Some more detail about the problem can be found here: https://bbs.archlinux.org/viewtopic.php?id=223056
 
-=== TPM 2.0 Intermittent ===
+==== TPM 2.0 Intermittent ====
 
 * The TPM was very unreliable, sometimes not showing up to the system. Updating to the latest TPM firmware fixed the problem. I could not seem to do this through `fwupd` so used the latest exe from the Dell website. Loading the exe through a command prompt on a Windows installer was adequate.
 

--- a/dell/xps/15-9560/README.wiki
+++ b/dell/xps/15-9560/README.wiki
@@ -31,9 +31,7 @@ These settings are needed both for booting the final install, and installer itse
 
 === Optional ===
 
-* ''Disable C-States.'' This is a processor idling thing. It seems to cause random crashes (Blank screen, no normal panic debug dump). Unfortunately, without it, the computer cannot be suspended. On the other hand, it doesn't seem to affect acpi's estimation of battery life when the computer is running with minimal load, but I haven't tested battery life in practice. I list it as optional as there's a tradeoff, and the crashes are rare enough one can probably get through installation just fine.
-
-  * This does not seem to be a problem on recent firmware/kernel versions.
+* ''Disable C-States.'' This is a processor idling thing. It seems to cause random crashes (Blank screen, no normal panic debug dump). Unfortunately, without it, the computer cannot be suspended. On the other hand, it doesn't seem to affect acpi's estimation of battery life when the computer is running with minimal load, but I haven't tested battery life in practice. I list it as optional as there's a tradeoff, and the crashes are rare enough one can probably get through installation just fine. This does not seem to be a problem on recent firmware/kernel versions.
 
 * ''Update BIOS.'' According to Reddit, this helps with battery life.
 

--- a/dell/xps/15-9560/README.wiki
+++ b/dell/xps/15-9560/README.wiki
@@ -14,6 +14,8 @@
 
 Not much tweaking of NixOS itself was needed. But we currently cannot automate the firmware setup, so this must be done by hand.
 
+== Installation ==
+
 === Before installation ===
 
 These settings are needed both for booting the final install, and installer itself. Therefore, they must be done first.
@@ -31,11 +33,23 @@ These settings are needed both for booting the final install, and installer itse
 
 * ''Disable C-States.'' This is a processor idling thing. It seems to cause random crashes (Blank screen, no normal panic debug dump). Unfortunately, without it, the computer cannot be suspended. On the other hand, it doesn't seem to affect acpi's estimation of battery life when the computer is running with minimal load, but I haven't tested battery life in practice. I list it as optional as there's a tradeoff, and the crashes are rare enough one can probably get through installation just fine.
 
+  * This does not seem to be a problem on recent firmware/kernel versions.
+
 * ''Update BIOS.'' According to Reddit, this helps with battery life.
 
 * ''Update Intel's Thunderbolt firmware.'' Without this, the Thunderbolt port will only work as power source, and not transfer data.
 
-=== Troubleshooting ===
+== Optional Functionality ==
+
+* ''Fan control'' This laptop supports Dell's own [libsmbios](https://github.com/dell/libsmbios) to set fan modes, as well as other bios settings. Simply add the `libsmbios` package to your environment.
+
+* ''TPM 2.0 LUKS Decryption'' If using the experimental systemd initrd, the TPM can easily be used to decrypt the root partition at boot. Simply use `systemd-cryptenroll` with desired options.
+
+* ''Firmware Upgrades'' `services.fwupd` and your desired front-end can be used to update almost all of the firmware on this system. Something curious is the BIOS offered through fwupd/lvfs is much newer than the one available on Dell's website.
+
+* ''Secure Boot'' This works. There is more than one way to enable it. Tested with [lanzaboote](https://github.com/nix-community/lanzaboote) v0.3.0
+
+== Troubleshooting ==
 
 ==== rcu_sched freezing problems ====
 
@@ -52,3 +66,12 @@ boot.kernelParams = [ "acpi_rev_override=1" "pcie_aspm=off" "nouveau.modeset=0" 
 ```
 
 Some more detail about the problem can be found here: https://bbs.archlinux.org/viewtopic.php?id=223056
+
+=== TPM 2.0 Intermittent ===
+
+* The TPM was very unreliable, sometimes not showing up to the system. Updating to the latest TPM firmware fixed the problem. I could not seem to do this through `fwupd` so used the latest exe from the Dell website. Loading the exe through a command prompt on a Windows installer was adequate.
+
+== Broken Functionality ==
+
+* ''Fingerprint Reader'': Can be enabled with `services.fprintd.enable`, and can read your fingerprint. Fingerprint authentication is extremely reliable to the point it is not worth using.
+

--- a/dell/xps/15-9560/README.wiki
+++ b/dell/xps/15-9560/README.wiki
@@ -41,13 +41,13 @@ These settings are needed both for booting the final install, and installer itse
 
 == Optional Functionality ==
 
-* ''Fan control'' This laptop supports Dell's own [libsmbios](https://github.com/dell/libsmbios) to set fan modes, as well as other bios settings. Simply add the `libsmbios` package to your environment.
+* ''Fan control'' This laptop supports Dell's own libsmbios: https://github.com/dell/libsmbios to set fan modes, as well as other bios settings. Simply add the `libsmbios` package to your environment.
 
 * ''TPM 2.0 LUKS Decryption'' If using the experimental systemd initrd, the TPM can easily be used to decrypt the root partition at boot. Simply use `systemd-cryptenroll` with desired options.
 
 * ''Firmware Upgrades'' `services.fwupd` and your desired front-end can be used to update almost all of the firmware on this system. Something curious is the BIOS offered through fwupd/lvfs is much newer than the one available on Dell's website.
 
-* ''Secure Boot'' This works. There is more than one way to enable it. Tested with [lanzaboote](https://github.com/nix-community/lanzaboote) v0.3.0
+* ''Secure Boot'' This works. There is more than one way to enable it. Tested with https://github.com/nix-community/lanzaboote v0.3.0
 
 == Troubleshooting ==
 

--- a/dell/xps/15-9560/default.nix
+++ b/dell/xps/15-9560/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../../common/cpu/intel
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop
     ./xps-common.nix
   ];

--- a/dell/xps/15-9560/intel/default.nix
+++ b/dell/xps/15-9560/intel/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ../../../../common/cpu/intel
+    ../../../../common/cpu/intel/kaby-lake
     ../../../../common/pc/laptop
     ../../../../common/gpu/nvidia/disable.nix
     ../xps-common.nix

--- a/dell/xps/15-9560/nvidia/default.nix
+++ b/dell/xps/15-9560/nvidia/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ ... }:
 
 {
   imports = [
@@ -14,9 +14,9 @@
   ##### disable intel, run nvidia only and as default
   hardware.nvidia.prime = {
     # Bus ID of the Intel GPU.
-    intelBusId = lib.mkDefault "PCI:0:2:0";
+    intelBusId = "PCI:0:2:0";
 
     # Bus ID of the NVIDIA GPU.
-    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+    nvidiaBusId = "PCI:1:0:0";
   };
 }

--- a/dell/xps/15-9560/xps-common.nix
+++ b/dell/xps/15-9560/xps-common.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 
 {
+  # Solution to rcu_sched freezing
   boot.kernelParams = [ "acpi_rev_override" ];
 
   # This will save you money and possibly your life!


### PR DESCRIPTION
###### Description of changes

Added information about hardware functionality and solutions I have discovered:
- Firmware updates with `fwupd`
- System control with `libsmbios`
- TPM 2.0 functions not working (with solutions)
- Note on secure boot functionality
- Note on using the TPM to unlock root drive

And some configuration changes:
- Do not use `lib.mkDefault` for the GPU IDs. User should not need to change this and this will prevent accidentally changing it.
- Import the `common/cpu/intel/kaby-lake` configuration for intel and bumblebee configurations

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

