### PR TITLE
framework amd: only apply suspend workaround on <6.7

### DIFF
--- a/framework/13-inch/7040-amd/README.md
+++ b/framework/13-inch/7040-amd/README.md
@@ -18,7 +18,7 @@ Then run
 
 ## Suspend/wake workaround
 
-As of firmware v03.03, a bug in the EC causes the system to wake if AC is connected _despite_ the lid being closed. The following works around this, with the trade-off that keyboard presses also no longer wake the system.
+As of firmware v03.03, a bug in the EC causes the system to wake if AC is connected _despite_ the lid being closed. A workaround has been [upstreamed](https://github.com/torvalds/linux/commit/a55bdad5dfd1efd4ed9ffe518897a21ca8e4e193) in Linux v6.7. For older kernels, the following works around this, with the trade-off that keyboard presses also no longer wake the system.
 
 ```nix
 {

--- a/framework/13-inch/7040-amd/default.nix
+++ b/framework/13-inch/7040-amd/default.nix
@@ -29,7 +29,9 @@ in
     # https://wireless.wiki.kernel.org/en/users/drivers/mediatek
     boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") (lib.mkDefault pkgs.linuxPackages_latest);
 
-    services.udev.extraRules = lib.optionalString cfg.preventWakeOnAC ''
+    # Workaround applied upstream in Linux >=6.7 (on BIOS 03.03)
+    # https://github.com/torvalds/linux/commit/a55bdad5dfd1efd4ed9ffe518897a21ca8e4e193
+    services.udev.extraRules = lib.mkIf (lib.versionOlder pkgs.linux.version "6.7" && cfg.preventWakeOnAC) ''
       # Prevent wake when plugging in AC during suspend. Trade-off: keyboard wake disabled. See:
       # https://community.frame.work/t/tracking-framework-amd-ryzen-7040-series-lid-wakeup-behavior-feedback/39128/45
       ACTION=="add", SUBSYSTEM=="serio", DRIVERS=="atkbd", ATTR{power/wakeup}="disabled"


### PR DESCRIPTION
###### Description of changes

A workaround has been [upstreamed](https://github.com/torvalds/linux/commit/a55bdad5dfd1efd4ed9ffe518897a21ca8e4e193) in Linux v6.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

