### PR TITLE
Fixed broken links in deprecation assertions for framework and surface modules

### DIFF
--- a/framework/default.nix
+++ b/framework/default.nix
@@ -2,7 +2,7 @@
   assertions = [
     {
       assertion = false;
-      message = "Importing framework/ (default.nix) directly is deprecated! See https://github.com/NixOS/nixos-hardware/blob/master/framework/OLD-BEHAVIOUR-DEPRECATED.md for more details.";
+      message = "Importing framework/ (default.nix) directly is deprecated! See https://github.com/NixOS/nixos-hardware/blob/master/framework/OLD-BEHAVIOUR-DEPRECATION.md for more details.";
     }
   ];
 }

--- a/microsoft/surface/default.nix
+++ b/microsoft/surface/default.nix
@@ -4,7 +4,7 @@
   assertions = [
     {
       assertion = false;
-      message = "Importing microsoft/surface/ (default.nix) directly is deprecated! See https://github.com/NixOS/nixos-hardware/blob/master/microsoft/surface/OLD-BEHAVIOUR-DEPRECATED.md for more details.";
+      message = "Importing microsoft/surface/ (default.nix) directly is deprecated! See https://github.com/NixOS/nixos-hardware/blob/master/microsoft/surface/OLD-BEHAVIOUR-DEPRECATION.md for more details.";
     }
   ];
 }


### PR DESCRIPTION
###### Description of changes

When importing deprecated modules `microsoft/surface/default.nix` and `framework/default.nix`, a link is shown to a markdown document guiding the user to import the new modules. These links are broken because they point to a non-existent `OLD-BEHAVIOUR-DEPRECATED.md`. This patch fixes them to point to the existing `OLD-BEHAVIOUR-DEPRECATION.md` documents.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration (attempted to build to display the assertion and make sure they link to the correct files).
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

