### PR TITLE
M600: Remove duplicate import

### DIFF
--- a/morefine/m600/default.nix
+++ b/morefine/m600/default.nix
@@ -2,7 +2,6 @@
   imports = [
     ../../common/cpu/amd
     ../../common/cpu/amd/pstate.nix
-    ../../common/gpu/amd
   ];
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

