### PR TITLE
Lenovo ThinkPad Z13 Gen 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ See code for all available configurations.
 | [Lenovo ThinkPad X280](lenovo/thinkpad/x280)                           | `<nixos-hardware/lenovo/thinkpad/x280>`                 |
 | [Lenovo ThinkPad X390](lenovo/thinkpad/x390)                           | `<nixos-hardware/lenovo/thinkpad/x390>`                 |
 | [Lenovo ThinkPad Z Series](lenovo/thinkpad/z)                          | `<nixos-hardware/lenovo/thinkpad/z>`                    |
-| [Lenovo ThinkPad Z13](lenovo/thinkpad/z/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/z13>`                |
+| [Lenovo ThinkPad Z13 Gen 1](lenovo/thinkpad/z/gen1/z13)                | `<nixos-hardware/lenovo/thinkpad/z/gen1/z13>`           |
+| [Lenovo ThinkPad Z13 Gen 2](lenovo/thinkpad/z/gen2/z13)                | `<nixos-hardware/lenovo/thinkpad/z/gen2/z13>`           |
 | [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                      | `<nixos-hardware/lenovo/yoga/6/13ALC6>`                 |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/amdgpu)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/amdgpu>`          |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          |

--- a/flake.nix
+++ b/flake.nix
@@ -175,7 +175,8 @@
       lenovo-thinkpad-x280 = import ./lenovo/thinkpad/x280;
       lenovo-thinkpad-x390 = import ./lenovo/thinkpad/x390;
       lenovo-thinkpad-z = import ./lenovo/thinkpad/z;
-      lenovo-thinkpad-z13 = import ./lenovo/thinkpad/z/z13;
+      lenovo-thinkpad-z13-gen1 = import ./lenovo/thinkpad/z/gen1/z13;
+      lenovo-thinkpad-z13-gen2 = import ./lenovo/thinkpad/z/gen2/z13;
       lenovo-yoga-6-13ALC6 = import ./lenovo/yoga/6/13ALC6;
       lenovo-yoga-7-14ARH7 = import ./lenovo/yoga/7/14ARH7;
       lenovo-yoga-7-slim-gen8 = import ./lenovo/yoga/7/slim/gen8;

--- a/lenovo/thinkpad/z/default.nix
+++ b/lenovo/thinkpad/z/default.nix
@@ -7,17 +7,14 @@
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/laptop/ssd
-    ../../../common/hidpi.nix # can be dropped after nixos 23.05
   ];
-  # kernel versions prior to 5.18 won't boot
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.18") (lib.mkDefault pkgs.linuxPackages_latest);
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;
   hardware.trackpoint.device = lib.mkDefault "TPPS/2 Elan TrackPoint";
 
   services.fprintd.enable = lib.mkDefault true;
 
-  # kernel versions below 6.0 don't contain ACPI suspend2idle drivers for the Z13s AMD hardware
+  # kernel versions below 6.0 don’t contain ACPI suspend2idle drivers for the Z-series’ AMD hardware
   # my Z13 froze after waking up from suspend/ hibernate
   services.logind.lidSwitch = lib.mkIf (lib.versionOlder pkgs.linux.version "6.00") (lib.mkDefault "lock");
 }

--- a/lenovo/thinkpad/z/gen1/default.nix
+++ b/lenovo/thinkpad/z/gen1/default.nix
@@ -1,0 +1,8 @@
+{ lib, pkgs, ... }: {
+  imports = [
+    ../../../../lenovo/thinkpad/z
+  ];
+
+  # Kernel 5.18 is required for the Ryzen 6000 series
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.18") (lib.mkDefault pkgs.linuxPackages_latest);
+}

--- a/lenovo/thinkpad/z/gen1/z13/default.nix
+++ b/lenovo/thinkpad/z/gen1/z13/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../../../../../lenovo/thinkpad/z/gen1
+  ];
+}

--- a/lenovo/thinkpad/z/gen2/default.nix
+++ b/lenovo/thinkpad/z/gen2/default.nix
@@ -1,0 +1,44 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../../lenovo/thinkpad/z
+  ];
+
+  # Kernel 6.4 is required for the Ryzen 7040 series
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.4") (lib.mkDefault pkgs.linuxPackages_latest);
+
+  systemd.services = {
+    # Modified from Arch Wiki
+    "touchpad-fix" = {
+      enable = lib.mkDefault true;
+      description = "I2C HID devices can fail to initialize so try to reload";
+      unitConfig = {
+        Type = "oneshot";
+      };
+      serviceConfig = {
+        User = "root";
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "multi-user.target" ];
+      script = ''
+        count=0
+        while true; do
+            ${lib.getExe pkgs.libinput} list-devices | ${lib.getExe pkgs.gnugrep} --quiet SNSL && break
+            count=$((count + 1))
+
+            if test $count -ge 5; then
+                echo "Touchpad not read after $count attempts"
+                break
+            fi
+
+            echo "Touchpad not ready; attempt $count to reload"
+            ${pkgs.kmod}/bin/rmmod i2c_hid_acpi
+            ${pkgs.kmod}/bin/modprobe i2c_hid_acpi
+
+            sleep $((2 + (count * 3)))
+        done
+      '';
+    };
+  };
+}

--- a/lenovo/thinkpad/z/gen2/z13/default.nix
+++ b/lenovo/thinkpad/z/gen2/z13/default.nix
@@ -1,0 +1,19 @@
+{ pkgs, lib, ...}:
+
+{
+  imports = [
+    ../../../../../lenovo/thinkpad/z/gen2
+  ];
+
+  sound.extraConfig = ''
+    pcm.!default {
+        type plug
+        slave.pcm "hw:1,0"
+    }
+
+    ctl.!default {
+        type hw
+        card 1
+    }
+  '';
+}

--- a/lenovo/thinkpad/z/z13/default.nix
+++ b/lenovo/thinkpad/z/z13/default.nix
@@ -1,5 +1,0 @@
-{
-  imports = [
-    ../../../../lenovo/thinkpad/z
-  ];
-}

--- a/lenovo/thinkpad/z13/default.nix
+++ b/lenovo/thinkpad/z13/default.nix
@@ -1,0 +1,10 @@
+{
+  assertions = [
+    {
+      assertion = true;
+      message = ''
+        Lenovo Z-series received a second generation so the hardware configuration has been split by generation. For the Z13 Gen 1 config, change from `lenovo-thinkpad-z13` to `lenovo-thinkpad-z13-gen1`.
+      '';
+    }
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Lenovo released a second generation of their Z series Thinkpads. This series has a 13" & 16" laptop named Z13 & Z16 respectively that runs much of the exact same hardware , so rather than splitting out `z/z13/gen1`, I thought `z/gen1/z13` made more sense (even if Z16 is missing since no one with the hardware has added it).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

~~Laptop is processing & will soon be in the mail, but I had the previous model (until got fried from an unlucky voltage spike) so I’m familiar enough with the hardware (co-authoring the Gen 1 commit). Gen 2 introduced nothing new other than a newer CPU, expanding RAM to 64 GB + SSD to 2 TB; the body, screen, battery, keyboard, trackpad & rest of the IO remains the same. The newer CPU requires a higher respective Linux kernel version--other than that, the rest of the commit is largely organizational. It appears the WiFi card may have changed brands. I will circle back to this as soon as it arrives to test.~~


[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.