### PR TITLE
asus/zephyrus/ga401: fix keymapping

### DIFF
--- a/asus/zephyrus/ga401/default.nix
+++ b/asus/zephyrus/ga401/default.nix
@@ -26,10 +26,11 @@
   services = {
     asusd.enable = lib.mkDefault true;
 
-    # fixes mic mute button
     udev.extraHwdb = ''
       evdev:name:*:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:*
-       KEYBOARD_KEY_ff31007c=f20
+       KEYBOARD_KEY_ff31007c=f20    # fixes mic mute button
+       KEYBOARD_KEY_ff3100b2=home   # Set fn+LeftArrow as Home
+       KEYBOARD_KEY_ff3100b3=end    # Set fn+RightArrow as End
     '';
   };
 }


### PR DESCRIPTION
###### Description of changes
Mapped fn+LeftArrow to be home key and fn+RightArrow to be end key.
The Asus Zephyrus GA401 does not have any home end functionality originally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

