### PR TITLE
replace bors with mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+queue_rules:
+  - name: default
+    merge_conditions:
+      - check-success=tests
+defaults:
+  actions:
+    queue:
+      allow_merging_configuration_change: true
+      method: rebase
+pull_request_rules:
+  - name: merge using the merge queue
+    conditions:
+      - base=master
+      - label~=merge-queue|dependencies
+    actions:
+      queue: {}

--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-cut_body_after = "" # don't include text from the PR body in the merge commit message
-status = [ "tests" ]


### PR DESCRIPTION
bors no longer works for merge queues.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

