### PR TITLE
Add initial support for Odroid h3/h3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ See code for all available configurations.
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                  | `<nixos-hardware/microsoft/surface-pro/3>`         |
 | [Morefine M600](morefine/m600)                                      | `<nixos-hardware/morefine/m600>`                   |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)          | `<nixos-hardware/hardkernel/odroid-hc4>`           |
+| [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)            | `<nixos-hardware/hardkernel/odroid-h3>`            |
 | [Omen en00015p](omen/en00015p)                                      | `<nixos-hardware/omen/en00015p>`                   |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |
 | [Panasonic Let's Note CF-LX4 ](panasonic/letsnote/cf-lx4)           | `<nixos-hardware/panasonic/letsnote/cf-lx4>`       |

--- a/common/cpu/intel/elkhart-lake/default.nix
+++ b/common/cpu/intel/elkhart-lake/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [ ../. ];
+
+  boot.kernelParams = [
+    "i915.enable_guc=2"
+  ];
+}

--- a/common/cpu/intel/jasper-lake/default.nix
+++ b/common/cpu/intel/jasper-lake/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [ ../. ];
+
+  boot.kernelParams = [
+    "i915.enable_guc=2"
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,7 @@
       msi-gl62 = import ./msi/gl62;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
       hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
+      hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;
       omen-en00015p = import ./omen/en00015p;
       onenetbook-4 = import ./onenetbook/4;
       pcengines-apu = import ./pcengines/apu;

--- a/hardkernel/odroid-h3/default.nix
+++ b/hardkernel/odroid-h3/default.nix
@@ -1,0 +1,7 @@
+{ config, lib, ... }:
+
+{
+  imports = [
+    ../../common/cpu/intel/jasper-lake
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Added intel Jasper and Elkhart lake common options: 
* Based on this documentation: https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#known-issues-and-limitations
* other relevant ticket: https://gitlab.freedesktop.org/drm/intel/-/issues/8080


Add initial support for odroid-h3 hardware:
* This should work for both odroid-h3 and h3+ as they both have a jasper
lake CPU (N5105 and N6005).
* I tested this only on a odroid h3+

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

