### PR TITLE
Add support for Asus TUF A15 (FA507RM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                     | `<nixos-hardware/asus/zephyrus/ga503>`                  |
 | [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                   | `<nixos-hardware/asus/zephyrus/gu603h>`                 |
 | [Asus TUF FX504GD](asus/fx504gd)                                       | `<nixos-hardware/asus/fx504gd>`                         |
+| [Asus TUF FA507RM](asus/fa507rm)                                       | `<nixos-hardware/asus/fa507rm>`                         |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                   | `<nixos-hardware/beagleboard/pocketbeagle>`             |
 | [Deciso DEC series](deciso/dec)                                        | `<nixos-hardware/deciso/dec>`                           |
 | [Dell G3 3779](dell/g3/3779)                                           | `<nixos-hardware/dell/g3/3779>`                         |

--- a/asus/fa507rm/default.nix
+++ b/asus/fa507rm/default.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+    imports = [
+      ../../common/cpu/amd
+      ../../common/gpu/nvidia/prime.nix
+      ../../common/pc/laptop
+      ../../common/pc/ssd
+    ];
+
+    hardware.nvidia.prime = {
+      amdgpuBusId = "PCI:5:0:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       asus-battery = import ./asus/battery.nix;
       asus-ally-rc71l = import ./asus/ally/rc71l;
       asus-fx504gd = import ./asus/fx504gd;
+      asus-fa507rm = import ./asus/fa507rm;
       asus-rog-strix-g513im = import ./asus/rog-strix/g513im;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;


### PR DESCRIPTION
###### Description of changes
Add Support for Asus TUF A15 (FA507RM)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x ] Tested the changes in your own NixOS Configuration (checked)
- [ x ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input (checked against `<nixos-hardware>` method)

