### PR TITLE
purism/librem5r4: linuxPackages_librem5: 6.4.14-librem5 -> 6.5.6-librem5

### DIFF
--- a/purism/librem/5r4/kernel/6.5.4.nix
+++ b/purism/librem/5r4/kernel/6.5.4.nix
@@ -6,14 +6,14 @@
 buildLinux (args
   // rec {
   defconfig = "librem5_defconfig";
-  version = "6.4.14-librem5";
+  version = "6.5.4-librem5";
   modDirVersion = version;
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "linux";
-    rev = "pureos/6.4.14pureos1";
-    hash = "sha256-PzRG6czWLMahklceuaWGK1QJ+m9FAKDa/m1jp87h62k=";
+    rev = "pureos/6.5.4pureos1";
+    hash = "sha256-wPosmPiQiaODfxlxNA/PGqOIBKlEcO+pOPvdZn7R9T0=";
   };
   kernelPatches = [ ];
   structuredExtraConfig = with lib.kernel; {

--- a/purism/librem/5r4/kernel/default.nix
+++ b/purism/librem/5r4/kernel/default.nix
@@ -1,4 +1,4 @@
 final: prev: {
-  linuxPackages_librem5_6_4_14 = final.linuxPackagesFor (final.callPackage ./6.4.14.nix { });
-  linuxPackages_librem5 = final.linuxPackages_librem5_6_4_14;
+  linuxPackages_librem5_6_5_4 = final.linuxPackagesFor (final.callPackage ./6.5.4.nix { });
+  linuxPackages_librem5 = final.linuxPackages_librem5_6_5_4;
 }

--- a/purism/librem/5r4/kernel/default.nix
+++ b/purism/librem/5r4/kernel/default.nix
@@ -1,4 +1,3 @@
 final: prev: {
-  linuxPackages_librem5_6_5_4 = final.linuxPackagesFor (final.callPackage ./6.5.4.nix { });
-  linuxPackages_librem5 = final.linuxPackages_librem5_6_5_4;
+  linuxPackages_librem5 = final.linuxPackagesFor (final.callPackage ./kernel.nix { });
 }

--- a/purism/librem/5r4/kernel/kernel.nix
+++ b/purism/librem/5r4/kernel/kernel.nix
@@ -6,14 +6,14 @@
 buildLinux (args
   // rec {
   defconfig = "librem5_defconfig";
-  version = "6.5.4-librem5";
+  version = "6.5.6-librem5";
   modDirVersion = version;
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "linux";
-    rev = "pureos/6.5.4pureos1";
-    hash = "sha256-wPosmPiQiaODfxlxNA/PGqOIBKlEcO+pOPvdZn7R9T0=";
+    rev = "pureos/6.5.6pureos1";
+    hash = "sha256-hOv0oy31mbC+43sI1n1oqKl7TtT/Ivj6UhiW4maumCg=";
   };
   kernelPatches = [ ];
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes

Update the linux kernel to the latest release on https://source.puri.sm/Librem5/linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

