### PR TITLE
surface: linux 6.5.11 -> 6.6.6

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -10,7 +10,7 @@ in {
     ./surface-control
   ];
 
-  microsoft-surface.kernelVersion = mkDefault "6.5.11";
+  microsoft-surface.kernelVersion = mkDefault "6.6.6";
 
   # Seems to be required to properly enable S0ix "Modern Standby":
   boot.kernelParams = mkDefault [ "mem_sleep_default=deep" ];

--- a/microsoft/surface/common/kernel/default.nix
+++ b/microsoft/surface/common/kernel/default.nix
@@ -6,7 +6,7 @@ let
 in {
   imports = [
     ./linux-6.1.x
-    ./linux-6.5.x
+    ./linux-6.6.x
   ];
 
   options.microsoft-surface.kernelVersion = mkOption {

--- a/microsoft/surface/common/kernel/linux-6.6.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/default.nix
@@ -8,8 +8,8 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.5.11";
-  majorVersion = "6.5";
+  version = "6.6.6";
+  majorVersion = "6.6";
   patchDir = repos.linux-surface + "/patches/${majorVersion}";
   kernelPatches = pkgs.callPackage ./patches.nix {
     inherit (lib) kernel;
@@ -21,7 +21,7 @@ let
     extraMeta.branch = majorVersion;
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-      sha256 = "sha256-LuJK+SgrgJI7LaVrcKrX3y6O5OPwdkUuBbpmviBZtRk=";
+      sha256 = "sha256-6/cKkXk0sTFp4b5blcO2wv6lvBTm3BRPHvuKABayJMg=";
     };
   };
 

--- a/microsoft/surface/common/kernel/linux-6.6.x/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/patches.nix
@@ -55,7 +55,7 @@
       VIDEO_DW9719 = module;
       VIDEO_IPU3_IMGU = module;
       VIDEO_IPU3_CIO2 = module;
-      CIO2_BRIDGE = yes;
+      IPU_BRIDGE = module;
       INTEL_SKL_INT3472 = module;
       REGULATOR_TPS68470 = module;
       COMMON_CLK_TPS68470 = module;

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "arch-6.6.1-1";
-    hash = "sha256-GfxRzxFxDZoSZyEOzxr/Hz0IonbuwzkGaisKl3VYvlI=";
+    rev = "arch-6.6.4-1";
+    hash = "sha256-uVNXwclBH72XeAgPWQr0I7lkhP+uGVlkT5N2xcBzbW4=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes

- linux: 6.5.11 -> 6.6.6

- linux-surface: arch-6.6.1-1 -> arch-6.6.4-1

- Update config for 6.6

- Tested on Surface Laptop 4 AMD

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

