### PR TITLE
Linux surface give iptsd configurable options.

### DIFF
--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -1,18 +1,39 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkDefault mkEnableOption mkIf mkMerge;
+  inherit (lib) mkDefault mkEnableOption mkIf mkMerge mkOption types;
 
   cfg = config.microsoft-surface.ipts;
 
-in {
+  iptsConfFile = pkgs.writeTextFile {
+    name = "iptsd.conf";
+    text = lib.generators.toINI { } cfg.config;
+  };
+
+in
+{
   options.microsoft-surface.ipts = {
     enable = mkEnableOption "Enable IPTSd for Microsoft Surface";
+
+    config = mkOption {
+      type = types.attrs;
+      default = { };
+      description = ''
+        Values to wrote to iptsd.conf, first key is section, second key is property.
+        See the example config; https://github.com/linux-surface/iptsd/blob/v1.4.0/etc/iptsd.conf
+      '';
+      example = ''
+        DFT = {
+          ButtonMinMag = 1000;
+        };
+      '';
+    };
   };
 
   config = mkMerge [
     {
       microsoft-surface.ipts.enable = mkDefault false;
+
     }
 
     (mkIf cfg.enable {
@@ -22,6 +43,8 @@ in {
         script = "iptsd $(iptsd-find-hidraw)";
         wantedBy = [ "multi-user.target" ];
       };
+
+      environment.etc."iptsd/iptsd.conf".source = "${iptsConfFile}";
     })
   ];
 }

--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -33,7 +33,6 @@ in
   config = mkMerge [
     {
       microsoft-surface.ipts.enable = mkDefault false;
-
     }
 
     (mkIf cfg.enable {
@@ -43,7 +42,6 @@ in
         script = "iptsd $(iptsd-find-hidraw)";
         wantedBy = [ "multi-user.target" ];
       };
-
       environment.etc."iptsd/iptsd.conf".source = "${iptsConfFile}";
     })
   ];

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,7 +4,7 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "a6eafcad32dc789ae92f42636b11e9aae6e7c879";
+    rev = "arch-6.6.1-1";
     hash = "sha256-GfxRzxFxDZoSZyEOzxr/Hz0IonbuwzkGaisKl3VYvlI=";
   };
 


### PR DESCRIPTION
###### Description of changes
Allow writing the [iptsd.conf](https://github.com/linux-surface/iptsd/blob/v1.4.0/etc/iptsd.conf) file from the nixos configuration.

So this allows specifying properties like [this](https://github.com/iwanders/nixos-surface/blob/f746cb6e58f81c9357aea6b4946e95c4016e8129/configuration.nix#L56-L61);
```nix
  microsoft-surface.ipts.enable = true;
  microsoft-surface.ipts.config = {
    DFT = {
      PositionMinMag = 500;
      ButtonMinMag = 20000;
    };
  };
```

Which then results in:
```
[root@papyrus:/etc/nixos]# cat /etc/iptsd/iptsd.conf 
[DFT]
ButtonMinMag=20000
PositionMinMag=500
```

Which is then used by iptsd.

Also changed the rev from #787 to a tag.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tested with [this config](https://github.com/iwanders/nixos-surface/blob/f746cb6e58f81c9357aea6b4946e95c4016e8129/configuration.nix#L56-L61).

