### PR TITLE
star64: fix boot from eMMC

### DIFF
--- a/pine64/star64/default.nix
+++ b/pine64/star64/default.nix
@@ -22,7 +22,12 @@
     kernelParams =
       lib.mkDefault [ "console=tty0" "console=ttyS0,115200n8" "earlycon=sbi" ];
 
-    initrd.availableKernelModules = [ "dw_mmc_starfive" ];
+    initrd.availableKernelModules = [
+      "8250_dw" # serial port driver
+      "dw_mmc_starfive" # eMMC/SD
+      "i2c_designware_platform" # i2c (needed for GPIO -> eMMC RST)
+      "axp15060_regulator" # PMIC (needed for eMMC)
+    ];
 
     # Ethernet. The module gets forced m due to other modules even though
     # it's marked y in defconfig.


### PR DESCRIPTION
###### Description of changes

initramfs was missing a bunch of modules

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

