### PR TITLE
Implement dt overlay for enabling built-in XHCIcontroller

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -14,6 +14,7 @@
     ./touch-ft5406.nix
     ./pwm0.nix
     ./pkgs-overlays.nix
+    ./xhci.nix
   ];
 
   boot = {

--- a/raspberry-pi/4/xhci.nix
+++ b/raspberry-pi/4/xhci.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.hardware.raspberry-pi."4".xhci;
+in {
+  options.hardware = {
+    raspberry-pi."4".xhci = {
+      enable = lib.mkEnableOption ''
+        Enable builtin XHCI controller for USB with otg_mode=1 in config.txt
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.deviceTree = {
+      overlays = [
+        {
+          name = "enable-xhci";
+          dtsText = ''
+            /dts-v1/;
+            /plugin/;
+
+            / {
+              compatible = "brcm,bcm2711";
+              fragment@0 {
+                //target-path = "/scb/xhci@7e9c0000";
+                target = <&xhci>;
+                __overlay__ {
+                  status = "okay";
+                };
+              };
+            };
+          '';
+        }
+      ];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes
Implemented a device tree overlay to enable XHCI controller on Raspberry Pi 4 family. Useful for CM4 when dwc2 is not applicable due to lower performance.

Not sure why it is disabled by default, but upon comparing device trees of fresh Raspberry Pi OS Lite and NixOS, the status was "disabled" on NixOS and "okay" on RPi OS. This may be due to some trickery in closed source RPi bootloader

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Imported from my own configuration: https://github.com/truelecter/hive/blob/master/cells/nixos/hosts/voron/_hardware-configuration.nix#L63-L90
