### PR TITLE
Add Asus ROG Strix G513IM

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See code for all available configurations.
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                    | `<nixos-hardware/apple/macbook-pro/14-1>`          |
 | [Apple Macs with a T2 Chip](apple/t2)                               | `<nixos-hardware/apple/t2>`                        |
 | [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                       | `<nixos-hardware/asus/ally/rc71l>`                 |
+| [Asus ROG Strix G513IM](asus/rog-strix/g513im)                      | `<nixos-hardware/asus/rog-strix/g513im>`           |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                      | `<nixos-hardware/asus/rog-strix/g733qs>`           |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                  | `<nixos-hardware/asus/zephyrus/ga401>`             |
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                  | `<nixos-hardware/asus/zephyrus/ga402>`             |

--- a/asus/rog-strix/g513im/default.nix
+++ b/asus/rog-strix/g513im/default.nix
@@ -1,0 +1,16 @@
+{
+	imports = [
+		../../../common/cpu/amd
+		../../../common/cpu/amd/pstate.nix
+		../../../common/gpu/nvidia
+		../../../common/gpu/nvidia/prime.nix
+		../../../common/pc/laptop
+		../../../common/pc/ssd
+		../../battery.nix
+	];
+
+	hardware.nvidia.prime = {
+		amdgpuBusId = "PCI:05:00:0";
+		nvidiaBusId = "PCI:01:00:0";
+	};
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       asus-battery = import ./asus/battery.nix;
       asus-ally-rc71l = import ./asus/ally/rc71l;
       asus-fx504gd = import ./asus/fx504gd;
+      asus-rog-strix-g513im = import ./asus/rog-strix/g513im;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;


### PR DESCRIPTION
###### Description of changes
Added a new profile for the Asus ROG Strix G513IM laptop.

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

