### PR TITLE
pine64-rockpro64: add fancontrol

### DIFF
--- a/pine64/rockpro64/default.nix
+++ b/pine64/rockpro64/default.nix
@@ -6,4 +6,25 @@
     "pcie_rockchip_host"
     "phy_rockchip_pcie"
   ];
+  # control the fan on the rockpro64 (like the one in the NAS case)
+  hardware.fancontrol = {
+    enable = lib.mkDefault true;
+    config = lib.mkDefault ''
+      INTERVAL=3
+      DEVPATH=hwmon0=devices/virtual/thermal/thermal_zone0 hwmon1=devices/virtual/thermal/thermal_zone1 hwmon3=devices/platform/pwm-fan
+      DEVNAME=hwmon0=cpu_thermal hwmon1=gpu_thermal hwmon3=pwmfan
+      # There can only be one sensor mapped to one pwm:
+      # https://github.com/lm-sensors/lm-sensors/issues/228
+      # Therefore you'll have to decide if you want to check CPU or GPU
+      # temps. If you want to use GPU instead, replace hwmon0 with
+      # hwmon1 below.
+      FCTEMPS=hwmon3/pwm1=hwmon0/temp1_input
+      MINTEMP=hwmon3/pwm1=40
+      MAXTEMP=hwmon3/pwm1=80
+      MINSTART=hwmon3/pwm1=35
+      MINSTOP=hwmon3/pwm1=30
+      MINPWM=hwmon3/pwm1=0
+      MAXPWM=hwmon3/pwm1=255
+    '';
+  };
 }


### PR DESCRIPTION
###### Description of changes
Controls the fan so it doesn't spin at full force after installation.  
rk3399's operating temps are -20 to 80°C. It has sensors for CPU and GPU. The MINSTART/-STOP values are a result of my own testing.  
Tested my fork without any changes and with `hardware.fancontrol.enable = false;` to disable it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

