### PR TITLE
Update repository path for nxp/imx

### DIFF
--- a/nxp/common/bsp/imx-atf.nix
+++ b/nxp/common/bsp/imx-atf.nix
@@ -7,7 +7,7 @@
 {
   armTrustedFirmwareiMX8 = buildArmTrustedFirmware rec {
     src = fetchgit {
-      url = "https://source.codeaurora.org/external/imx/imx-atf";
+      url = "https://github.com/nxp-imx/imx-atf.git";
       # tag: "lf_v2.6"
       rev = "c6a19b1a351308cc73443283f6aa56b2eff791b8";
       sha256 = "sha256-C046MrZBDFuzBdnjuPC2fAGtXzZjTWRrO8nYTf1rjeg=";

--- a/nxp/common/bsp/imx-mkimage.nix
+++ b/nxp/common/bsp/imx-mkimage.nix
@@ -4,15 +4,20 @@ with pkgs;
 pkgs.stdenv.mkDerivation rec {
   pname = "imx-mkimage";
   version = "lf-5.15.32-2.0.0";
-
   src = fetchgit {
-    url = "https://source.codeaurora.org/external/imx/imx-mkimage.git";
+    url = "https://github.com/nxp-imx/imx-mkimage.git";
     rev = version;
-    sha256 = "sha256-31pib5DTDPVfiAAoOSzK8HWUlnuiNnfXQIsxbjneMCc=";
+    sha256 = "sha256-vJuWK2GOAtps798QY1I6xIcixgenJmntrh24s9KtsKU=";
     leaveDotGit = true;
   };
 
+  postPatch = ''
+    substituteInPlace Makefile \
+        --replace 'CC = gcc' 'CC = clang'
+  '';
+
   nativeBuildInputs = [
+    clang
     git
   ];
 

--- a/nxp/common/bsp/imx-optee-os.nix
+++ b/nxp/common/bsp/imx-optee-os.nix
@@ -35,7 +35,7 @@ pkgs.stdenv.mkDerivation rec {
   ];
 
   src = fetchGit {
-    url = "https://source.codeaurora.org/external/imx/imx-optee-os.git";
+    url = "https://github.com/nxp-imx/imx-optee-os.git";
     ref = "lf-5.15.32_2.0.0";
   };
 

--- a/nxp/common/bsp/imx-uboot.nix
+++ b/nxp/common/bsp/imx-uboot.nix
@@ -32,7 +32,7 @@ in {
   ubootImx8 = buildUBoot {
     version = "2022.04";
     src = fetchgit {
-      url = "https://source.codeaurora.org/external/imx/uboot-imx.git";
+      url = "https://github.com/nxp-imx/uboot-imx.git";
       # tag: "lf_v2022.04"
       rev = "1c881f4da83cc05bee50f352fa183263d7e2622b";
       sha256 = "sha256-0TS6VH6wq6PwZUq6ekbuLaisZ9LrE0/haU9nseGdiE0=";


### PR DESCRIPTION
###### Description of changes
Updated repositories for NXP/imx platform.
Old repositories doesn't exist anymore.
Fixed compilation issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

