### PR TITLE
purism librem5r4: linuxPackages_librem5: 6.5.6-librem5 -> 6.6.6-librem5

### DIFF
--- a/purism/librem/5r4/kernel/kernel.nix
+++ b/purism/librem/5r4/kernel/kernel.nix
@@ -6,14 +6,14 @@
 buildLinux (args
   // rec {
   defconfig = "librem5_defconfig";
-  version = "6.5.6-librem5";
+  version = "6.6.6-librem5";
   modDirVersion = version;
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "linux";
-    rev = "pureos/6.5.6pureos1";
-    hash = "sha256-hOv0oy31mbC+43sI1n1oqKl7TtT/Ivj6UhiW4maumCg=";
+    rev = "pureos/6.6.6pureos1";
+    hash = "sha256-LJfY45yNYgFYLCGxb+WRMYBUHnY4HCI2rkflPeaeFe0=";
   };
   kernelPatches = [ ];
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

