### PR TITLE
surface: linux 6.1.62 -> 6.1.71

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.1.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.1.x/default.nix
@@ -8,7 +8,7 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.1.62";
+  version = "6.1.71";
   majorVersion = "6.1";
   patchDir = repos.linux-surface + "/patches/${majorVersion}";
   kernelPatches = pkgs.callPackage ./patches.nix {
@@ -21,7 +21,7 @@ let
     extraMeta.branch = majorVersion;
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-      sha256 = "sha256-uf1hb6zWvs/O74i5vnGNDxZiXKs/6B0ROEgCpwkehew=";
+      sha256 = "sha256-Lfd03VP5/9Tlfr+ATPWXcJKV32owT+Jh0lIgoTS38EE=";
     };
   };
 

--- a/microsoft/surface/surface-go/default.nix
+++ b/microsoft/surface/surface-go/default.nix
@@ -17,7 +17,7 @@ in {
     ../../../common/cpu/intel/kaby-lake
   ];
 
-  microsoft-surface.kernelVersion = "6.1.62";
+  microsoft-surface.kernelVersion = "6.1.71";
 
   boot.kernelParams = [
     "i915.enable_rc6=1"


### PR DESCRIPTION
###### Description of changes

Update surface linux kernel from 6.1.62 to 6.1.71.

---

It fixes a build fault below:

```log
cpupower> applying patch /nix/store/lf6nr283p1vwm6gi5930sqmkmj614197-source/patches/6.1/0010-surface-shutdown.patch
cpupower> patching file drivers/pci/pci-driver.c
cpupower> patching file drivers/pci/quirks.c
cpupower> Hunk #1 FAILED at 6070.
cpupower> 1 out of 1 hunk FAILED -- saving rejects to file drivers/pci/quirks.c.rej
cpupower> patching file include/linux/pci.h
error: builder for '/nix/store/9j0h3djqqjzpvhinqfz675yk8szrkz5d-cpupower-6.1.62.drv' failed with exit code 1
```

https://github.com/NixOS/nixos-hardware/commit/249a94e715a3d6cc0217b37b0172dea1edd4afd2 updated `linux-surface` from `arch-6.6.4-1` to `arch-6.6.6-1`, which also introduced the commit https://github.com/linux-surface/linux-surface/commit/944cabb9a01b3069d1f016d021f0b6b8aa78f69d for linux 6.1.

This commit has a change https://github.com/linux-surface/linux-surface/commit/944cabb9a01b3069d1f016d021f0b6b8aa78f69d#diff-87dba197d613f882797cd43bc87e0ca180ecefbc3c28bac379f1d1d9b4c1ef47 , which updated the patch files' base commit.

https://github.com/torvalds/linux/commit/c9260693aa0c1e029ed23693cfd4d7814eee6624 was introduced in linux 6.1 by https://github.com/torvalds/linux/commit/1c8f75ee92334d89f1ddada26d47f9caa955f1a4 , which is the newer `0010-surface-shutdown.patch` based on, but we didn't update linux 6.1 at the same time.

Finally, boom——

---

What I would like to suggest is that maybe we should update and test more carefully, or an unexpected ripple effect could cause a 6.6 update to break a 6.1 build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

