### PR TITLE
raspberry-pi/4: add LED-disable overlay

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -8,6 +8,7 @@
     ./digi-amp-plus.nix
     ./dwc2.nix
     ./i2c.nix
+    ./leds.nix
     ./modesetting.nix
     ./pkgs-overlays.nix
     ./poe-hat.nix

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -5,17 +5,17 @@
     ./audio.nix
     ./backlight.nix
     ./cpu-revision.nix
+    ./digi-amp-plus.nix
     ./dwc2.nix
     ./i2c.nix
     ./modesetting.nix
+    ./pkgs-overlays.nix
     ./poe-hat.nix
     ./poe-plus-hat.nix
+    ./pwm0.nix
     ./tc358743.nix
     ./touch-ft5406.nix
-    ./pwm0.nix
-    ./pkgs-overlays.nix
     ./xhci.nix
-    ./digi-amp-plus.nix
   ];
 
   boot = {
@@ -24,7 +24,7 @@
       "usbhid"
       "usb_storage"
       "vc4"
-      "pcie_brcmstb"      # required for the pcie bus to work
+      "pcie_brcmstb" # required for the pcie bus to work
       "reset-raspberrypi" # required for vl805 firmware to load
     ];
 

--- a/raspberry-pi/4/leds.nix
+++ b/raspberry-pi/4/leds.nix
@@ -2,25 +2,25 @@
 
 let
   cfg = config.hardware.raspberry-pi."4".leds;
+  mkDisableOption = name: lib.mkOption {
+    default = false;
+    example = true;
+    description = "Whether to disable ${name}.";
+    type = lib.types.bool;
+  };
 in
 {
   options.hardware = {
     raspberry-pi."4".leds = {
-      disable-eth = lib.mkEnableOption ''
-        disable ethernet LEDs.
-      '';
-      disable-act = lib.mkEnableOption ''
-        disable activity LED.
-      '';
-      disable-pwr = lib.mkEnableOption ''
-        disable power LED.
-      '';
+      eth.disable = mkDisableOption ''ethernet LEDs.'';
+      act.disable = mkDisableOption ''activity LED.'';
+      pwr.disable = mkDisableOption ''power LED.'';
     };
   };
 
   # Adapted from: https://gist.github.com/SFrijters/206d2c09656affb04284f076c75a1969
   config = lib.mkMerge [
-    (lib.mkIf cfg.disable-eth {
+    (lib.mkIf cfg.eth.disable {
       hardware.deviceTree = {
         overlays = [
           # https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README
@@ -58,7 +58,7 @@ in
         ];
       };
     })
-    (lib.mkIf cfg.disable-act {
+    (lib.mkIf cfg.act.disable {
       hardware.deviceTree = {
         overlays = [
           # Debugging:
@@ -85,7 +85,7 @@ in
         ];
       };
     })
-    (lib.mkIf cfg.disable-pwr {
+    (lib.mkIf cfg.pwr.disable {
       hardware.deviceTree = {
         overlays = [
           # Debugging:

--- a/raspberry-pi/4/leds.nix
+++ b/raspberry-pi/4/leds.nix
@@ -1,0 +1,116 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".leds;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".leds = {
+      disable-eth = lib.mkEnableOption ''
+        disable ethernet LEDs.
+      '';
+      disable-act = lib.mkEnableOption ''
+        disable activity LED.
+      '';
+      disable-pwr = lib.mkEnableOption ''
+        disable power LED.
+      '';
+    };
+  };
+
+  # Adapted from: https://gist.github.com/SFrijters/206d2c09656affb04284f076c75a1969
+  config = lib.mkMerge [
+    (lib.mkIf cfg.disable-eth {
+      hardware.deviceTree = {
+        overlays = [
+          # https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README
+          # eth_led0                Set mode of LED0 - amber on Pi3B+ (default "1"),
+          #                         green on Pi4 (default "0").
+          #                         The legal values are:
+          #
+          #                         Pi4
+          #
+          #                         0=Speed/Activity         1=Speed
+          #                         2=Flash activity         3=FDX
+          #                         4=Off                    5=On
+          #                         6=Alt                    7=Speed/Flash
+          #                         8=Link                   9=Activity
+          #
+          # Debugging:
+          # $ hexdump /proc/device-tree/scb/ethernet@7d580000/mdio@e14/ethernet-phy@1/led-modes
+          {
+            name = "disable-eth-leds";
+            filter = "*rpi-4-b*";
+            dtsText = ''
+              /dts-v1/;
+              /plugin/;
+              /{
+                  compatible = "raspberrypi,4-model-b";
+                  fragment@0 {
+                      target = <&phy1>;
+                      __overlay__ {
+                          led-modes = <0x04 0x04>;
+                      };
+                  };
+              };
+            '';
+          }
+        ];
+      };
+    })
+    (lib.mkIf cfg.disable-act {
+      hardware.deviceTree = {
+        overlays = [
+          # Debugging:
+          # $ hexdump /proc/device-tree/leds/led-act/gpios
+          # $ cat /proc/device-tree/leds/led-act/linux,default-trigger
+          {
+            name = "disable-act-led";
+            filter = "*rpi-4-b*";
+            dtsText = ''
+              /dts-v1/;
+              /plugin/;
+              /{
+                  compatible = "raspberrypi,4-model-b";
+                  fragment@0 {
+                      target = <&act_led>;
+                      __overlay__ {
+                          gpios = <&gpio 42 0>; /* first two values copied from bcm2711-rpi-4-b.dts */
+                          linux,default-trigger = "none";
+                      };
+                  };
+              };
+            '';
+          }
+        ];
+      };
+    })
+    (lib.mkIf cfg.disable-pwr {
+      hardware.deviceTree = {
+        overlays = [
+          # Debugging:
+          # $ hexdump /proc/device-tree/leds/led-pwr/gpios
+          # $ cat /proc/device-tree/leds/led-pwr/linux,default-trigger
+          {
+            name = "disable-pwr-led";
+            filter = "*rpi-4-b*";
+            dtsText = ''
+              /dts-v1/;
+              /plugin/;
+              /{
+                  compatible = "raspberrypi,4-model-b";
+                  fragment@0 {
+                      target = <&pwr_led>;
+                      __overlay__ {
+                          gpios = <&expgpio 2 0>; /* first two values copied from bcm2711-rpi-4-b.dts */
+                          linux,default-trigger = "default-on";
+                      };
+                  };
+              };
+            '';
+          }
+        ];
+      };
+    })
+  ];
+}


### PR DESCRIPTION
###### Description of changes
because the `boot.loader.raspberryPi.firmwareConfig` will be deprecated, others might want to disable the LEDs. Found in:
https://gist.github.com/SFrijters/206d2c09656affb04284f076c75a1969

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

