### PR TITLE
feat(asus/zephyrus): add GU603H (2021 Zephyrus M16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                  | `<nixos-hardware/asus/zephyrus/ga402>`             |
 | [Asus ROG Zephyrus G15 GA502](asus/zephyrus/ga502)                  | `<nixos-hardware/asus/zephyrus/ga502>`             |
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                  | `<nixos-hardware/asus/zephyrus/ga503>`             |
+| [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                  | `<nixos-hardware/asus/zephyrus/gu603h>`             |
 | [Asus TUF FX504GD](asus/fx504gd)                                    | `<nixos-hardware/asus/fx504gd>`                    |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                | `<nixos-hardware/beagleboard/pocketbeagle>`        |
 | [Deciso DEC series](deciso/dec)                                     | `<nixos-hardware/deciso/dec>`                      |

--- a/asus/zephyrus/gu603h/default.nix
+++ b/asus/zephyrus/gu603h/default.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;
       asus-zephyrus-ga502 = import ./asus/zephyrus/ga502;
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
+      asus-zephyrus-gu603h = import ./asus/zephyrus/gu603h;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
       deciso-dec = import ./deciso/dec;
       dell-e7240 = import ./dell/e7240;


### PR DESCRIPTION
###### Description of changes

Adds configs for the Asus ROG Zephyrus M16, model GU603H. My specific model is listed as a GU603HM, but I think other laptops in the same series would work too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
