### PR TITLE
framework AMD 7040: work around white screen / flickering issue on newer kernels

### DIFF
--- a/common/cpu/amd/raphael/igpu.nix
+++ b/common/cpu/amd/raphael/igpu.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, config, ... }:
 
 {
   # Sets the kernel version to the latest kernel to make the usage of the iGPU possible if your kernel version is too old
@@ -10,10 +10,9 @@
   boot = lib.mkMerge [
     (lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") {
       kernelPackages = pkgs.linuxPackages_latest;
-      kernelParams = ["amdgpu.sg_display=0"];
     })
 
-    (lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.2") {
+    (lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.2") {
       kernelParams = ["amdgpu.sg_display=0"];
     })
   ];

--- a/framework/13-inch/7040-amd/default.nix
+++ b/framework/13-inch/7040-amd/default.nix
@@ -7,6 +7,7 @@ in
   imports = [
     ../common
     ../common/amd.nix
+    ../../../common/cpu/amd/raphael/igpu.nix
   ];
 
   options = {
@@ -24,11 +25,6 @@ in
   };
 
   config = {
-    # Newer kernel is better for amdgpu driver updates
-    # Requires at least 5.16 for working wi-fi and bluetooth (RZ616, kmod mt7922):
-    # https://wireless.wiki.kernel.org/en/users/drivers/mediatek
-    boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") (lib.mkDefault pkgs.linuxPackages_latest);
-
     # Workaround applied upstream in Linux >=6.7 (on BIOS 03.03)
     # https://github.com/torvalds/linux/commit/a55bdad5dfd1efd4ed9ffe518897a21ca8e4e193
     services.udev.extraRules = lib.mkIf (lib.versionOlder pkgs.linux.version "6.7" && cfg.preventWakeOnAC) ''


### PR DESCRIPTION
###### Description of changes
Fixes #817.

Also fix the condition in `common/cpu/amd/raphael/igpu.nix`, which is required to make this work.

Updating the kernel if it is too old is already done by `common/cpu/amd/raphael/igpu.nix`, so I removed the redundant code.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input