### PR TITLE
feat: add dell latitude 7390 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See code for all available configurations.
 | [Dell Latitude 3340](dell/latitude/3340)                               | `<nixos-hardware/dell/latitude/3340>`                   |
 | [Dell Latitude 3480](dell/latitude/3480)                               | `<nixos-hardware/dell/latitude/3480>`                   |
 | [Dell Latitude 5520](dell/latitude/5520)                               | `<nixos-hardware/dell/latitude/5520>`                   |
+| [Dell Latitude 7390](dell/latitude/7390)                               | `<nixos-hardware/dell/latitude/7390>`                   |
 | [Dell Latitude 7430](dell/latitude/7430)                               | `<nixos-hardware/dell/latitude/7430>`                   |
 | [Dell Latitude 7490](dell/latitude/7490)                               | `<nixos-hardware/dell/latitude/7490>`                   |
 | [Dell Poweredge R7515](dell/poweredge/r7515)                           | `<nixos-hardware/dell/poweredge/r7515>`                 |

--- a/dell/latitude/7390/default.nix
+++ b/dell/latitude/7390/default.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
       dell-latitude-3340 = import ./dell/latitude/3340;
       dell-latitude-3480 = import ./dell/latitude/3480;
       dell-latitude-5520 = import ./dell/latitude/5520;
+      dell-latitude-7390 = import ./dell/latitude/7390;
       dell-latitude-7430 = import ./dell/latitude/7430;
       dell-latitude-7490 = import ./dell/latitude/7490;
       dell-poweredge-r7515 = import ./dell/poweredge/r7515;


### PR DESCRIPTION
###### Description of changes

Adds a Nix module for the `Dell Latitude 7390` hardware.

###### Things done

- [X] Tested the changes in your own NixOS Configuration - Completed and works
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input - Completed and works
      see (https://github.com/dominicegginton/dotfiles/commit/38fc4d2d66713fa08c32e5a85d938f06b642f5a6)

