### PR TITLE
star64: set governor to schedutil

### DIFF
--- a/pine64/star64/default.nix
+++ b/pine64/star64/default.nix
@@ -41,4 +41,8 @@
 
   hardware.deviceTree.name =
     lib.mkDefault "starfive/jh7110-pine64-star64.dtb";
+
+  # Only "performance" and "schedutil" are available,
+  # and "performance" takes precedence by default, which is a waste of power.
+  powerManagement.cpuFreqGovernor = lib.mkDefault "schedutil";
 }


### PR DESCRIPTION
###### Description of changes

By default it's "performance", which is not ideal.

Not sure if this belongs to nixos-hardware though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

