### PR TITLE
surface: Allow specifying major versions for kernel

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.1.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.1.x/default.nix
@@ -9,15 +9,16 @@ let
   cfg = config.microsoft-surface;
 
   version = "6.1.62";
-  extraMeta.branch = "6.1";
-  patchDir = repos.linux-surface + "/patches/${extraMeta.branch}";
+  majorVersion = "6.1";
+  patchDir = repos.linux-surface + "/patches/${majorVersion}";
   kernelPatches = pkgs.callPackage ./patches.nix {
     inherit (lib) kernel;
     inherit version patchDir;
   };
 
   kernelPackages = linuxPackage {
-    inherit version extraMeta kernelPatches;
+    inherit version kernelPatches;
+    extraMeta.branch = majorVersion;
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
       sha256 = "sha256-uf1hb6zWvs/O74i5vnGNDxZiXKs/6B0ROEgCpwkehew=";
@@ -27,10 +28,10 @@ let
 
 in {
   options.microsoft-surface.kernelVersion = mkOption {
-    type = types.enum [ version ];
+    type = types.enum [ version majorVersion ];
   };
 
-  config = mkIf (cfg.kernelVersion == version ) {
+  config = mkIf (cfg.kernelVersion == version || cfg.kernelVersion == majorVersion) {
     boot = {
       inherit kernelPackages;
     };

--- a/microsoft/surface/common/kernel/linux-6.5.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.5.x/default.nix
@@ -9,15 +9,16 @@ let
   cfg = config.microsoft-surface;
 
   version = "6.5.11";
-  extraMeta.branch = "6.5";
-  patchDir = repos.linux-surface + "/patches/${extraMeta.branch}";
+  majorVersion = "6.5";
+  patchDir = repos.linux-surface + "/patches/${majorVersion}";
   kernelPatches = pkgs.callPackage ./patches.nix {
     inherit (lib) kernel;
     inherit version patchDir;
   };
 
   kernelPackages = linuxPackage {
-    inherit version extraMeta kernelPatches;
+    inherit version kernelPatches;
+    extraMeta.branch = majorVersion;
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
       sha256 = "sha256-LuJK+SgrgJI7LaVrcKrX3y6O5OPwdkUuBbpmviBZtRk=";
@@ -30,7 +31,7 @@ in {
     type = types.enum [ version ];
   };
 
-  config = mkIf (cfg.kernelVersion == version) {
+  config = mkIf (cfg.kernelVersion == version || cfg.kernelVersion == majorVersion) {
     boot = {
       inherit kernelPackages;
     };


### PR DESCRIPTION
###### Description of changes

It's annoying to change `microsoft-surface.kernelVersion` every time it gets bumped. This should make it so you can specify the major version and it will always bump itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Running `nixos-rebuild build --flake github:ifd3f/infra/surface-major-version#shai-hulud` (which depends on my fork, but [sets `kernelVersion` to `"6.1"`](https://github.com/ifd3f/infra/commit/579ac8aba297d0f8f58f6c0f59eee3beb4521ef9)) successfully evaluated. I did not perform a full build.

