### PR TITLE
starfive visionfive2: update kernel to 6.6.0

### DIFF
--- a/starfive/visionfive/v2/linux-6.6.nix
+++ b/starfive/visionfive/v2/linux-6.6.nix
@@ -9,8 +9,8 @@ let
       src = fetchFromGitHub {
         owner = "starfive-tech";
         repo = "linux";
-        rev = "7ccbe4604c1498e880cc63c7e8b45e3c55914d6d";
-        hash = "sha256-iO7tnnWYfveVbyvVZKL0dDLwONijt1n0RUD1kTkOQew=";
+        rev = "13eb70da2a73187c8c7aece13d23d68928aa8210";
+        hash = "sha256-bwB7Pc+Z+MWXPfWYdgtRGuhqjiNHLDGNCY62e4lBGvE=";
       };
 
       inherit modDirVersion kernelPatches;


### PR DESCRIPTION
###### Description of changes
Yes, 6.6.0 again, the vendor commits are updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

