### PR TITLE
Apply Mic92's suggestions re Framework 13th gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See code for all available configurations.
 | [Dell XPS E7240](dell/e7240)                                        | `<nixos-hardware/dell/e7240>`                      |
 | [Framework 11th Gen Intel Core](framework)                          | `<nixos-hardware/framework>`                       |
 | [Framework 12th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
-| [Framework 13th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
+| [Framework 13th Gen Intel Core](framework/13th-gen-intel)           | `<nixos-hardware/framework/13th-gen-intel>`        |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
 | [Focus M2 Gen 1](focus/m2/gen1)                                     | `<nixos-hardware/focus/m2/gen1>`                   |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
       dell-xps-17-9710-intel = import ./dell/xps/17-9710/intel;
       framework = import ./framework;
       framework-12th-gen-intel = import ./framework/12th-gen-intel;
+      framework-13th-gen-intel = import ./framework/13th-gen-intel;
       friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
       focus-m2-gen1 = import ./focus/m2/gen1;
       google-pixelbook = import ./google/pixelbook;


### PR DESCRIPTION
###### Description of changes

This applies @Mic92's edit suggestions from https://github.com/NixOS/nixos-hardware/pull/675#discussion_r1278526926, fixing the README link and adding a flake.nix field for 13th-generation Intel-based Framework laptops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

