### PR TITLE
[Dell Inspiron 5509] Import Intel GPU module

### DIFF
--- a/dell/inspiron/5509/default.nix
+++ b/dell/inspiron/5509/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ../../../common/cpu/intel
+    ../../../common/gpu/intel
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];


### PR DESCRIPTION
###### Description of changes
Import Intel GPU module for Dell Inspiron 5509. Should've done it right in the beginning but had it defined separately

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

