### PR TITLE
16ach6h: Various fixes

### DIFF
--- a/lenovo/legion/16ach6h/README.md
+++ b/lenovo/legion/16ach6h/README.md
@@ -3,6 +3,12 @@ Due to the introduction of DDG feature, you may toggle DDG frequently, so for th
 **But It will slow down NixOS evaluation by factor 2 and increase memory usage.**  
 So if you don't need specialization feature, you can just use hybrid only configuration or nvidia only (DDG only) configuration
 
+## Using multiple drives with this configuration
+
+When using more than one drive, the value of `hardware.nvidia.prime.amdgpuBusId` will change from the default of `PCI:5:0:0`.
+
+Make sure you override this default in your personal configuration. For two drives, it should be `PCI:6:0:0`.
+
 ## Setup at the time of testing
 ```
 $ nix-info -m

--- a/lenovo/legion/16ach6h/default.nix
+++ b/lenovo/legion/16ach6h/default.nix
@@ -6,13 +6,6 @@
   specialisation.ddg.configuration = {
     # This specialisation is for the case where "DDG" (Dual-Direct GFX, A hardware feature that can enable in bios) is enabled, since the amd igpu is blocked at hardware level and the built-in display is directly connected to the dgpu, we no longer need the amdgpu and prime configuration.
     system.nixos.tags = [ "Dual-Direct-GFX-Mode" ];
-    services.xserver.videoDrivers = [ "nvidia" ]; # This will override services.xserver.videoDrivers = lib.mkDefault [ "amdgpu" "nvidia" ];
-    hardware = {
-      nvidia.prime.offload.enable = false;
-      amdgpu = {
-        amdvlk = false;
-        opencl = false;
-      };
-    };
+    imports = [ ./nvidia ];
   };
 }

--- a/lenovo/legion/16ach6h/edid/default.nix
+++ b/lenovo/legion/16ach6h/edid/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ...}:
+{ pkgs, ... }:
 
 let
   # This file was obtained from the display while "DDG" mode was enabled.
@@ -11,5 +11,7 @@ in
   hardware.firmware = [ chip_edid ];
 
   boot.kernelParams = [ "drm.edid_firmware=edid/16ach6h.bin" ];
-  boot.initrd.extraFiles."lib/firmware/edid/16ach6h.bin".source = pkgs.runCommandLocal "chip_edid" { } "cp ${./16ach6h.bin} $out";
+  # This fails at the moment, https://github.com/NixOS/nixos-hardware/issues/795
+  # Extra refresh rates seem to work regardless
+  # boot.initrd.extraFiles."lib/firmware/edid/16ach6h.bin".source = pkgs.runCommandLocal "chip_edid" { } "cp ${./16ach6h.bin} $out";
 }

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -11,6 +11,15 @@
     ../edid
   ];
 
+  # Still needs to load at some point if we want X11 to work
+  boot.kernelModules = [ "amdgpu" ];
+
+  # modesetting just doesn't work (on X11?), so get rid of it by only explicitly declaring nvidia
+  # Needed due to https://github.com/NixOS/nixos-hardware/commit/630a8e3e4eea61d35524699f2f59dbc64886357d
+  # See also https://github.com/NixOS/nixos-hardware/issues/628
+  # options.services.xserver.drivers will have a amdgpu entry from using the prime stuff in nixpkgs
+  services.xserver.videoDrivers = [ "nvidia" ];
+
   hardware = {
     amdgpu.loadInInitrd = lib.mkDefault false;
 

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -28,7 +28,7 @@
       powerManagement.enable = lib.mkDefault true;
 
       prime = {
-        amdgpuBusId = "PCI:6:0:0";
+        amdgpuBusId = lib.mkDefault "PCI:5:0:0";
         nvidiaBusId = "PCI:1:0:0";
       };
     };


### PR DESCRIPTION
###### Description of changes

A few commits to fix various annoyances I had with the config.

Fixes #628 and #795

Before merging I'd like to discuss the following the various people using this config the fact that the currently selected `amdgpuBusId = "PCI:06:00:0"` will only work for people who have two drives installed, while those that have one need to select `PCI:05:00:0` (see also https://github.com/NixOS/nixos-hardware/issues/786#issuecomment-1890439075 for a similar case, this was also brought up to my attention a long time ago on discord with the same issue)

If I had to choose a "sane default" that would be to do `lib.mkDefault "PCI:05:00:0"` with an accompanying note to set this manually for 2 drive users, but I wanted to hear your thoughts about it.

^ cc @LostAttractor @afreakk @piousdeer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

