### PR TITLE
ROG Ally: Add basic config as default.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ See code for all available configurations.
 | [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                    | `<nixos-hardware/apple/macbook-pro/12-1>`          |
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                    | `<nixos-hardware/apple/macbook-pro/14-1>`          |
 | [Apple Macs with a T2 Chip](apple/t2)                               | `<nixos-hardware/apple/t2>`                        |
+| [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                       | `<nixos-hardware/asus/ally/rc71l>`                 |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                      | `<nixos-hardware/asus/rog-strix/g733qs>`           |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                  | `<nixos-hardware/asus/zephyrus/ga401>`             |
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                  | `<nixos-hardware/asus/zephyrus/ga402>`             |

--- a/asus/ally/rc71l/README.md
+++ b/asus/ally/rc71l/README.md
@@ -1,0 +1,10 @@
+# [ROG Ally (2023)](https://rog.asus.com/gaming-handhelds/rog-ally/rog-ally-2023/)
+
+## BIOS
+
+The ROG Ally has a troublesome history with different BIOS versions creating different issues.
+At the time of writing, the current BIOS version 330 allows for working audio without further kernel patches.
+
+## Further resources
+
+- The steam module from https://github.com/Jovian-Experiments/Jovian-NixOS can be used to boot into the Steam Deck UI

--- a/asus/ally/rc71l/default.nix
+++ b/asus/ally/rc71l/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, lib, ... }:
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+    ../../battery.nix
+  ];
+
+  # 6.5 adds many fixes and improvements for the Ally
+  # This includes for example performance, audio and bluetooth
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.5") (lib.mkDefault pkgs.linuxPackages_latest);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       apple-macbook-pro-14-1 = import ./apple/macbook-pro/14-1;
       apple-t2 = import ./apple/t2;
       asus-battery = import ./asus/battery.nix;
+      asus-ally-rc71l = import ./asus/ally/rc71l;
       asus-fx504gd = import ./asus/fx504gd;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;


### PR DESCRIPTION
###### Description of changes

Added basic configuration for the ROG Ally RC71L (2023), based on what I have been using so far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

