### PR TITLE
init: omen-16-n0005ne

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ See code for all available configurations.
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)          | `<nixos-hardware/hardkernel/odroid-hc4>`           |
 | [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)            | `<nixos-hardware/hardkernel/odroid-h3>`            |
 | [Omen 15-en0010ca](omen/15-en0010ca)                                | `<nixos-hardware/omen/15-en0010ca>`                |
+| [Omen 16-n0005ne](omen/16-n0005ne)                                  | `<nixos-hardware/omen/16-n0005ne>`                 |
 | [Omen 15-en1007sa](omen/15-en1007sa)                                | `<nixos-hardware/omen/15-en1007sa>`                |
 | [Omen en00015p](omen/en00015p)                                      | `<nixos-hardware/omen/en00015p>`                   |
 | [One-Netbook OneNetbook 4](onenetbook/4)                            | `<nixos-hardware/onenetbook/4>`                    |

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,7 @@
       hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
       hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;
       omen-15-en0010ca = import ./omen/15-en0010ca;
+      omen-16-n0005ne = import ./omen/16-n0005ne;
       omen-15-en1007sa = import ./omen/15-en1007sa;
       omen-en00015p = import ./omen/en00015p;
       onenetbook-4 = import ./onenetbook/4;

--- a/omen/16-n0005ne/README.md
+++ b/omen/16-n0005ne/README.md
@@ -1,0 +1,4 @@
+# HP Omen 16-n0005ne
+
+## ACPI platform profiles
+This config enables `hp-wmi`, which allows switch between cool, balanced, and performance modes on the platform EC, used by power management tools like `power-profile-daemon` and `tlp`.

--- a/omen/16-n0005ne/default.nix
+++ b/omen/16-n0005ne/default.nix
@@ -1,0 +1,15 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/gpu/amd
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+  ];
+
+  # Enables ACPI platform profiles
+  boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") {
+    kernelModules = [ "hp-wmi" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Added profile for AMD only variant of the omen 16 line of HP laptops.
Currently this profile is almost identical to existing omen 15 profile but without any NVIDIA modules. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

