### PR TITLE
Bump linux-surface to a6eafcad32dc789ae92f42636b11e9aae6e7c879.

### DIFF
--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "b82e8acd3c015190423b114770b0e9fcc206dd2d";
-    hash = "sha256-parp1F5fFzKkiM6ILK+ZolMdSwU1kLOOMvksSwE/zKA=";
+    rev = "a6eafcad32dc789ae92f42636b11e9aae6e7c879";
+    hash = "sha256-GfxRzxFxDZoSZyEOzxr/Hz0IonbuwzkGaisKl3VYvlI=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes
(First contribution to this repo) 

Bump the [linux-surface](https://github.com/linux-surface/linux-surface) version to the most recently [tagged release](https://github.com/linux-surface/linux-surface/releases/tag/arch-6.6.1-1).

###### Things done


- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Confirmed system comes up and without any noticable regressions using [this NixOS](https://github.com/iwanders/nixos-surface/blob/67fe8d0b35c2b04b1cc17b84b7c1c506940456dd/flake.nix#L4) configuration on an Surface Pro 9.
