### PR TITLE
framework/13-inch/12th-gen-intel: ec crash fix

### DIFF
--- a/framework/13-inch/12th-gen-intel/default.nix
+++ b/framework/13-inch/12th-gen-intel/default.nix
@@ -13,9 +13,14 @@
     "i915.enable_psr=1"
   ];
 
-  # This enables the brightness and airplane mode keys to work
-  # https://community.frame.work/t/12th-gen-not-sending-xf86monbrightnessup-down/20605/11
-  boot.blacklistedKernelModules = [ "hid-sensor-hub" ];
+  boot.blacklistedKernelModules = [ 
+    # This enables the brightness and airplane mode keys to work
+    # https://community.frame.work/t/12th-gen-not-sending-xf86monbrightnessup-down/20605/11
+    "hid-sensor-hub"
+    # This fixes controller crashes during sleep
+    # https://community.frame.work/t/tracking-fn-key-stops-working-on-popos-after-a-while/21208/32
+    "cros_ec_lpcs"
+  ];
   
   # Further tweak to ensure the brightness and airplane mode keys work
   # https://community.frame.work/t/responded-12th-gen-not-sending-xf86monbrightnessup-down/20605/67


### PR DESCRIPTION
###### Description of changes

Fixing EC crashes during sleep for FW13 12th gen Intel by blacklisting cros_ec_lpcs. Not sure about other generations. 

###### Things done

Tested it on my hardware for a month.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

