### PR TITLE
Add Omen 15-en0010ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ See code for all available configurations.
 | [Morefine M600](morefine/m600)                                      | `<nixos-hardware/morefine/m600>`                   |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)          | `<nixos-hardware/hardkernel/odroid-hc4>`           |
 | [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)            | `<nixos-hardware/hardkernel/odroid-h3>`            |
+| [Omen 15-en0010ca](omen/15-en0010ca)                                | `<nixos-hardware/omen/15-en0010ca>`                |
 | [Omen en00015p](omen/en00015p)                                      | `<nixos-hardware/omen/en00015p>`                   |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |
 | [Panasonic Let's Note CF-LX4 ](panasonic/letsnote/cf-lx4)           | `<nixos-hardware/panasonic/letsnote/cf-lx4>`       |

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,7 @@
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
       hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
       hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;
+      omen-15-en0010ca = import ./omen/15-en0010ca;
       omen-en00015p = import ./omen/en00015p;
       onenetbook-4 = import ./onenetbook/4;
       pcengines-apu = import ./pcengines/apu;

--- a/omen/15-en0010ca/README.md
+++ b/omen/15-en0010ca/README.md
@@ -2,5 +2,3 @@
 
 ## ACPI platform profiles
 This config enables `hp-wmi`, which allows switch between cool, balanced, and performance modes on the platform EC, used by power management tools like `power-profile-daemon` and `tlp`.
-
-Note - this is not yet compiled on Nixpkgs provided Kernels as of September 2023. See [the relevant PR](https://github.com/NixOS/nixpkgs/pull/255846).

--- a/omen/15-en0010ca/README.md
+++ b/omen/15-en0010ca/README.md
@@ -1,0 +1,6 @@
+# HP Omen 15-en0001ca 
+
+## ACPI platform profiles
+This config enables `hp-wmi`, which allows switch between cool, balanced, and performance modes on the platform EC, used by power management tools like `power-profile-daemon` and `tlp`.
+
+Note - this is not yet compiled on Nixpkgs provided Kernels as of September 2023. See [the relevant PR](https://github.com/NixOS/nixpkgs/pull/255846).

--- a/omen/15-en0010ca/default.nix
+++ b/omen/15-en0010ca/default.nix
@@ -1,0 +1,22 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/gpu/amd
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+  ];
+
+  # Enables ACPI platform profiles
+  # TODO - enable module after PR merge
+  # boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") { 
+  #   kernelModules = [ "hp-wmi" ];  
+  # };
+
+  hardware.nvidia.prime = {
+    amdgpuBusId = "PCI:7:0:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}

--- a/omen/15-en0010ca/default.nix
+++ b/omen/15-en0010ca/default.nix
@@ -10,10 +10,9 @@
   ];
 
   # Enables ACPI platform profiles
-  # TODO - enable module after PR merge
-  # boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") { 
-  #   kernelModules = [ "hp-wmi" ];  
-  # };
+  boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") { 
+    kernelModules = [ "hp-wmi" ];  
+  };
 
   hardware.nvidia.prime = {
     amdgpuBusId = "PCI:7:0:0";


### PR DESCRIPTION
###### Description of changes

~~The required modules not yet set to compile on Nixpkgs provided Kernels as of right now (See [the relevant PR](https://github.com/NixOS/nixpkgs/pull/255846)).~~

~~I've commented the relevant config out before the PR merges.~~

Added support for my laptop, a HP Omen 15 (2020). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

