### PR TITLE
surface: linux 6.6.6 -> 6.6.8

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -10,7 +10,7 @@ in {
     ./surface-control
   ];
 
-  microsoft-surface.kernelVersion = mkDefault "6.6.6";
+  microsoft-surface.kernelVersion = mkDefault "6.6.8";
 
   # Seems to be required to properly enable S0ix "Modern Standby":
   boot.kernelParams = mkDefault [ "mem_sleep_default=deep" ];

--- a/microsoft/surface/common/kernel/linux-6.6.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/default.nix
@@ -8,7 +8,7 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.6.6";
+  version = "6.6.8";
   majorVersion = "6.6";
   patchDir = repos.linux-surface + "/patches/${majorVersion}";
   kernelPatches = pkgs.callPackage ./patches.nix {
@@ -21,7 +21,7 @@ let
     extraMeta.branch = majorVersion;
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-      sha256 = "sha256-6/cKkXk0sTFp4b5blcO2wv6lvBTm3BRPHvuKABayJMg=";
+      sha256 = "sha256-UDbENOEeSzbY2j9ImFH3+CnPeF+n94h0aFN6nqRXJBY=";
     };
   };
 

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "arch-6.6.4-1";
-    hash = "sha256-uVNXwclBH72XeAgPWQr0I7lkhP+uGVlkT5N2xcBzbW4=";
+    rev = "arch-6.6.6-1";
+    hash = "sha256-0pP/A0XllR/iheIBEBwEApaXpyFYzsnGZ+wdm4w5Jjg=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes

* surface: linux 6.6.6 -> 6.6.8

* linux-surface: arch-6.6.4-1 -> arch-6.6.6-1

* Tested on Surface Laptop 4 AMD

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

