### PR TITLE
star64: linux: force disable DRM_FBDEV_EMULATION

### DIFF
--- a/pine64/star64/linux-5.15.nix
+++ b/pine64/star64/linux-5.15.nix
@@ -61,7 +61,7 @@ let
         DRM_DP_AUX_BUS = no;
         DRM_DP_AUX_CHARDEV = lib.mkForce no;
         DRM_KMS_HELPER = no;
-        DRM_FBDEV_EMULATION = no;
+        DRM_FBDEV_EMULATION = lib.mkForce no;
         DRM_LOAD_EDID_FIRMWARE = lib.mkForce no;
         DRM_TTM = no;
         DRM_VRAM_HELPER = no;


### PR DESCRIPTION
###### Description of changes

It was enabled in this nixpkgs commit:
https://github.com/NixOS/nixpkgs/commit/e00c606455cef66797d48b3a145e913b509a4077


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

