### PR TITLE
microchip icicle-kit: Fixes to kernel

### DIFF
--- a/microchip/common/bsp/linux-icicle-kit.nix
+++ b/microchip/common/bsp/linux-icicle-kit.nix
@@ -1,64 +1,60 @@
-{ pkgs, ... } @ args:
+{ lib, buildLinux, fetchFromGitHub
+, kernelPatches ? []
+, structuredExtraConfig ? {}
+, extraMeta ? {}
+, argsOverride ? {}
+, ... } @ args:
 
-with pkgs;
-
-buildLinux (args // rec {
+let
   version = "6.1.43-linux4microchip+fpga-2023.09";
+in buildLinux (args // {
+  inherit version kernelPatches extraMeta;
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = version;
 
   defconfig = "mpfs_defconfig";
 
-  kernelPatches = [
-  ];
-
   autoModules = false;
 
-  extraConfig = ''
-    OF_OVERLAY y
-    OF_CONFIGFS y
-    MFD_SENSEHAT_CORE m
-    INPUT_JOYDEV m
-    INPUT_JOYSTICK y
-    JOYSTICK_SENSEHAT m
-    AUXDISPLAY y
-    SENSEHAT_DISPLAY m
-    HTS221 m
-    IIO_ST_PRESS m
-    IIO_ST_LSM6DSX m
-    IIO_ST_MAGN_3AXIS m
-    POLARFIRE_SOC_DMA_NONCOHERENT y
-    MTD_SPI_NOR_USE_4K_SECTORS n
-    MTD_UBI y
-    MTD_CMDLINE_PARTS y
-    UBIFS_FS y
-    USB_UAS m
-    CRYPTO_TLS m
-    TLS y
-    MD y
-    BLK_DEV_MD m
-    MD_AUTODETECT y
-    MD_RAID0 m
-    MD_RAID1 m
-    MD_RAID10 m
-    MD_RAID456 m
-    DM_VERITY m
-    LOGO y
-    FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
-    FB_EFI n
-    EFI_STUB y
-    EFI y
-    VIRTIO y
-    VIRTIO_PCI y
-    VIRTIO_BLK y
-    DRM_VIRTIO_GPU y
-    EXT4_FS y
-    USBIP_CORE m
-    USBIP_VHCI_HCD m
-    USBIP_HOST m
-    USBIP_VUDC m
-  '';
+  structuredExtraConfig = with lib.kernel; {
+    OF_OVERLAY = yes;
+    OF_CONFIGFS = yes;
+    MFD_SENSEHAT_CORE = module;
+    INPUT_JOYDEV = module;
+    INPUT_JOYSTICK = yes;
+    JOYSTICK_SENSEHAT = module;
+    AUXDISPLAY = yes;
+    SENSEHAT_DISPLAY = module;
+    HTS221 = module;
+    IIO_ST_PRESS = module;
+    IIO_ST_LSM6DSX = module;
+    IIO_ST_MAGN_3AXIS = module;
+    POLARFIRE_SOC_DMA_NONCOHERENT = yes;
+    MTD_SPI_NOR_USE_4K_SECTORS = no;
+    MTD_UBI = yes;
+    MTD_CMDLINE_PARTS = yes;
+    UBIFS_FS = yes;
+    USB_UAS = module;
+    EFI_STUB = yes;
+    EFI = yes;
+    USBIP_CORE = module;
+    USBIP_VHCI_HCD = module;
+    USBIP_HOST = module;
+    USBIP_VUDC = module;
+    CRYPTO_TLS = module;
+    MD = yes;
+    BLK_DEV_MD = module;
+    MD_LINEAR = module;
+    MD_RAID0 = module;
+    MD_RAID1 = module;
+    MD_RAID10 = module;
+    MD_RAID456 = module;
+
+    # This device doesn't have any kind of display output at all
+    FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER = lib.mkForce no;
+    FB_EFI = lib.mkForce no;
+  } // structuredExtraConfig;
 
   src = fetchFromGitHub {
     owner = "linux4microchip";
@@ -66,4 +62,4 @@ buildLinux (args // rec {
     rev = "25e35c7c54ad853d03c14a02b189b408cb5b5eb3";
     sha256 = "sha256-wj7lz247MkhxmhSHUcNeWmcZK+DL+5PAnLwTmALD97M=";
   };
-} // (args.argsOverride or { }))
+} // argsOverride)

--- a/microchip/common/modules.nix
+++ b/microchip/common/modules.nix
@@ -1,7 +1,8 @@
-{ pkgs, lib, ... }: {
+{ pkgs, lib, config, ... }: {
   boot = {
-    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/linux-icicle-kit.nix { });
-    initrd.includeDefaultModules = lib.mkForce false;
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/linux-icicle-kit.nix {
+      inherit (config.boot) kernelPatches;
+    });
+    initrd.includeDefaultModules = lib.mkDefault false;
   };
-
 }


### PR DESCRIPTION
###### Description of changes

This change was mostly done, because in my NixOS configuration, I want to be able to use `boot.kernelPatches` to enable kernel options and patch the kernel.

* Improve by changing from legacy extraConfig to the structuredExtraConfig style kerenl configuration.
* Remove few unneeded kernel modules from default configuration.
* Make kernelPatches, structuredExtraConfig and extraMeta overrideable.
* Change callPackage-style function to actually take the individual attributes from pkgs.
* Get rid of recursive syntax.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

