### PR TITLE
surface: add kernel 6.4.12

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -10,7 +10,7 @@ in {
     ./surface-control
   ];
 
-  microsoft-surface.kernelVersion = mkDefault "6.1.18";
+  microsoft-surface.kernelVersion = mkDefault "6.4.12";
 
   # Seems to be required to properly enable S0ix "Modern Standby":
   boot.kernelParams = mkDefault [ "mem_sleep_default=deep" ];

--- a/microsoft/surface/common/kernel/default.nix
+++ b/microsoft/surface/common/kernel/default.nix
@@ -8,6 +8,7 @@ in {
     ./linux-5.19.17
     ./linux-6.0.17
     ./linux-6.1.18
+    ./linux-6.4.12
   ];
 
   options.microsoft-surface.kernelVersion = mkOption {

--- a/microsoft/surface/common/kernel/linux-6.4.12/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.4.12/default.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf mkOption types;
+  inherit (pkgs) fetchurl;
+
+  inherit (pkgs.callPackage ../linux-package.nix { }) linuxPackage repos;
+
+  cfg = config.microsoft-surface;
+
+  version = "6.4.12";
+  extraMeta.branch = "6.4";
+  patchDir = repos.linux-surface + "/patches/${extraMeta.branch}";
+  kernelPatches = pkgs.callPackage ./patches.nix {
+    inherit (lib) kernel;
+    inherit version patchDir;
+  };
+
+  kernelPackages = linuxPackage {
+    inherit version extraMeta kernelPatches;
+    src = fetchurl {
+      url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
+      sha256 = "0x56b4hslm730ghvggz41fjkbzlnxp6k8857dn7iy27yavlipafc";
+    };
+  };
+
+
+in {
+  options.microsoft-surface.kernelVersion = mkOption {
+    type = types.enum [ "6.4.12" ];
+  };
+
+  config = mkIf (cfg.kernelVersion == "6.4.12") {
+    boot = {
+      inherit kernelPackages;
+    };
+  };
+}

--- a/microsoft/surface/common/kernel/linux-6.4.12/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.4.12/patches.nix
@@ -1,0 +1,138 @@
+{ kernel,
+  patchDir,
+  version,
+}:
+
+[
+  {
+    name = "microsoft-surface-patches-linux-${version}";
+    patch = null;
+    structuredExtraConfig = with kernel; {
+      STREAMING_MEDIA = yes;
+
+      #
+      # Surface Aggregator Module
+      #
+      SURFACE_AGGREGATOR = module;
+      SURFACE_AGGREGATOR_ERROR_INJECTION = no;
+      SURFACE_AGGREGATOR_BUS = yes;
+      SURFACE_AGGREGATOR_CDEV = module;
+      SURFACE_AGGREGATOR_HUB = module;
+      SURFACE_AGGREGATOR_REGISTRY = module;
+      SURFACE_AGGREGATOR_TABLET_SWITCH = module;
+
+      SURFACE_ACPI_NOTIFY = module;
+      SURFACE_DTX = module;
+      SURFACE_PLATFORM_PROFILE = module;
+
+      SURFACE_HID = module;
+      SURFACE_KBD = module;
+
+      BATTERY_SURFACE = module;
+      CHARGER_SURFACE = module;
+
+      #
+      # Surface Hotplug
+      #
+      SURFACE_HOTPLUG = module;
+
+      #
+      # Intel Touch Host Controller
+      #
+      HID_ITHC = module;
+
+      #
+      # IPTS touchscreen
+      #
+      # This only enables the user interface for IPTS data.
+      # For the touchscreen to work, you need to install iptsd.
+      #
+      MISC_IPTS = module;
+
+      #
+      # Cameras: IPU3
+      #
+      VIDEO_DW9719 = module;
+      VIDEO_IPU3_IMGU = module;
+      VIDEO_IPU3_CIO2 = module;
+      CIO2_BRIDGE = yes;
+      INTEL_SKL_INT3472 = module;
+      REGULATOR_TPS68470 = module;
+      COMMON_CLK_TPS68470 = module;
+      COMMON_LEDS_TPS68470 = module;
+
+      #
+      # Cameras: Sensor drivers
+      #
+      VIDEO_OV5693 = module;
+      VIDEO_OV7251 = module;
+      VIDEO_OV8865 = module;
+
+      #
+      # ALS Sensor for Surface Book 3, Surface Laptop 3, Surface Pro 7
+      #
+      APDS9960 = module;
+
+      #
+      # Other Drivers
+      #
+      INPUT_SOC_BUTTON_ARRAY = module;
+      SURFACE_3_POWER_OPREGION = module;
+      SURFACE_PRO3_BUTTON = module;
+      SURFACE_GPE = module;
+      SURFACE_BOOK1_DGPU_SWITCH = module;
+    };
+  }
+  {
+    name = "ms-surface/0001-surface3-oemb";
+    patch = patchDir + "/0001-surface3-oemb.patch";
+  }
+  {
+    name = "ms-surface/0002-mwifiex";
+    patch = patchDir + "/0002-mwifiex.patch";
+  }
+  {
+    name = "ms-surface/0003-ath10k";
+    patch = patchDir + "/0003-ath10k.patch";
+  }
+  {
+    name = "ms-surface/0004-ipts";
+    patch = patchDir + "/0004-ipts.patch";
+  }
+  {
+    name = "ms-surface/0005-ithc";
+    patch = patchDir + "/0005-ithc.patch";
+  }
+  {
+    name = "ms-surface/0006-surface-sam-over-hid";
+    patch = patchDir + "/0006-surface-sam-over-hid.patch";
+  }
+  {
+    name = "ms-surface/0007-surface-button";
+    patch = patchDir + "/0007-surface-button.patch";
+  }
+  {
+    name = "ms-surface/0008-surface-typecover";
+    patch = patchDir + "/0008-surface-typecover.patch";
+  }
+  {
+    name = "ms-surface/0009-surface-shutdown";
+    patch = patchDir + "/0009-surface-shutdown.patch";
+  }
+  {
+    name = "ms-surface/0010-surface-gpe";
+    patch = patchDir + "/0010-surface-gpe.patch";
+  }
+  {
+    name = "ms-surface/0011-cameras";
+    patch = patchDir + "/0011-cameras.patch";
+  }
+  {
+    name = "ms-surface/0012-amd-gpio";
+    patch = patchDir + "/0012-amd-gpio.patch";
+  }
+  {
+    name = "ms-surface/0013-rtc";
+    patch = patchDir + "/0013-rtc.patch";
+  }
+]

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "efe7ddadd4aad3d1a6531334fe086931ec8640a1";
-    sha256 = "sha256-WgJHLY4vU4lsZ6M0hOng8TMVRALxQeSwQM4QX6DzrbI=";
+    rev = "32c55fe01ce62bf763181d06f0493c29e178cc62";
+    hash = "sha256-oWZeHoLR3jSkMFfc36ikEwyFuXWzwXK/dC4sE98R0oc=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes

- Adds kernel 6.4.12 with linux-surface patches
- Changes default `microsoft-surface.kernelVersion` to 6.4.12
- Tested on Surface Laptop 4 AMD
- Not tested on other surface devices
- Other kernel versions (6.1, etc) not tested

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

