### PR TITLE
Make so that kernel configs are actually read when compiling for microsoft surface devices.

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.6.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/default.nix
@@ -23,6 +23,7 @@ let
       url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
       sha256 = "sha256-nuYn5MEJrsf8o+2liY6B0gGvLH6y99nX2UwfDhIFVGw=";
     };
+    ignoreConfigErrors=true;
   };
 
 

--- a/microsoft/surface/common/kernel/linux-6.6.x/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/patches.nix
@@ -7,8 +7,8 @@
   {
     name = "microsoft-surface-patches-linux-${version}";
     patch = null;
-    structuredExtraConfig = with kernel; {
-      STREAMING_MEDIA = yes;
+    extraStructuredConfig = with kernel; {
+      STAGING_MEDIA = yes;
 
       #
       # Surface Aggregator Module


### PR DESCRIPTION
###### Description of changes

As discussed here: https://github.com/NixOS/nixos-hardware/issues/523
1) `structuredExtraConfig` is called `extraStructuredConfig` when using `kernelPatches`.
2) `STREAMING_MEDIA` should be `STAGING_MEDIA`.

Since the kernel configs now are actually read, an error is thrown if any of the configs in `patches.nix` are unused, so `ignoreConfigErrors=true;` must be added to `default.nix` to make sure it builds either way.

With these changes the cameras on my Surface book 2 are recognized.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

