### PR TITLE
surface: Remove patchset for Intel Thread Director

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.1.18/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.1.18/patches.nix
@@ -138,8 +138,4 @@
     name = "ms-surface/0014-rtc";
     patch = patchDir + "/0014-rtc.patch";
   }
-  {
-    name = "ms-surface/0015-intel-thread-director";
-    patch = patchDir + "/0015-intel-thread-director.patch";
-  }
 ]


### PR DESCRIPTION
upstream: https://github.com/linux-surface/linux-surface/commit/a53f55d8f0f92773e623df6c1bab1a7c58260582

fix: build failed introduced by 416249d1ba7f4312836fe7216a95cb06c288312a

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

