### PR TITLE
framework/*: add fw-ectool for led control, etc

### DIFF
--- a/framework/12th-gen-intel/default.nix
+++ b/framework/12th-gen-intel/default.nix
@@ -73,4 +73,9 @@
 
   # Fix font sizes in X
   # services.xserver.dpi = 200;
+
+  # This adds a patched ectool, to interact with the Embedded Controller
+  # Can be used to interact with leds from userspace, etc.
+  # Not part of a nixos release yet, so package only gets added if it exists.
+  environment.systemPackages = lib.optional (pkgs ? "fw-ectool") pkgs.fw-ectool;
 }

--- a/framework/default.nix
+++ b/framework/default.nix
@@ -45,4 +45,9 @@
 
   # Fix font sizes in X
   # services.xserver.dpi = 200;
+
+  # This adds a patched ectool, to interact with the Embedded Controller
+  # Can be used to interact with leds from userspace, etc.
+  # Not part of a nixos release yet, so package only gets added if it exists.
+  environment.systemPackages = lib.optional (pkgs ? "fw-ectool") pkgs.fw-ectool;
 }


### PR DESCRIPTION

###### Description of changes


This adds a patched ectool, to interact with the Embedded Controller

Can be used to interact with leds from userspace, etc. Not part of a nixos release yet, so package only gets added if it exists.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

