### PR TITLE
Add support for lenovo idapad s145 15api laptop

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See code for all available configurations.
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)           | `<nixos-hardware/lenovo/ideapad/15arh05>`          |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                          | `<nixos-hardware/lenovo/ideapad/z510>`             |
 | [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                      | `<nixos-hardware/lenovo/ideapad/slim-5>`           |
+| [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)              | `<nixos-hardware/lenovo/ideapad/s145-15api>`       |
 | [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                  | `<nixos-hardware/lenovo/legion/15arh05h>`          |
 | [Lenovo Legion 7 Slim 15ach6](lenovo/legion/15ach6)                 | `<nixos-hardware/lenovo/legion/15ach6>`            |
 | [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                | `<nixos-hardware/lenovo/legion/16ach6h>`           |

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
       lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;
       lenovo-ideapad-slim-5 = import ./lenovo/ideapad/slim-5;
+      lenovo-ideapad-s145-15api = import ./lenovo/ideapad/s145-15api;
       lenovo-legion-15ach6 = import ./lenovo/legion/15ach6;
       lenovo-legion-15arh05h = import ./lenovo/legion/15arh05h;
       lenovo-legion-16ach6h = import ./lenovo/legion/16ach6h;

--- a/lenovo/ideapad/s145-15api/default.nix
+++ b/lenovo/ideapad/s145-15api/default.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/gpu/amd
+    ../../../common/gpu/amd/southern-islands
+  ];
+
+  # Blacklist ideapad-laptop because it keeps resetting rfkill devices
+  boot.blacklistedKernelModules = [ "ideapad-laptop" ];
+
+  # For some reason we have to specify manually which model we want snd-hda-intel to use
+  # without it external microphone won't work
+  boot.extraModprobeConfig = ''
+    options snd-hda-intel model=alc255-acer,dell-headset-multi
+  '';
+}


### PR DESCRIPTION
###### Description of changes
Blacklist ideapad-laptop kernel module because it keeps messes with rfkill devices 
Specify which model snd-hda-intel should use, because without it external microphones won't work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ X ] Tested the changes in your own NixOS Configuration
- [ X ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

