### PR TITLE
framework amd: apply headset mic fix on older kernels

### DIFF
--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -6,9 +6,7 @@
 
   # Fix TRRS headphones missing a mic
   # https://community.frame.work/t/headset-microphone-on-linux/12387/3
-  #
-  # This is temporary until a kernel patch is submitted
-  boot.extraModprobeConfig = ''
+  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder pkgs.linux.version "6.6.8") ''
     options snd-hda-intel model=dell-headset-multi
   '';
 

--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }: {
+{ lib, pkgs, ... }: {
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd


### PR DESCRIPTION
###### Description of changes

A kernel fix landed in https://github.com/torvalds/linux/commit/33038efb64f7576bac635164021f5c984d4c755f, which is in >= v6.7-rc5 and CC’ed to stable, so part of 6.6.8 too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

