### PR TITLE
dell inspiron 5515: add early kms

### DIFF
--- a/dell/inspiron/5515/default.nix
+++ b/dell/inspiron/5515/default.nix
@@ -29,5 +29,9 @@
   # https://bbs.archlinux.org/viewtopic.php?id=266108 says linux >= 5.12 required
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.12") pkgs.linuxPackages_latest;
 
+  # sometimes boots to a black screen, and pressing alt+sysrq+k makes the
+  # display manager start
+  # fixed by early kernel modesetting
+  boot.initrd.kernelModules = [ "amdgpu" ];
 
 }


### PR DESCRIPTION
since the update to 23.11, the screen would remain black frequently on boot. Pressing alt+sysrq+k would make the display manager start. Empirically, setting early kms up has solved the issue. I've been using this setting for about a month.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

