### PR TITLE
starfive visionfive2: use stable opensbi release

### DIFF
--- a/starfive/visionfive/v2/opensbi.nix
+++ b/starfive/visionfive/v2/opensbi.nix
@@ -1,42 +1,14 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, python3
-, withPlatform ? "generic"
-, withPayload ? null
-, withFDT ? null
-}:
+{ opensbi, withPayload, withFDT }:
 
-stdenv.mkDerivation rec {
-  pname = "opensbi";
-  version = "1.3-git-2868f26";
-
-  src = fetchFromGitHub {
-    owner = "riscv-software-src";
-    repo = "opensbi";
-    rev = "2868f26131308ff345382084681ea89c5b0159f1";
-    sha256 = "sha256-E+nVFLSpH6lQ2nVmMlVRTr7qYRVY0ULW7gUvAyTr90I=";
-  };
-
-  postPatch = ''
-    patchShebangs ./scripts
-  '';
-
-  nativeBuildInputs = [ python3 ];
-
-  installFlags = [
-    "I=$(out)"
-  ];
-
-  makeFlags = [
-    "PLATFORM=${withPlatform}"
+(opensbi.override {
+  inherit withPayload withFDT;
+}).overrideAttrs (attrs: {
+  makeFlags = attrs.makeFlags ++ [
+    # opensbi generic platform default FW_TEXT_START is 0x80000000
+    # For JH7110, need to specify the FW_TEXT_START to 0x40000000
+    # Otherwise, the fw_payload.bin downloading via jtag will not run.
+    # https://github.com/starfive-tech/VisionFive2/blob/7733673d27052dc5a48f1cb1d060279dfa3f0241/Makefile#L274
     "FW_TEXT_START=0x40000000"
-  ] ++ lib.optionals (withPayload != null) [
-    "FW_PAYLOAD_PATH=${withPayload}"
-  ] ++ lib.optionals (withFDT != null) [
-    "FW_FDT_PATH=${withFDT}"
   ];
+})
 
-  dontStrip = true;
-  dontPatchELF = true;
-}


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

