### PR TITLE
Add ASUS FA706IU 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                     | `<nixos-hardware/asus/zephyrus/ga503>`                  |
 | [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                   | `<nixos-hardware/asus/zephyrus/gu603h>`                 |
 | [Asus TUF FX504GD](asus/fx504gd)                                       | `<nixos-hardware/asus/fx504gd>`                         |
+| [Asus TUF FA706IU](asus/fa706iu)                                       | `<nixos-hardware/asus/fa706iu>`                         |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                   | `<nixos-hardware/beagleboard/pocketbeagle>`             |
 | [Deciso DEC series](deciso/dec)                                        | `<nixos-hardware/deciso/dec>`                           |
 | [Dell G3 3779](dell/g3/3779)                                           | `<nixos-hardware/dell/g3/3779>`                         |

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -12,7 +12,7 @@
     powerManagement.enable = lib.mkDefault false;
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
-    package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;
+    package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
     nvidiaSettings = lib.mkDefault true;
     prime = {
       offload.enable = lib.mkForce true;

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -13,7 +13,7 @@
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;
-    package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
+    package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;
     prime = {
       offload.enable = lib.mkDefault true;
       amdgpuBusId = "PCI:6:0:0";

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -3,7 +3,7 @@
   imports = [
     ../../common/cpu/amd
     ../../common/gpu/amd
-    ../../common/gpu/nvidia
+    ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop  
   ];
   # These are the BusID's for this device.
@@ -15,7 +15,6 @@
     package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
     nvidiaSettings = lib.mkDefault true;
     prime = {
-      offload.enable = lib.mkForce true;
       amdgpuBusId = "PCI:6:0:0";
       nvidiaBusId = "PCI:1:0:0";
     };

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -13,7 +13,7 @@
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;
-    package = config.boot.kernelPackages.nvidiaPackages.stable;
+    package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
     prime = {
       offload.enable = lib.mkDefault true;
       amdgpuBusId = "PCI:6:0:0";

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -1,3 +1,4 @@
+# Please include `package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;` in your config.
 { lib, config, ... }:
 {
   imports = [
@@ -13,7 +14,6 @@
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;
-    package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;
     prime = {
       offload.enable = lib.mkDefault true;
       amdgpuBusId = "PCI:6:0:0";

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -4,7 +4,7 @@
     ../../common/cpu/amd
     ../../common/gpu/amd
     ../../common/cpu/amd/pstate.nix
- 		../../common/gpu/nvidia
+    ../../common/gpu/nvidia
     ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop  
     ../../common/pc/ssd

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -7,12 +7,19 @@
     ../../common/pc/laptop  
   ];
   # These are the BusID's for this device.
-  hardware.nvidia.prime = {
-    offload.enable = lib.mkDefault true;
-    amdgpuBusId = "PCI:6:0:0";
-    nvidiaBusId = "PCI:1:0:0";
+  hardware.nvidia = {
+    modesetting.enable = lib.mkDefault true;
+    powerManagement.enable = lib.mkDefault false;
+    powerManagement.finegrained = lib.mkDefault false;
+    open = lib.mkDefault false;
+    nvidiaSettings = lib.mkDefault true;
+    package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
+    prime = {
+      offload.enable = lib.mkDefault true;
+      amdgpuBusId = "PCI:6:0:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
   };
-  # force kernel to use iGPU first
-  boot.initrd.kernelModules = [ "amdgpu" ];
-
+  #Early KMS
+  boot.initrd.kernelModules = [ "amdgpu" "nvidia"];
 }

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -3,8 +3,11 @@
   imports = [
     ../../common/cpu/amd
     ../../common/gpu/amd
+    ../../common/cpu/amd/pstate.nix
+ 		../../common/gpu/nvidia
     ../../common/gpu/nvidia/prime.nix
     ../../common/pc/laptop  
+    ../../common/pc/ssd
   ];
   # These are the BusID's for this device.
   hardware.nvidia = {

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, config, ... }:
 {
   imports = [
     ../../common/cpu/amd

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -13,7 +13,7 @@
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;
-    package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
+    package = config.boot.kernelPackages.nvidiaPackages.stable;
     prime = {
       offload.enable = lib.mkDefault true;
       amdgpuBusId = "PCI:6:0:0";

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -1,4 +1,3 @@
-# Please include `package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;` in your config.
 { lib, config, ... }:
 {
   imports = [
@@ -13,9 +12,10 @@
     powerManagement.enable = lib.mkDefault false;
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
+    package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;
     nvidiaSettings = lib.mkDefault true;
     prime = {
-      offload.enable = lib.mkDefault true;
+      offload.enable = lib.mkForce true;
       amdgpuBusId = "PCI:6:0:0";
       nvidiaBusId = "PCI:1:0:0";
     };

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 {
   imports = [
     ../../common/cpu/amd

--- a/asus/fa706iu/default.nix
+++ b/asus/fa706iu/default.nix
@@ -1,0 +1,18 @@
+{ ... }:
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/gpu/amd
+    ../../common/gpu/nvidia
+    ../../common/pc/laptop  
+  ];
+  # These are the BusID's for this device.
+  hardware.nvidia.prime = {
+    offload.enable = lib.mkDefault true;
+    amdgpuBusId = "PCI:6:0:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+  # force kernel to use iGPU first
+  boot.initrd.kernelModules = [ "amdgpu" ];
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       asus-battery = import ./asus/battery.nix;
       asus-ally-rc71l = import ./asus/ally/rc71l;
       asus-fx504gd = import ./asus/fx504gd;
+      asus-fa706iu = import ./asus/fa706iu;
       asus-rog-strix-g513im = import ./asus/rog-strix/g513im;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;


### PR DESCRIPTION
###### Description of changes


###### Things done
Covers configuration for nvidia prime on fa706iu, including setting gpu bus id's

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

