### PR TITLE
Add fgaz to star64 codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,6 @@ dell/xps/13-9380 @kalbasit
 lenovo/thinkpad/x230 @makefu @yegortimoshenko
 lenovo/thinkpad/x250 @Mic92
 pcengines/apu @yegortimoshenko
+pine64/star64 @fgaz
 purism/librem/13v3 @yegortimoshenko
 system76/darp6 @khumba


### PR DESCRIPTION
###### Description of changes

I forgot to add myself when I added the module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

