### PR TITLE
starfive visionfive2: update kernel to 6.6.0

### DIFF
--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -4,7 +4,7 @@
     supportedFilesystems =
       lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
     consoleLogLevel = lib.mkDefault 7;
-    kernelPackages = lib.mkDefault (pkgs.callPackage ./linux-6.5.nix {
+    kernelPackages = lib.mkDefault (pkgs.callPackage ./linux-6.6.nix {
       inherit (config.boot) kernelPatches;
     });
 

--- a/starfive/visionfive/v2/linux-6.6.nix
+++ b/starfive/visionfive/v2/linux-6.6.nix
@@ -1,7 +1,7 @@
 { lib, callPackage, linuxPackagesFor, kernelPatches, ... }:
 
 let
-  modDirVersion = "6.5.0";
+  modDirVersion = "6.6.0";
   linuxPkg = { lib, fetchFromGitHub, buildLinux, ... }@args:
     buildLinux (args // {
       version = "${modDirVersion}-starfive-visionfive2";
@@ -9,8 +9,8 @@ let
       src = fetchFromGitHub {
         owner = "starfive-tech";
         repo = "linux";
-        rev = "0dfeb6ace464f0c455a9508815bb9f70760d6faf";
-        hash = "sha256-ZDMvEhnJtbyCVNI/WbE80k7ZWOldF491mgx6K/iPgdE=";
+        rev = "7ccbe4604c1498e880cc63c7e8b45e3c55914d6d";
+        hash = "sha256-iO7tnnWYfveVbyvVZKL0dDLwONijt1n0RUD1kTkOQew=";
       };
 
       inherit modDirVersion kernelPatches;


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

