### PR TITLE
surface: Fix kernel 6.1.18 by removing 0015-intel-thread-director.patch

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.1.18/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.1.18/patches.nix
@@ -138,8 +138,4 @@
     name = "ms-surface/0014-rtc";
     patch = patchDir + "/0014-rtc.patch";
   }
-  {
-    name = "ms-surface/0015-intel-thread-director";
-    patch = patchDir + "/0015-intel-thread-director.patch";
-  }
 ]


### PR DESCRIPTION
###### Description of changes

[The latest version of linux-surface](https://github.com/linux-surface/linux-surface/tree/7eb766437ef4bea52900e177a2bee86d4b4908b5/patches/6.1) does not contain 0015-intel-thread-director.patch. This was breaking the 6.1.x kernel build like so:

```
       > Hunk #3 succeeded at 1314 (offset -5 lines).
       > patching file arch/x86/kernel/acpi/boot.c
       > Hunk #1 succeeded at 1250 (offset -5 lines).
       > applying patch /nix/store/paasl6sbph09j5vm169307k2qzmrwd5c-source/patches/6.1/0014-rtc.patch
       > patching file drivers/acpi/acpi_tad.c
       > applying patch /nix/store/paasl6sbph09j5vm169307k2qzmrwd5c-source/patches/6.1/0015-intel-thread-director.patch
       > /nix/store/vfdg65hiv4bwls48588msw8la7452w2q-stdenv-linux/setup: line 1216: /nix/store/paasl6sbph09j5vm169307k2qzmrwd5c-source/patches/6.1/0015-intel-thread-director.patch: No such file or directory
       For full logs, run 'nix log /nix/store/jshzbq97k8ayrh99m88bzxz9r7nnlbyq-linux-config-6.1.18.drv'.
error: 1 dependencies of derivation '/nix/store/yrlnq1riv3w98jkr12ix6xlhyxvw4xcl-linux-6.1.18.drv' failed to build
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Successfully built nixos configuration at flake `github:ifd3f/infra/surface-unbreak#shai-hulud`, which uses input `github:ifd3f/nixos-hardware/remove-intel-thread-director` and kernel 6.1.18.

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via Flake input

