### PR TITLE
Add amd pstate to all omen laptops

### DIFF
--- a/omen/15-en0010ca/default.nix
+++ b/omen/15-en0010ca/default.nix
@@ -4,14 +4,15 @@
   imports = [
     ../../common/cpu/amd
     ../../common/gpu/amd
+    ../../common/gpu/amd/pstate.nix
     ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop
     ../../common/pc/ssd
   ];
 
   # Enables ACPI platform profiles
-  boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") { 
-    kernelModules = [ "hp-wmi" ];  
+  boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") {
+    kernelModules = [ "hp-wmi" ];
   };
 
   hardware.nvidia.prime = {

--- a/omen/15-en0010ca/default.nix
+++ b/omen/15-en0010ca/default.nix
@@ -3,8 +3,8 @@
 {
   imports = [
     ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
     ../../common/gpu/amd
-    ../../common/gpu/amd/pstate.nix
     ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop
     ../../common/pc/ssd

--- a/omen/15-en1007sa/default.nix
+++ b/omen/15-en1007sa/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
     ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop
     ../../common/pc/ssd

--- a/omen/16-n0005ne/default.nix
+++ b/omen/16-n0005ne/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
     ../../common/gpu/amd
     ../../common/pc/laptop
     ../../common/pc/ssd

--- a/omen/en00015p/default.nix
+++ b/omen/en00015p/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
     ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop
     ../../common/pc/ssd


### PR DESCRIPTION
###### Description of changes

AMD PState was missing as an import for Omen devices. This should improve batter life of the devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

