### PR TITLE
framework intel: Disable cros-usbpd-charger

### DIFF
--- a/framework/13-inch/common/intel.nix
+++ b/framework/13-inch/common/intel.nix
@@ -15,6 +15,9 @@
   # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") (lib.mkDefault pkgs.linuxPackages_latest);
 
+  # Module is not used for Framework EC but causes boot time error log.
+  boot.blacklistedKernelModules = [ "cros-usbpd-charger" ];
+
   # Custom udev rules
   services.udev.extraRules = ''
     # Fix headphone noise when on powersave


### PR DESCRIPTION
###### Description of changes

Disables an unused module that otherwise outputs an error log on bootup.

See https://community.frame.work/t/responded-linux-kernel-errors-about-cros-usbpd-charger/26264

I've had this disabled on 11th gen, and when upgraded it to 13th gen, still had log without it. I have not tested 12th gen but I assume it is the same.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

