### PR TITLE
Add framework-laptop-kmod for framework laptops

### DIFF
--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../kmod.nix
   ];
 
   # Fix TRRS headphones missing a mic

--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -1,0 +1,18 @@
+{ config, lib, ... }:
+{
+  options.hardware.framework.enableKmod = lib.mkOption {
+    type = lib.types.bool;
+    # Enable by default if on new enough version of NixOS
+    default = (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05");
+    description = ''
+      Enable the community created Framework kernel module that
+      allows interacting with the embedded controller from sysfs.
+    '';
+  };
+
+  config = lib.mkIf options.hardware.framework.enableKmod {
+    boot.extraModulePackages = with config.boot.kernelPackages; [
+      framework-laptop-kmod
+    ];
+  };
+}


### PR DESCRIPTION
Whether this is enabled is an option as requested in #829

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

