### PR TITLE
default value for `services.hardware.openrgb.motherboard`

### DIFF
--- a/common/cpu/amd/default.nix
+++ b/common/cpu/amd/default.nix
@@ -3,4 +3,6 @@
 {
   hardware.cpu.amd.updateMicrocode =
     lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  services.hardware.openrgb.motherboard = lib.mkDefault "amd";
 }

--- a/common/cpu/intel/default.nix
+++ b/common/cpu/intel/default.nix
@@ -1,6 +1,10 @@
+{lib, ...}:
+
 {
   imports = [
     ./cpu-only.nix
     ../../gpu/intel
   ];
+
+  services.hardware.openrgb.motherboard = lib.mkDefault "intel";
 }


### PR DESCRIPTION
###### Description of changes
With this PR if something references the common processor module so that OpenRGB works out of the box if enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

