### PR TITLE
Thinkpad X1 11th Gen: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`      |
 | [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)          | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`      |
 | [Lenovo ThinkPad X1 (10th Gen)](lenovo/thinkpad/x1/10th-gen)        | `<nixos-hardware/lenovo/thinkpad/x1/10th-gen>`     |
+| [Lenovo ThinkPad X1 (11th Gen)](lenovo/thinkpad/x1/11th-gen)        | `<nixos-hardware/lenovo/thinkpad/x1/11th-gen>`     |
 | [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2) | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>` |
 | [Lenovo ThinkPad X1 Extreme Gen 4](lenovo/thinkpad/x1-extreme/gen4) | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen4>` |
 | [Lenovo ThinkPad X1 Nano Gen 1](lenovo/thinkpad/x1-nano/gen1)       | `<nixos-hardware/lenovo/thinkpad/x1-nano/gen1>`    |

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,7 @@
       lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
       lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;
       lenovo-thinkpad-x1-10th-gen = import ./lenovo/thinkpad/x1/10th-gen;
+      lenovo-thinkpad-x1-11th-gen = import ./lenovo/thinkpad/x1/11th-gen;
       lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
       lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
       lenovo-thinkpad-x1-extreme-gen4 = import ./lenovo/thinkpad/x1-extreme/gen4;

--- a/lenovo/thinkpad/x1/11th-gen/default.nix
+++ b/lenovo/thinkpad/x1/11th-gen/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ../.
+    ../../../../common/pc/laptop/ssd
+  ];
+
+  # Use the right Intel graphics driver
+  boot.kernelParams = [ "i915.force_probe=a7a1" ];
+}


### PR DESCRIPTION
###### Description of changes
Adding Thinkpad X1 11th Gen.

Got id from:
```bash
$ nix-shell -p pciutils --run 'lspci -nn | grep VGA'
00:02.0 VGA compatible controller [0300]: Intel Corporation Raptor Lake-P [Iris Xe Graphics] [8086:a7a1] (rev 04)
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

