### PR TITLE
Add HP Elitebook 845 g7 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ See code for all available configurations.
 | [GPD WIN 2](gpd/win-2)                                              | `<nixos-hardware/gpd/win-2>`                       |
 | [Google Pixelbook](google/pixelbook)                                | `<nixos-hardware/google/pixelbook>`                |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                            | `<nixos-hardware/hp/elitebook/2560p>`              |
+| [HP Elitebook 845g7](hp/elitebook/845/g7)                           | `<nixos-hardware/hp/elitebook/845/g7>`             |
 | [HP Elitebook 845g9](hp/elitebook/845/g9)                           | `<nixos-hardware/hp/elitebook/845/g9>`             |
 | [HP Notebook 14-df0023](hp/notebook/14-df0023)                      | `<nixos-hardware/hp/notebook/14-df0023>`           |
 | [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)         | `<nixos-hardware/nxp/imx8qm-mek>`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
       gpd-pocket-3 = import ./gpd/pocket-3;
       gpd-win-2 = import ./gpd/win-2;
       hp-elitebook-2560p = import ./hp/elitebook/2560p;
+      hp-elitebook-845g7 = import ./hp/elitebook/845/g7;
       hp-elitebook-845g9 = import ./hp/elitebook/845/g9;
       hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
       intel-nuc-8i7beh = import ./intel/nuc/8i7beh;

--- a/hp/elitebook/845/g7/default.nix
+++ b/hp/elitebook/845/g7/default.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports =
+    [
+      ../../../../common/cpu/amd
+      ../../../../common/cpu/amd/pstate.nix
+      ../../../../common/gpu/amd
+      ../../../../common/pc/laptop
+      ../../../../common/pc/laptop/acpi_call.nix
+      ../../../../common/pc/laptop/ssd
+    ];
+
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+  boot.kernelModules = [ "synaptics_usb" ];
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.3") (lib.mkDefault pkgs.linuxPackages_latest);
+
+  # disable Scatter/Gather APU recently enabled by default,
+  # which results in white screen after display reconfiguration
+  boot.kernelParams = [ "amdgpu.sg_display=0" ];
+
+  services.xserver = {
+    videoDrivers = [ "amdgpu" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Add configuration for HP Elitebook 845 g7

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

