### PR TITLE
Fix audio interference in headphone jack on Thinkpad x1 Nano Gen 1

### DIFF
--- a/lenovo/thinkpad/x1-nano/gen1/default.nix
+++ b/lenovo/thinkpad/x1-nano/gen1/default.nix
@@ -1,3 +1,17 @@
-{ ... }: {
+{ pkgs, ... }: 
   imports = [ ../. ];
+
+    environment.systemPackages = with pkgs; [
+        alsa-utils
+    ];
+
+   systemd.services.x1-fix = {
+   description = "Use alsa-utils to fix sound interference on Thinkpad x1 Nano";
+   serviceConfig = {
+     Type = "simple";
+     ExecStart = "${pkgs.alsa-tools}/bin/hda-verb /dev/snd/hwC0D0 0x1d SET_PIN_WIDGET_CONTROL 0x0";
+     Restart = "on-failure";
+   };
+   wantedBy = [ "default.target" ];
+ };
 }


### PR DESCRIPTION
###### Description of changes

In order to fix audio interference in headphone jack on this laptop, the command hda-verb from the package alsa-utils must be used. The required command has been wrapped in a custom systemd service.

###### Things done

- [ ] Tested the changes in my personal flake
- [ ] Tested the changes end-to-end by using the fork in a barebones default flake
