### PR TITLE
GPD Win Max 2 2023: synchronize with upstream changes, initialize BMI260 driver

### DIFF
--- a/gpd/win-max-2/2023/README.md
+++ b/gpd/win-max-2/2023/README.md
@@ -1,0 +1,7 @@
+# GPD Win Max 2 2023
+
+## Gyro
+
+The IMU (Bosch BMI260) is incorrectly identified in the BIOS. It's named BMI0160:00 in ACPI table.
+
+The IMU is on `/dev/i2c-2`, address `0x69`. It's `CHIP_ID` in reg `0x00` is `0x27`, which could determine that it is actually BMI0260: https://chromium.googlesource.com/chromiumos/platform/ec/+/master/driver/accelgyro_bmi260.h#28

--- a/gpd/win-max-2/2023/bmi260/default.nix
+++ b/gpd/win-max-2/2023/bmi260/default.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  bmi260 = config.boot.kernelPackages.callPackage ./package.nix { };
+
+in
+{
+
+  meta.maintainers = [ maintainers.Cryolitia ];
+
+  ###### interface
+
+  options = {
+
+    hardware.sensor.iio.bmi260.enable = mkOption {
+      default = false;
+      type = types.bool;
+      description = mdDoc ''
+        Enable Bosch BMI260 IMU kernel module driver.
+      '';
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.hardware.sensor.iio.bmi260.enable {
+    boot.extraModulePackages = [ bmi260 ];
+    boot.kernelModules = [ "bmi260_core" "bmi260_i2c" ];
+  };
+}

--- a/gpd/win-max-2/2023/bmi260/package.nix
+++ b/gpd/win-max-2/2023/bmi260/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, kernel
+}:
+
+stdenv.mkDerivation (finalAttr: {
+  pname = "bmi260";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "hhd-dev";
+    repo = finalAttr.pname;
+    rev = "v${finalAttr.version}";
+    hash = "sha256-J0npD75QqOGY1QUoznBjQ+jX28gq5u6b0JZOseclwE8=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install *.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/bmi260
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/hhd-dev/bmi260";
+    description = "A kernel module driver for the Bosch BMI260 IMU";
+    license = with licenses; [ bsd3 gpl2Only ];
+    maintainers = with maintainers; [ Cryolitia ];
+    platforms = platforms.linux;
+  };
+})

--- a/gpd/win-max-2/2023/default.nix
+++ b/gpd/win-max-2/2023/default.nix
@@ -7,9 +7,4 @@ with lib;
     ../../../common/cpu/amd/pstate.nix
     ../../../common/gpu/amd
   ];
-
-  # fix suspend problem: https://www.reddit.com/r/gpdwin/comments/16veksm/win_max_2_2023_linux_experience_suspend_problems/
-  services.udev.extraRules = ''
-    ACTION=="add" SUBSYSTEM=="pci" ATTR{vendor}=="0x1022" ATTR{device}=="0x14ee" ATTR{power/wakeup}="disabled"
-  '';
 }

--- a/gpd/win-max-2/2023/default.nix
+++ b/gpd/win-max-2/2023/default.nix
@@ -13,4 +13,5 @@ with lib;
 
   #see README
   boot.blacklistedKernelModules = mkIf config.hardware.sensor.iio.bmi260.enable [ "bmi160_spi" "bmi160_i2c" "bmi160_core" ];
+  hardware.sensor.iio.enable = mkIf config.hardware.sensor.iio.bmi260.enable true;
 }

--- a/gpd/win-max-2/2023/default.nix
+++ b/gpd/win-max-2/2023/default.nix
@@ -6,5 +6,11 @@ with lib;
     ../../../common/cpu/amd
     ../../../common/cpu/amd/pstate.nix
     ../../../common/gpu/amd
+    ./bmi260
   ];
+
+  hardware.sensor.iio.bmi260.enable = lib.mkDefault true;
+
+  #see README
+  boot.blacklistedKernelModules = mkIf config.hardware.sensor.iio.bmi260.enable [ "bmi160_spi" "bmi160_i2c" "bmi160_core" ];
 }


### PR DESCRIPTION
###### Description of changes

- Synchronize with upstream changes
  - Remove udev rule disabling PCI wakeup. It's already fixed in linux kernel mainline and backported https://github.com/torvalds/linux/commit/805c74eac8cb306dc69b87b6b066ab4da77ceaf1
- Initialize BMI260 driver
  - found in https://chromium.googlesource.com/chromiumos/platform/ec/+/master/driver/accelgyro_bmi260.h
  - repacked in https://github.com/hhd-dev/bmi260
 
I'm not sure where the BMI260 driver should be. I don't know if there's other device with NixOS users also use the BMI260. Seems it's too niche to package in nixpkgs. So I just put it here. I'm glad to discuss it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

