### PR TITLE
build-profile: also accept nvidia license

### DIFF
--- a/tests/build-profile.nix
+++ b/tests/build-profile.nix
@@ -14,6 +14,7 @@ let
     nixpkgs.config = {
       allowBroken = true;
       allowUnfree = true;
+      nvidia.acceptLicense = true;
     };
   };
 in (import <nixpkgs/nixos> {


### PR DESCRIPTION
There seems to be recursive dependencies between adding video drivers and checking if the unfree flag is set.

###### Description of changes



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

