### PR TITLE
Update to fix audio interference on Thinkpad X1 Nano Gen 1

### DIFF
--- a/lenovo/thinkpad/x1-nano/gen1/default.nix
+++ b/lenovo/thinkpad/x1-nano/gen1/default.nix
@@ -1,3 +1,19 @@
 { ... }: {
-  imports = [ ../. ];
+
+imports = [ ../. ];
+
+    environment.systemPackages = with pkgs; [
+        alsa-utils
+    ];
+
+   systemd.services.x1-fix = {
+   description = "Use alsa-utils to fix sound interference on Thinkpad x1 Nano";
+   serviceConfig = {
+     Type = "simple";
+     ExecStart = "${pkgs.alsa-tools}/bin/hda-verb /dev/snd/hwC0D0 0x1d SET_PIN_WIDGET_CONTROL 0x0";
+     Restart = "on-failure";
+   };
+   wantedBy = [ "default.target" ];
+ };
+
 }


### PR DESCRIPTION
Fixes the issue that this model of laptop has with audio interference in the headphone jack.

###### Description of changes

Uses the command hda-verb in the package alsa-utils to fix the audio interference with this Laptop. This is wrapped in a systemd service. Tested and working on my own X1 Nano. May also apply to other models but I can not confirm this.

My first pull request anywhere ever.  If something is improper,  let me know.

###### Things done

- [ ] Tested the changes on own flake
- [ ] Tested the changes in a default post-install flake

