### PR TITLE
Added support for Lenovo Legion Slim 5 (16APH8)

### DIFF
--- a/common/cpu/amd/raphael/igpu.nix
+++ b/common/cpu/amd/raphael/igpu.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }: 
+{ lib, pkgs, ... }:
 
 {
   # Sets the kernel version to the latest kernel to make the usage of the iGPU possible if your kernel version is too old
@@ -10,7 +10,7 @@
   boot = lib.mkMerge [
     (lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") {
       kernelPackages = pkgs.linuxPackages_latest;
-      kernelParams = ["amdgpu.sg_display=0"];  
+      kernelParams = ["amdgpu.sg_display=0"];
     })
 
     (lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.2") {

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,7 @@
       lenovo-legion-16ach6h-nvidia = import ./lenovo/legion/16ach6h/nvidia;
       lenovo-legion-16achg6-hybrid = import ./lenovo/legion/16achg6/hybrid;
       lenovo-legion-16achg6-nvidia = import ./lenovo/legion/16achg6/nvidia;
+      lenovo-legion-16aph8 = import ./lenovo/legion/16aph8;
       lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
       lenovo-legion-16irx8h = import ./lenovo/legion/16irx8h;
       lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;

--- a/lenovo/legion/16aph8/README.md
+++ b/lenovo/legion/16aph8/README.md
@@ -1,0 +1,38 @@
+I was unable to get the hybrid settings working well with lightdm or sddm, but Optimus Sync
+mode seems to work the best for me.
+
+I am running the Linux 6.6 LTS kernel with KDE + SDDM, and it seems to be working well.
+
+## hardware-configuration.nix
+
+I have the following customizations added for my nvidia drivers.
+
+```
+hardware.nvidia = {
+    nvidiaSettings = true;
+    package = config.boot.kernelPackages.nvidiaPackages.stable;
+};
+```
+
+## Setup at the time of testing
+
+### nix-info
+```
+$ nix-info -m
+ - system: `"x86_64-linux"`
+ - host os: `Linux 6.1.68, NixOS, 23.11 (Tapir), 23.11.20231220.d65bcea`
+ - multi-user?: `yes`
+ - sandbox: `yes`
+ - version: `nix-env (Nix) 2.18.1`
+ - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixos`
+```
+
+### lspci
+```
+$ lspci
+...
+01:00.0 VGA compatible controller: NVIDIA Corporation AD107M [GeForce RTX 4060 Max-Q / Mobile] (rev a1)
+...
+05:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Phoenix1 (rev c2)
+...
+```

--- a/lenovo/legion/16aph8/README.md
+++ b/lenovo/legion/16aph8/README.md
@@ -20,7 +20,7 @@ hardware.nvidia = {
 ```
 $ nix-info -m
  - system: `"x86_64-linux"`
- - host os: `Linux 6.1.68, NixOS, 23.11 (Tapir), 23.11.20231220.d65bcea`
+ - host os: `Linux 6.6.8, NixOS, 23.11 (Tapir), 23.11.20231231.32f6357`
  - multi-user?: `yes`
  - sandbox: `yes`
  - version: `nix-env (Nix) 2.18.1`

--- a/lenovo/legion/16aph8/default.nix
+++ b/lenovo/legion/16aph8/default.nix
@@ -18,8 +18,10 @@
     })
   ];
 
+  services.xserver.videoDrivers = [ "nvidia" ];
+
   hardware.nvidia = {
-      modesetting.enable = lib.mkDefault false;
+      modesetting.enable = lib.mkDefault true;
       powerManagement.enable = lib.mkDefault false;
       powerManagement.finegrained = lib.mkDefault false;
       open = lib.mkDefault false;

--- a/lenovo/legion/16aph8/default.nix
+++ b/lenovo/legion/16aph8/default.nix
@@ -13,7 +13,7 @@
   # Use latest LTS kernel for more Raphael fixes
   boot = lib.mkMerge [
     (lib.mkIf (lib.versionOlder pkgs.linux.version "6.6") {
-      kernelPackages = pkgs.linuxPackages_6_6;
+      kernelPackages = pkgs.linuxPackages_latest;
       kernelParams = ["amdgpu.sg_display=0"];
     })
   ];

--- a/lenovo/legion/16aph8/default.nix
+++ b/lenovo/legion/16aph8/default.nix
@@ -1,0 +1,36 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/gpu/nvidia
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # Use latest LTS kernel for more Raphael fixes
+  boot = lib.mkMerge [
+    (lib.mkIf (lib.versionOlder pkgs.linux.version "6.6") {
+      kernelPackages = pkgs.linuxPackages_6_6;
+      kernelParams = ["amdgpu.sg_display=0"];
+    })
+  ];
+
+  hardware.nvidia = {
+      modesetting.enable = lib.mkDefault true;
+      powerManagement.enable = lib.mkDefault false;
+      powerManagement.finegrained = lib.mkDefault false;
+      open = lib.mkDefault false;
+      prime = {
+          sync.enable = lib.mkDefault true;
+          amdgpuBusId = "PCI:5:0:0";
+          nvidiaBusId = "PCI:1:0:0";
+      };
+  };
+
+  # AMD has better battery life with PPD over TLP:
+  # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13
+  services.power-profiles-daemon.enable = lib.mkDefault true;
+}

--- a/lenovo/legion/16aph8/default.nix
+++ b/lenovo/legion/16aph8/default.nix
@@ -19,7 +19,7 @@
   ];
 
   hardware.nvidia = {
-      modesetting.enable = lib.mkDefault true;
+      modesetting.enable = lib.mkDefault false;
       powerManagement.enable = lib.mkDefault false;
       powerManagement.finegrained = lib.mkDefault false;
       open = lib.mkDefault false;

--- a/lenovo/legion/16aph8/default.nix
+++ b/lenovo/legion/16aph8/default.nix
@@ -18,8 +18,6 @@
     })
   ];
 
-  services.xserver.videoDrivers = [ "nvidia" ];
-
   hardware.nvidia = {
       modesetting.enable = lib.mkDefault true;
       powerManagement.enable = lib.mkDefault false;
@@ -31,6 +29,9 @@
           nvidiaBusId = "PCI:1:0:0";
       };
   };
+
+  # Avoid issues with modesetting causing blank screen
+  services.xserver.videoDrivers = [ "nvidia" ];
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13


### PR DESCRIPTION
###### Description of changes
Added support for Lenovo Legion Slim 5 (16APH8)
Added PPD after researching the Framework laptops with AMD 7000 series
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

