### PR TITLE
framework laptop 11th gen: Improve sleep power efficiency

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -6,9 +6,8 @@
   ];
 
   boot.kernelParams = [
-    # For Power consumption
-    # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
-    "mem_sleep_default=deep"
+    # Fixes a regression in s2idle, making it more power efficient than deep sleep
+    "acpi_osi=\"!Windows 2020\""
     # For Power consumption
     # https://community.frame.work/t/linux-battery-life-tuning/6665/156
     "nvme.noacpi=1"


### PR DESCRIPTION
###### Description of changes
Change `mem_sleep_default=deep` kernel parameter to `acpi_osi="!Windows 2020"` (fixes a regression in s2idle, making it more power efficient than deep sleep). It's also a good idea to get rid of deep sleep on the 11th gen anyway, as it doesn't function correctly and takes 10-15 seconds to wake back up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I haven't tested it using my own fork, as I just started using NixOS yesterday, but I've been using this kernel parameter on my Arch Linux install for a while now.