### PR TITLE
starfive visionfive2: use upstream u-boot v2024.01-rc5

### DIFF
--- a/starfive/visionfive/v2/firmware.nix
+++ b/starfive/visionfive/v2/firmware.nix
@@ -12,7 +12,7 @@ rec {
     runtimeInputs = [ mtdutils ];
     text = ''
       flashcp -v ${uboot}/u-boot-spl.bin.normal.out /dev/mtd0
-      flashcp -v ${uboot}/u-boot.itb /dev/mtd1
+      flashcp -v ${uboot}/u-boot.itb /dev/mtd2
     '';
   };
   updater-sd = writeShellApplication {

--- a/starfive/visionfive/v2/firmware.nix
+++ b/starfive/visionfive/v2/firmware.nix
@@ -1,78 +1,26 @@
-{ callPackage, pkgsBuildHost, writeText, writeShellApplication
-, stdenv, dtc, mtdutils, coreutils }:
-let
-  uboot = callPackage ./uboot.nix { };
-  opensbi = callPackage ./opensbi.nix {
-    withPayload = "${uboot}/u-boot.bin";
-    withFDT = "${uboot}/starfive_visionfive2.dtb";
-  };
-  spl-tool = pkgsBuildHost.callPackage ./spl-tool.nix { };
-  its-file = writeText "visionfive2-uboot-fit-image.its" ''
-    /dts-v1/;
+{ callPackage
+, writeShellApplication
+, stdenv
+, mtdutils
+}:
 
-    / {
-      description = "U-boot-spl FIT image for JH7110 VisionFive2";
-      #address-cells = <2>;
-
-      images {
-        firmware {
-          description = "u-boot";
-          data = /incbin/("${opensbi}/share/opensbi/lp64/generic/firmware/fw_payload.bin");
-          type = "firmware";
-          arch = "riscv";
-          os = "u-boot";
-          load = <0x0 0x40000000>;
-          entry = <0x0 0x40000000>;
-          compression = "none";
-        };
-      };
-
-      configurations {
-        default = "config-1";
-
-        config-1 {
-          description = "U-boot-spl FIT config for JH7110 VisionFive2";
-          firmware = "firmware";
-        };
-      };
-    };
-  '';
-in rec {
-  inherit opensbi uboot;
-  spl = stdenv.mkDerivation {
-    name = "starfive-visionfive2-spl";
-    depsBuildBuild = [ spl-tool ];
-    phases = [ "installPhase" ];
-    installPhase = ''
-      mkdir -p $out/share/starfive-visionfive2/
-      ln -s ${uboot}/u-boot-spl.bin .
-      spl_tool -c -f ./u-boot-spl.bin
-      cp u-boot-spl.bin.normal.out $out/share/starfive-visionfive2/spl.bin
-    '';
-  };
-  uboot-fit-image = stdenv.mkDerivation {
-    name = "starfive-visionfive2-uboot-fit-image";
-    nativeBuildInputs = [ dtc ];
-    phases = [ "installPhase" ];
-    installPhase = ''
-      mkdir -p $out/share/starfive-visionfive2/
-      ${uboot}/mkimage -f ${its-file} -A riscv -O u-boot -T firmware $out/share/starfive-visionfive2/visionfive2_fw_payload.img
-    '';
-  };
+rec {
+  opensbi = callPackage ./opensbi.nix { };
+  uboot = callPackage ./uboot.nix { inherit opensbi; };
   updater-flash = writeShellApplication {
     name = "visionfive2-firmware-update-flash";
     runtimeInputs = [ mtdutils ];
     text = ''
-      flashcp -v ${spl}/share/starfive-visionfive2/spl.bin /dev/mtd0
-      flashcp -v ${uboot-fit-image}/share/starfive-visionfive2/visionfive2_fw_payload.img /dev/mtd1
+      flashcp -v ${uboot}/u-boot-spl.bin.normal.out /dev/mtd0
+      flashcp -v ${uboot}/u-boot.itb /dev/mtd1
     '';
   };
   updater-sd = writeShellApplication {
     name = "visionfive2-firmware-update-sd";
     runtimeInputs = [ ];
     text = ''
-      dd if=${spl}/share/starfive-visionfive2/spl.bin of=/dev/mmcblk0p1 conv=fsync
-      dd if=${uboot-fit-image}/share/starfive-visionfive2/visionfive2_fw_payload.img of=/dev/mmcblk0p2 conv=fsync
+      dd if=${uboot}/u-boot-spl.bin.normal.out of=/dev/mmcblk0p1 conv=fsync
+      dd if=${uboot}/u-boot.itb of=/dev/mmcblk0p2 conv=fsync
     '';
   };
 }

--- a/starfive/visionfive/v2/opensbi.nix
+++ b/starfive/visionfive/v2/opensbi.nix
@@ -1,14 +1,13 @@
-{ opensbi, withPayload, withFDT }:
+{ opensbi }:
 
-(opensbi.override {
-  inherit withPayload withFDT;
-}).overrideAttrs (attrs: {
+opensbi.overrideAttrs (attrs: {
   makeFlags = attrs.makeFlags ++ [
     # opensbi generic platform default FW_TEXT_START is 0x80000000
     # For JH7110, need to specify the FW_TEXT_START to 0x40000000
     # Otherwise, the fw_payload.bin downloading via jtag will not run.
     # https://github.com/starfive-tech/VisionFive2/blob/7733673d27052dc5a48f1cb1d060279dfa3f0241/Makefile#L274
+    # Also matches u-boot documentation: https://docs.u-boot.org/en/latest/board/starfive/visionfive2.html
     "FW_TEXT_START=0x40000000"
+    "FW_OPTIONS=0"
   ];
 })
-

--- a/starfive/visionfive/v2/sd-image.nix
+++ b/starfive/visionfive/v2/sd-image.nix
@@ -36,10 +36,10 @@ in {
       EOF
 
       eval $(partx $img -o START,SECTORS --nr 1 --pairs)
-      dd conv=notrunc if=${firmware.spl}/share/starfive-visionfive2/spl.bin of=$img seek=$START count=$SECTORS
+      dd conv=notrunc if=${firmware.uboot}/u-boot-spl.bin.normal.out of=$img seek=$START count=$SECTORS
 
       eval $(partx $img -o START,SECTORS --nr 2 --pairs)
-      dd conv=notrunc if=${firmware.uboot-fit-image}/share/starfive-visionfive2/visionfive2_fw_payload.img of=$img seek=$START count=$SECTORS
+      dd conv=notrunc if=${firmware.uboot}/u-boot.itb of=$img seek=$START count=$SECTORS
     '';
 
     populateRootCommands = ''

--- a/starfive/visionfive/v2/uboot.nix
+++ b/starfive/visionfive/v2/uboot.nix
@@ -1,20 +1,36 @@
-{ fetchFromGitHub, buildUBoot }:
+{ lib
+, fetchFromGitHub
+, buildUBoot
+, buildPackages
+, opensbi
+}:
 
 buildUBoot rec {
-  version = "5.10.3";
+  version = "2024.01-rc5";
 
   src = fetchFromGitHub {
-    owner = "starfive-tech";
+    owner = "u-boot";
     repo = "u-boot";
-    rev = "refs/tags/JH7110_VF2_6.1_v${version}";
-    hash = "sha256-4E/AxPCFCluwJBEf6xGuxAi1hPZK5ZxEs5WlBVVfvYE=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-QlwgvnSaXh39z9AM7HNF731lRiUkPbN3oQyioQNTYFA=";
   };
 
+  # workaround for https://github.com/NixOS/nixpkgs/pull/146634
+  # uboot: only apply raspberry pi patches to raspberry pi builds
+  patches = [ ];
+
+  extraMakeFlags = [
+    # workaround for https://github.com/NixOS/nixpkgs/pull/277997
+    # buildUBoot: specify absolute path of dtc, fix building u-boot 2023.10+
+    "DTC=${lib.getExe buildPackages.dtc}"
+
+    "OPENSBI=${opensbi}/share/opensbi/lp64/generic/firmware/fw_dynamic.bin"
+  ];
+
   defconfig = "starfive_visionfive2_defconfig";
+
   filesToInstall = [
-    "u-boot.bin"
-    "arch/riscv/dts/starfive_visionfive2.dtb"
-    "spl/u-boot-spl.bin"
-    "tools/mkimage"
+    "spl/u-boot-spl.bin.normal.out"
+    "u-boot.itb"
   ];
 }


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

