### PR TITLE
FW13 7040: workaround for SuspendThenHibernate bug

### DIFF
--- a/framework/13-inch/common/amd.nix
+++ b/framework/13-inch/common/amd.nix
@@ -1,9 +1,12 @@
-{ lib, ... }: {
+{ lib, config, ... }: {
   imports = [
     ../../../common/cpu/amd
     ../../../common/cpu/amd/pstate.nix
     ../../../common/gpu/amd
   ];
+
+  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+  boot.kernelParams = lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") ["rtc_cmos.use_acpi_alarm=1"] ;
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13


### PR DESCRIPTION
This fixes a bug that affects Framework AMD Ryzen laptops, also documented on the Arch wiki here: https://wiki.archlinux.org/title/Framework_Laptop_13#Suspend-then-hibernate_on_AMD_version

It looks like the patch has been merged to rtc-next, so should be present starting in Linux 6.8.

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

