### PR TITLE
Disable `hardware.nvidia.powerManagement.enable`

### DIFF
--- a/asus/zephyrus/ga401/default.nix
+++ b/asus/zephyrus/ga401/default.nix
@@ -16,6 +16,8 @@
     modesetting.enable = lib.mkDefault true;
     # Enable DRM kernel mode setting
     powerManagement.enable = lib.mkDefault true;
+
+    dynamicBoost.enable = true;
     
     prime = {
       amdgpuBusId = "PCI:4:0:0";

--- a/asus/zephyrus/ga401/default.nix
+++ b/asus/zephyrus/ga401/default.nix
@@ -11,11 +11,9 @@
   ];
 
   hardware.nvidia = {
-    # PCI-Express Runtime D3 Power Management is enabled by default on this laptop
-    # But it can fix screen tearing & suspend/resume screen corruption in sync mode
-    modesetting.enable = lib.mkDefault true;
     # Enable DRM kernel mode setting
-    powerManagement.enable = lib.mkDefault true;
+    # This will also cause "PCI-Express Runtime D3 Power Management" to be enabled by default
+    modesetting.enable = lib.mkDefault true;
 
     dynamicBoost.enable = true;
     


### PR DESCRIPTION
###### Description of changes
I have encountered a strange problem a long time ago.
If I put my laptop to sleep and wake it up again, it will go back to sleep a few seconds after waking up. If I wake it up again immediately, everything will be normal.
I always thought it was some bios bug or hardware issues, so I had no idea what to do.

Recently, I wanted to try the open source nvidia driver, so I read the nixos module for nvidia.
And I found [this](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/hardware/video/nvidia.nix#L491).
Its specific documentation is [here](https://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/powermanagement.html).

NVIDIA said this interface is still considered experimental and not used by default.
And after turning it off, the problem disappeared.

I can't confirm whether it's a problem with NixOS's implementation (it seems unlikely) or a problem with NVIDIA's implementation.
Or is there something wrong with the implementation of bios/vbios?

So I thought maybe it would be a good idea to turn it off, because of RTD3, sleeping while dGPU is on is not really common.

Also, I enabled dynamicBoost, It just works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

