### PR TITLE
surface: Add majorVersion option to 6.6.x enum

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.6.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/default.nix
@@ -28,7 +28,7 @@ let
 
 in {
   options.microsoft-surface.kernelVersion = mkOption {
-    type = types.enum [ version ];
+    type = types.enum [ version majorVersion ];
   };
 
   config = mkIf (cfg.kernelVersion == version || cfg.kernelVersion == majorVersion) {


### PR DESCRIPTION
###### Description of changes

This was missing as an option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

