### PR TITLE
friendlyarm/nanopi-r5s: init config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See code for all available configurations.
 | [Framework 12th Gen Intel Core](framework/12th-gen-intel)           | `<nixos-hardware/framework/12th-gen-intel>`        |
 | [Framework 13th Gen Intel Core](framework/13th-gen-intel)           | `<nixos-hardware/framework/13th-gen-intel>`        |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                      | `<nixos-hardware/friendlyarm/nanopc-t4>`           |
+| [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                    | `<nixos-hardware/friendlyarm/nanopi-r5s>`          |
 | [Focus M2 Gen 1](focus/m2/gen1)                                     | `<nixos-hardware/focus/m2/gen1>`                   |
 | [GPD MicroPC](gpd/micropc)                                          | `<nixos-hardware/gpd/micropc>`                     |
 | [GPD P2 Max](gpd/p2-max)                                            | `<nixos-hardware/gpd/p2-max>`                      |

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
       framework-12th-gen-intel = import ./framework/12th-gen-intel;
       framework-13th-gen-intel = import ./framework/13th-gen-intel;
       friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
+      friendlyarm-nanopi-r5s = import ./friendlyarm/nanopi-r5s;
       focus-m2-gen1 = import ./focus/m2/gen1;
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;

--- a/friendlyarm/nanopi-r5s/default.nix
+++ b/friendlyarm/nanopi-r5s/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, pkgs
+, ...
+}:
+
+{
+  boot.loader = {
+    grub.enable = lib.mkDefault false;
+    # Enables the generation of /boot/extlinux/extlinux.conf.
+    generic-extlinux-compatible = {
+      enable = lib.mkDefault true;
+      useGenerationDeviceTree = true;
+    };
+  };
+
+  # This file needs to be at the top of /boot
+  hardware.deviceTree.name = lib.mkDefault "../../rk3568-nanopi-r5s.dtb";
+
+  boot.kernelParams = [
+    "console=tty1"
+    "console=ttyS2,1500000"
+    "earlycon=uart8250,mmio32,0xfe660000"
+  ];
+  boot.kernelPatches = [
+    {
+      name = "rockchip-config.patch";
+      patch = null;
+      extraConfig = ''
+        PCIE_ROCKCHIP_EP y
+        PCIE_ROCKCHIP_DW_HOST y
+        ROCKCHIP_VOP2 y
+      '';
+    }
+    {
+      name = "status-leds.patch";
+      patch = null;
+      extraConfig = ''
+        LED_TRIGGER_PHY y
+        USB_LED_TRIG y
+        LEDS_BRIGHTNESS_HW_CHANGED y
+        LEDS_TRIGGER_MTD y
+      '';
+    }
+  ];
+
+  boot.initrd.availableKernelModules = [
+    ## Rockchip
+    ## Storage
+    "sdhci_of_dwcmshc"
+    "dw_mmc_rockchip"
+
+    "analogix_dp"
+    "io-domain"
+    "rockchip_saradc"
+    "rockchip_thermal"
+    "rockchipdrm"
+    "rockchip-rga"
+    "pcie_rockchip_host"
+    "phy-rockchip-pcie"
+    "phy_rockchip_snps_pcie3"
+    "phy_rockchip_naneng_combphy"
+    "phy_rockchip_inno_usb2"
+    "dwmac_rk"
+    "dw_wdt"
+    "dw_hdmi"
+    "dw_hdmi_cec"
+    "dw_hdmi_i2s_audio"
+    "dw_mipi_dsi"
+  ];
+
+  # Most Rockchip CPUs (especially with hybrid cores) work best with "schedutil"
+  powerManagement.cpuFreqGovernor = "schedutil";
+
+  # Let's blacklist the Rockchips RTC module so that the
+  # battery-powered HYM8563 (rtc_hym8563 kernel module) will be used
+  # by default
+  boot.blacklistedKernelModules = [ "rtc_rk808" ];
+}


### PR DESCRIPTION
###### Description of changes
Add an initial bootable configuration for the [FriendlyElec/FriendlyARM NanoPi R5s](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R5S). This config comes from https://github.com/inindev/nanopi-r5/issues/11#issue-1789308883 which I expanded a little bit in my [blog post](https://alanpearce.eu/post/nixos-on-nanopi-r5s/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

