### PR TITLE
CODEOWNERS: add tomfitzhenry to Pine64 Pinebook Pro

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@ dell/xps/13-9380 @kalbasit
 lenovo/thinkpad/x230 @makefu @yegortimoshenko
 lenovo/thinkpad/x250 @Mic92
 pcengines/apu @yegortimoshenko
+pine64/pinebook-pro @tomfitzhenry
 pine64/star64 @fgaz
 purism/librem/13v3 @yegortimoshenko
 system76/darp6 @khumba


### PR DESCRIPTION
###### Description of changes

Add self as an owner for pine64/pinebook-pro. My goal is to eventually remove all PineBook Pro config from nixos-hardware! :)

Prior contributions:

* https://github.com/NixOS/nixos-hardware/pull/444
* https://github.com/NixOS/nixos-hardware/pull/445
* https://github.com/NixOS/nixos-hardware/pull/446

Pending contributions:

* https://github.com/NixOS/nixos-hardware/pull/743

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

