### PR TITLE
NXP iMX8 MPlus and iMX8 MQuad evaluation platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ See code for all available configurations.
 | [Microsoft Surface Range (Common Modules)](microsoft/surface/common)   | `<nixos-hardware/microsoft/surface/common>`             |
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                     | `<nixos-hardware/microsoft/surface-pro/3>`              |
 | [Morefine M600](morefine/m600)                                         | `<nixos-hardware/morefine/m600>`                        |
+| [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                        | `<nixos-hardware/nxp/imx8mp-evk>`                 |
+| [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                        | `<nixos-hardware/nxp/imx8mq-evk>`                 |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)             | `<nixos-hardware/hardkernel/odroid-hc4>`                |
 | [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)               | `<nixos-hardware/hardkernel/odroid-h3>`                 |
 | [Omen 15-en0010ca](omen/15-en0010ca)                                   | `<nixos-hardware/omen/15-en0010ca>`                     |

--- a/flake.nix
+++ b/flake.nix
@@ -184,6 +184,7 @@
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
       nxp-imx8mp-evk = import ./nxp/imx8mp-evk;
+      nxp-imx8mq-evk = import ./nxp/imx8mq-evk;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
       hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
       hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
       morefine-m600 = import ./morefine/m600;
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
+      nxp-imx8mp-evk = import ./nxp/imx8mp-evk;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
       hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
       hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;

--- a/nxp/README.md
+++ b/nxp/README.md
@@ -5,6 +5,8 @@
  - [i.MX8QuadXPlus Multisensory Enablement Kit](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadxplus-multisensory-enablement-kit-mek:MCIMX8QXP-CPU) (**imx8qxp-mek**) - device-specific U-Boot and Linux kernel.
 
 ## 2. How to use
+
+### 2.1  For imx8qm-mek
 Currently this NXP overlay is used for generating EFI-bootable NixOS images.
 I recommend to use [Tow-Boot](https://tow-boot.org/) as a bootloader, but U-Boot from this overlay can also be used.
 U-Boot was tested separately from NixOS.
@@ -18,3 +20,20 @@ Code snippet example that enables imx8qm configuration:
   ];
 }
 ```
+
+### 2.2 For imx8mq-evk/imx8mp-evk
+This NXP overlay is used for generating sdimage.
+Current configuration uses uboot as a bootloader. It provides an options to use optee-os which is currently disabled. It can be enabled using `enable-tee` boolean argument avalable in `imx8m<q/p>-boot.nix`, which is `false` by default.  
+
+Code snippet example that enables 'imx8mp-evk/emx8mq-evk' configuration:
+
+```
+{ nixos-hardware, }: {
+  system = "aarch64-linux";
+  modules = [
+    nixos-hardware.nixosModules.imx8mp-evk  #For imx8mp-evk
+    #nixos-hardware.nixosModules.imx8mq-evk  #For imx8mq-evk
+  ];
+}
+```
+

--- a/nxp/imx8mp-evk/bsp/imx8mp-atf.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-atf.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  pkgs,
+  buildArmTrustedFirmware,
+  fetchgit,
+  enable-tee,
+}:
+with pkgs; let
+  opteedflag =
+    if enable-tee
+    then "SPD=opteed"
+    else "";
+  target-board = "imx8mp";
+in
+  buildArmTrustedFirmware rec {
+    pname = "imx8mp-atf";
+    platform = target-board;
+    enableParallelBuilding = true;
+    extraMeta.platforms = ["aarch64-linux"];
+
+    src = fetchgit {
+      url = "https://github.com/nxp-imx/imx-atf.git";
+      #lf6.1.55_2.2.0
+      rev = "08e9d4eef2262c0dd072b4325e8919e06d349e02";
+      sha256 = "sha256-96EddJXlFEkP/LIGVgNBvUP4IDI3BbDE/c9Yub22gnc=";
+    };
+
+    extraMakeFlags = lib.concatLists [
+      (lib.optional (lib.versionAtLeast pkgs.binutils.version "2.39") "LDFLAGS=--no-warn-rwx-segments")
+      ["PLAT=${platform}" "bl31" "${opteedflag}"]
+    ];
+
+    filesToInstall = ["build/${target-board}/release/bl31.bin"];
+  }

--- a/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
@@ -1,12 +1,12 @@
 {
   pkgs,
-  enable-tee ? false,
+  enable-tee ? true,
 }:
 with pkgs; let
   fw-ver = "202006";
   cp-tee =
     if enable-tee
-    then "install -m 0644 ${optee-os}/tee.bin ./iMX8M/tee.bin"
+    then "install -m 0644 ${imx8mp-optee-os}/tee.bin ./iMX8M/tee.bin"
     else "";
 
   imx8mp-atf = pkgs.callPackage ./imx8mp-atf.nix {

--- a/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
@@ -1,0 +1,80 @@
+{
+  pkgs,
+  enable-tee ? false,
+}:
+with pkgs; let
+  fw-ver = "202006";
+  cp-tee =
+    if enable-tee
+    then "install -m 0644 ${optee-os}/tee.bin ./iMX8M/tee.bin"
+    else "";
+
+  imx8mp-atf = pkgs.callPackage ./imx8mp-atf.nix {
+    inherit (pkgs) buildArmTrustedFirmware;
+    inherit enable-tee;
+  };
+  imx8mp-firmware = pkgs.callPackage ./imx8mp-firmware.nix {};
+  imx8mp-uboot = pkgs.callPackage ./imx8mp-uboot.nix {};
+  imx8mp-optee-os = pkgs.callPackage ./imx8mp-optee-os.nix {};
+in {
+  imx8m-boot = pkgs.stdenv.mkDerivation rec {
+    name = "imx8mp-mkimage";
+    version = "lf-6.1.55-2.2.0";
+    src = pkgs.fetchgit {
+      url = "https://github.com/nxp-imx/imx-mkimage.git";
+      rev = "c4365450fb115d87f245df2864fee1604d97c06a";
+      sha256 = "sha256-xycEaWKVM63BlDyBKNN0OefyK6iX/fQOTvv4fRVM55U=";
+      leaveDotGit = true;
+    };
+
+    postPatch = ''
+      substituteInPlace Makefile \
+          --replace 'CC = gcc' 'CC = clang'
+      patchShebangs scripts
+    '';
+
+    nativeBuildInputs = [
+      clang
+      git
+      dtc
+    ];
+
+    buildInputs = [
+      git
+      glibc.static
+      zlib
+      zlib.static
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      make bin
+      make SOC=iMX8MP mkimage_imx8
+
+      cp -v ${pkgs.ubootTools}/bin/mkimage ./iMX8M/mkimage_uboot
+
+      install -m 0644 ${imx8mp-uboot}/u-boot-spl.bin ./iMX8M/u-boot-spl.bin
+      install -m 0644 ${imx8mp-uboot}/u-boot-nodtb.bin ./iMX8M/u-boot-nodtb.bin
+      install -m 0644 ${imx8mp-uboot}/imx8mp-evk.dtb ./iMX8M/imx8mp-evk.dtb
+      install -m 0644 ${imx8mp-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_1d_dmem_${fw-ver}.bin ./iMX8M/lpddr4_pmu_train_1d_dmem_${fw-ver}.bin
+      install -m 0644 ${imx8mp-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_1d_imem_${fw-ver}.bin ./iMX8M/lpddr4_pmu_train_1d_imem_${fw-ver}.bin
+      install -m 0644 ${imx8mp-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_2d_dmem_${fw-ver}.bin ./iMX8M/lpddr4_pmu_train_2d_dmem_${fw-ver}.bin
+      install -m 0644 ${imx8mp-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_2d_imem_${fw-ver}.bin ./iMX8M/lpddr4_pmu_train_2d_imem_${fw-ver}.bin
+      install -m 0644 ${imx8mp-firmware}/firmware/hdmi/cadence/signed_hdmi_imx8m.bin ./iMX8M/signed_hdmi_imx8m.bin
+      install -m 0644 ${imx8mp-atf}/bl31.bin ./iMX8M/bl31.bin
+      ${cp-tee}
+
+      make SOC=iMX8MP flash_evk
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/image
+      install -m 0644 ./iMX8M/flash.bin $out/image
+      runHook postInstall
+    '';
+  };
+}

--- a/nxp/imx8mp-evk/bsp/imx8mp-firmware.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-firmware.nix
@@ -1,0 +1,19 @@
+{pkgs, ...}:
+with pkgs;
+  stdenv.mkDerivation rec {
+    pname = "imx8mp-firmware";
+    version = "8.22";
+
+    src = pkgs.fetchurl {
+      url = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-${version}.bin";
+      sha256 = "sha256-lMi86sVuxQPCMuYU931rvY4Xx9qnHU5lHqj9UDTDA1A=";
+    };
+
+    dontUnpack = true;
+    dontStrip = true;
+
+    installPhase = ''
+      ${pkgs.bash}/bin/bash $src --auto-accept --force
+      mv firmware-imx-${version} $out
+    '';
+  }

--- a/nxp/imx8mp-evk/bsp/imx8mp-linux.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-linux.nix
@@ -1,0 +1,50 @@
+{pkgs, ...} @ args:
+with pkgs;
+  buildLinux (args
+    // rec {
+      version = "6.1.55";
+      name = "imx8mp-linux";
+
+      # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+      modDirVersion = version;
+
+      defconfig = "imx_v8_defconfig";
+
+      kernelPatches = [
+      ];
+
+      autoModules = false;
+
+      extraConfig = ''
+        CRYPTO_TLS m
+        TLS y
+        MD_RAID0 m
+        MD_RAID1 m
+        MD_RAID10 m
+        MD_RAID456 m
+        DM_VERITY m
+        LOGO y
+        FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+        FB_EFI n
+        EFI_STUB y
+        EFI y
+        VIRTIO y
+        VIRTIO_PCI y
+        VIRTIO_BLK y
+        DRM_VIRTIO_GPU y
+        EXT4_FS y
+        USBIP_CORE m
+        USBIP_VHCI_HCD m
+        USBIP_HOST m
+        USBIP_VUDC m
+      '';
+
+      src = fetchFromGitHub {
+        owner = "nxp-imx";
+        repo = "linux-imx";
+        # tag: lf-6.1.55-2.2.0
+        rev = "770c5fe2c1d1529fae21b7043911cd50c6cf087e";
+        sha256 = "sha256-tIWt75RUrjB6KmUuAYBVyAC1dmVGSUAgqV5ROJh3xU0=";
+      };
+    }
+    // (args.argsOverride or {}))

--- a/nxp/imx8mp-evk/bsp/imx8mp-optee-os.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-optee-os.nix
@@ -1,0 +1,66 @@
+{pkgs}: let
+  python3 = pkgs.buildPackages.python3;
+  toolchain = pkgs.gcc9Stdenv.cc;
+  binutils = pkgs.gcc9Stdenv.cc.bintools.bintools_bin;
+  cpp = pkgs.gcc;
+in
+  pkgs.stdenv.mkDerivation rec {
+    pname = "imx8mp-optee-os";
+    version = "lf-6.1.55-2.2.0";
+
+    nativeBuildInputs = [
+      python3
+    ];
+
+    enableParallelBuilding = true;
+
+    propagatedBuildInputs = with python3.pkgs; [
+      pycryptodomex
+      pyelftools
+      cryptography
+    ];
+
+    src = pkgs.fetchgit {
+      url = "https://github.com/nxp-imx/imx-optee-os.git";
+      rev = "a303fc80f7c4bd713315687a1fa1d6ed136e78ee";
+      sha256 = "sha256-OpyG812DX0c06bRZPKWB2cNu6gtZCOvewDhsKgrGB+s=";
+    };
+
+    postPatch = ''
+      substituteInPlace scripts/arm32_sysreg.py \
+        --replace '/usr/bin/env python3' '${python3}/bin/python'
+      substituteInPlace scripts/gen_tee_bin.py \
+        --replace '/usr/bin/env python3' '${python3}/bin/python'
+      substituteInPlace scripts/pem_to_pub_c.py \
+        --replace '/usr/bin/env python3' '${python3}/bin/python'
+      substituteInPlace ta/pkcs11/scripts/verify-helpers.sh \
+        --replace '/bin/bash' '${pkgs.bash}/bin/bash'
+      substituteInPlace mk/gcc.mk \
+        --replace "\$(CROSS_COMPILE_\$(sm))objcopy" ${binutils}/bin/${toolchain.targetPrefix}objcopy
+      substituteInPlace mk/gcc.mk \
+        --replace "\$(CROSS_COMPILE_\$(sm))objdump" ${binutils}/bin/${toolchain.targetPrefix}objdump
+      substituteInPlace mk/gcc.mk \
+        --replace "\$(CROSS_COMPILE_\$(sm))nm" ${binutils}/bin/${toolchain.targetPrefix}nm
+      substituteInPlace mk/gcc.mk \
+        --replace "\$(CROSS_COMPILE_\$(sm))readelf" ${binutils}/bin/${toolchain.targetPrefix}readelf
+      substituteInPlace mk/gcc.mk \
+        --replace "\$(CROSS_COMPILE_\$(sm))ar" ${binutils}/bin/${toolchain.targetPrefix}ar
+      substituteInPlace mk/gcc.mk \
+        --replace "\$(CROSS_COMPILE_\$(sm))cpp" ${cpp}/bin/cpp
+    '';
+
+    makeFlags = [
+      "PLATFORM=imx"
+      "PLATFORM_FLAVOR=mx8qmmek"
+      "CFG_ARM64_core=y"
+      "CFG_TEE_TA_LOG_LEVEL=0"
+      "CFG_TEE_CORE_LOG_LEVEL=0"
+      "CROSS_COMPILE=${toolchain}/bin/${toolchain.targetPrefix}"
+      "CROSS_COMPILE64=${toolchain}/bin/${toolchain.targetPrefix}"
+    ];
+
+    installPhase = ''
+      mkdir -p $out
+      cp ./out/arm-plat-imx/core/tee-raw.bin $out/tee.bin
+    '';
+  }

--- a/nxp/imx8mp-evk/bsp/imx8mp-uboot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-uboot.nix
@@ -1,0 +1,41 @@
+{pkgs}:
+with pkgs; let
+  inherit buildUBoot;
+in
+  (buildUBoot {
+    pname = "imx8mp-uboot";
+    version = "2023.04";
+
+    src = fetchgit {
+      url = "https://github.com/nxp-imx/uboot-imx.git";
+      # tag: "lf-6.1.55-2.2.0"
+      rev = "49b102d98881fc28af6e0a8af5ea2186c1d90a5f";
+      sha256 = "sha256-1j6X82DqezEizeWoSS600XKPNwrQ4yT0vZuUImKAVVA=";
+    };
+
+    extraConfig = ''
+      CONFIG_USE_BOOTCOMMAND=y
+      CONFIG_BOOTCOMMAND="setenv ramdisk_addr_r 0x45000000; setenv fdt_addr_r 0x44000000; run distro_bootcmd; "
+      CONFIG_CMD_BOOTEFI_SELFTEST=y
+      CONFIG_CMD_BOOTEFI=y
+      CONFIG_EFI_LOADER=y
+      CONFIG_BLK=y
+      CONFIG_PARTITIONS=y
+      CONFIG_DM_DEVICE_REMOVE=n
+      CONFIG_CMD_CACHE=y
+    '';
+
+    enableParallelBuilding = true;
+    defconfig = "imx8mp_evk_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+
+    filesToInstall = [
+      "./u-boot-nodtb.bin"
+      "./spl/u-boot-spl.bin"
+      "./arch/arm/dts/imx8mp-evk.dtb"
+      ".config"
+    ];
+  })
+  .overrideAttrs (old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.perl];
+  })

--- a/nxp/imx8mp-evk/default.nix
+++ b/nxp/imx8mp-evk/default.nix
@@ -1,0 +1,18 @@
+{pkgs, ...}: {
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  imports = [
+    ./modules.nix
+  ];
+
+  boot.loader.grub.extraFiles = {
+    "imx8mp-evk.dtb" = "${pkgs.callPackage ./bsp/imx8mp-linux.nix {}}/dtbs/freescale/imx8mp-evk.dtb";
+  };
+
+  hardware.deviceTree = {
+    filter = "imx8mp-*.dtb";
+    name = "imx8mp-evk.dtb";
+  };
+}

--- a/nxp/imx8mp-evk/modules.nix
+++ b/nxp/imx8mp-evk/modules.nix
@@ -1,0 +1,16 @@
+{
+  pkgs,
+  lib,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-linux";
+
+  boot = {
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/imx8mp-linux.nix {});
+    initrd.includeDefaultModules = lib.mkForce false;
+  };
+
+  disabledModules = ["profiles/all-hardware.nix"];
+
+  hardware.deviceTree.enable = true;
+}

--- a/nxp/imx8mp-evk/overlay.nix
+++ b/nxp/imx8mp-evk/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  inherit (final.callPackage ./bsp/imx8mp-boot.nix {pkgs = final;}) imx8m-boot;
+}

--- a/nxp/imx8mq-evk/bsp/imx8mq-atf.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-atf.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  pkgs,
+  buildArmTrustedFirmware,
+  fetchgit,
+  enable-tee,
+}:
+with pkgs; let
+  opteedflag =
+    if enable-tee
+    then "SPD=opteed"
+    else "";
+  target-board = "imx8mq";
+in
+  buildArmTrustedFirmware rec {
+    pname = "imx8mq-atf";
+    platform = target-board;
+    enableParallelBuilding = true;
+    extraMeta.platforms = ["aarch64-linux"];
+
+    src = fetchgit {
+      url = "https://github.com/nxp-imx/imx-atf.git";
+      #lf6.1.55_2.2.0
+      rev = "08e9d4eef2262c0dd072b4325e8919e06d349e02";
+      sha256 = "sha256-96EddJXlFEkP/LIGVgNBvUP4IDI3BbDE/c9Yub22gnc=";
+    };
+
+    extraMakeFlags = lib.concatLists [
+      (lib.optional (lib.versionAtLeast pkgs.binutils.version "2.39") "LDFLAGS=--no-warn-rwx-segments")
+      ["PLAT=${platform}" "bl31" "${opteedflag}"]
+    ];
+
+    filesToInstall = ["build/${target-board}/release/bl31.bin"];
+  }

--- a/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
@@ -1,0 +1,78 @@
+{
+  pkgs,
+  enable-tee ? false,
+}:
+with pkgs; let
+  cp-tee =
+    if enable-tee
+    then "install -m 0644 ${imx8mq-optee-os}/tee.bin ./iMX8M/tee.bin"
+    else "";
+
+  imx8mq-atf = pkgs.callPackage ./imx8mq-atf.nix {
+    inherit (pkgs) buildArmTrustedFirmware;
+    inherit enable-tee;
+  };
+  imx8mq-firmware = pkgs.callPackage ./imx8mq-firmware.nix {};
+  imx8mq-uboot = pkgs.callPackage ./imx8mq-uboot.nix {};
+  imx8mq-optee-os = pkgs.callPackage ./imx8mq-optee-os.nix {};
+in {
+  imx8m-boot = pkgs.stdenv.mkDerivation rec {
+    name = "imx8mq-mkimage";
+    version = "lf-6.1.55-2.2.0";
+    src = pkgs.fetchgit {
+      url = "https://github.com/nxp-imx/imx-mkimage.git";
+      rev = "c4365450fb115d87f245df2864fee1604d97c06a";
+      sha256 = "sha256-xycEaWKVM63BlDyBKNN0OefyK6iX/fQOTvv4fRVM55U=";
+      leaveDotGit = true;
+    };
+
+    postPatch = ''
+      substituteInPlace Makefile \
+          --replace 'CC = gcc' 'CC = clang'
+      patchShebangs scripts
+    '';
+
+    nativeBuildInputs = [
+      clang
+      git
+      dtc
+    ];
+
+    buildInputs = [
+      git
+      glibc.static
+      zlib
+      zlib.static
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      make bin
+      make SOC=iMX8M mkimage_imx8
+      cp -v ${pkgs.ubootTools}/bin/mkimage ./iMX8M/mkimage_uboot
+
+      install -m 0644 ${imx8mq-uboot}/u-boot-spl.bin ./iMX8M/u-boot-spl.bin
+      install -m 0644 ${imx8mq-uboot}/u-boot-nodtb.bin ./iMX8M/u-boot-nodtb.bin
+      install -m 0644 ${imx8mq-uboot}/imx8mq-evk.dtb ./iMX8M/imx8mq-evk.dtb
+      install -m 0644 ${imx8mq-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_1d_dmem.bin ./iMX8M/lpddr4_pmu_train_1d_dmem.bin
+      install -m 0644 ${imx8mq-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_1d_imem.bin ./iMX8M/lpddr4_pmu_train_1d_imem.bin
+      install -m 0644 ${imx8mq-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_2d_dmem.bin ./iMX8M/lpddr4_pmu_train_2d_dmem.bin
+      install -m 0644 ${imx8mq-firmware}/firmware/ddr/synopsys/lpddr4_pmu_train_2d_imem.bin ./iMX8M/lpddr4_pmu_train_2d_imem.bin
+      install -m 0644 ${imx8mq-firmware}/firmware/hdmi/cadence/signed_hdmi_imx8m.bin ./iMX8M/signed_hdmi_imx8m.bin
+      install -m 0644 ${imx8mq-atf}/bl31.bin ./iMX8M/bl31.bin
+      ${cp-tee}
+
+      make SOC=iMX8M flash_evk
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/image
+      install -m 0644 ./iMX8M/flash.bin $out/image
+      runHook postInstall
+    '';
+  };
+}

--- a/nxp/imx8mq-evk/bsp/imx8mq-firmware.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-firmware.nix
@@ -1,0 +1,19 @@
+{pkgs, ...}:
+with pkgs;
+  stdenv.mkDerivation rec {
+    pname = "imx8mq-firmware";
+    version = "8.22";
+
+    src = pkgs.fetchurl {
+      url = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-${version}.bin";
+      sha256 = "sha256-lMi86sVuxQPCMuYU931rvY4Xx9qnHU5lHqj9UDTDA1A=";
+    };
+
+    dontUnpack = true;
+    dontStrip = true;
+
+    installPhase = ''
+      ${pkgs.bash}/bin/bash $src --auto-accept --force
+      mv firmware-imx-${version} $out
+    '';
+  }

--- a/nxp/imx8mq-evk/bsp/imx8mq-linux.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-linux.nix
@@ -1,0 +1,50 @@
+{pkgs, ...} @ args:
+with pkgs;
+  buildLinux (args
+    // rec {
+      version = "6.1.55";
+      name = "imx8mq-linux";
+
+      # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+      modDirVersion = version;
+
+      defconfig = "imx_v8_defconfig";
+
+      kernelPatches = [
+      ];
+
+      autoModules = false;
+
+      extraConfig = ''
+        CRYPTO_TLS m
+        TLS y
+        MD_RAID0 m
+        MD_RAID1 m
+        MD_RAID10 m
+        MD_RAID456 m
+        DM_VERITY m
+        LOGO y
+        FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+        FB_EFI n
+        EFI_STUB y
+        EFI y
+        VIRTIO y
+        VIRTIO_PCI y
+        VIRTIO_BLK y
+        DRM_VIRTIO_GPU y
+        EXT4_FS y
+        USBIP_CORE m
+        USBIP_VHCI_HCD m
+        USBIP_HOST m
+        USBIP_VUDC m
+      '';
+
+      src = fetchFromGitHub {
+        owner = "nxp-imx";
+        repo = "linux-imx";
+        # tag: lf-6.1.55-2.2.0
+        rev = "770c5fe2c1d1529fae21b7043911cd50c6cf087e";
+        sha256 = "sha256-tIWt75RUrjB6KmUuAYBVyAC1dmVGSUAgqV5ROJh3xU0=";
+      };
+    }
+    // (args.argsOverride or {}))

--- a/nxp/imx8mq-evk/bsp/imx8mq-optee-os.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-optee-os.nix
@@ -5,7 +5,7 @@
   cpp = pkgs.gcc;
 in
   pkgs.stdenv.mkDerivation rec {
-    pname = "imx8mp-optee-os";
+    pname = "imx8mq-optee-os";
     version = "lf-6.1.55-2.2.0";
 
     nativeBuildInputs = [
@@ -51,7 +51,7 @@ in
 
     makeFlags = [
       "PLATFORM=imx"
-      "PLATFORM_FLAVOR=mx8mpevk"
+      "PLATFORM_FLAVOR=mx8mqevk"
       "CFG_ARM64_core=y"
       "CFG_TEE_TA_LOG_LEVEL=0"
       "CFG_TEE_CORE_LOG_LEVEL=0"

--- a/nxp/imx8mq-evk/bsp/imx8mq-uboot.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-uboot.nix
@@ -1,0 +1,41 @@
+{pkgs}:
+with pkgs; let
+  inherit buildUBoot;
+in
+  (buildUBoot {
+    pname = "imx8mq-uboot";
+    version = "2023.04";
+
+    src = fetchgit {
+      url = "https://github.com/nxp-imx/uboot-imx.git";
+      # tag: "lf-6.1.55-2.2.0"
+      rev = "49b102d98881fc28af6e0a8af5ea2186c1d90a5f";
+      sha256 = "sha256-1j6X82DqezEizeWoSS600XKPNwrQ4yT0vZuUImKAVVA=";
+    };
+
+    extraConfig = ''
+      CONFIG_USE_BOOTCOMMAND=y
+      CONFIG_BOOTCOMMAND="setenv ramdisk_addr_r 0x45000000; setenv fdt_addr_r 0x44000000; run distro_bootcmd; "
+      CONFIG_CMD_BOOTEFI_SELFTEST=y
+      CONFIG_CMD_BOOTEFI=y
+      CONFIG_EFI_LOADER=y
+      CONFIG_BLK=y
+      CONFIG_PARTITIONS=y
+      CONFIG_DM_DEVICE_REMOVE=n
+      CONFIG_CMD_CACHE=y
+    '';
+
+    enableParallelBuilding = true;
+    defconfig = "imx8mq_evk_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+
+    filesToInstall = [
+      "./u-boot-nodtb.bin"
+      "./spl/u-boot-spl.bin"
+      "./arch/arm/dts/imx8mq-evk.dtb"
+      ".config"
+    ];
+  })
+  .overrideAttrs (old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.perl];
+  })

--- a/nxp/imx8mq-evk/default.nix
+++ b/nxp/imx8mq-evk/default.nix
@@ -1,0 +1,18 @@
+{pkgs, ...}: {
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  imports = [
+    ./modules.nix
+  ];
+
+  boot.loader.grub.extraFiles = {
+    "imx8mq-evk.dtb" = "${pkgs.callPackage ./bsp/imx8mq-linux.nix {}}/dtbs/freescale/imx8mq-evk.dtb";
+  };
+
+  hardware.deviceTree = {
+    filter = "imx8mq-*.dtb";
+    name = "imx8mq-evk.dtb";
+  };
+}

--- a/nxp/imx8mq-evk/modules.nix
+++ b/nxp/imx8mq-evk/modules.nix
@@ -1,0 +1,16 @@
+{
+  pkgs,
+  lib,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-linux";
+
+  boot = {
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/imx8mq-linux.nix {});
+    initrd.includeDefaultModules = lib.mkForce false;
+  };
+
+  disabledModules = ["profiles/all-hardware.nix"];
+
+  hardware.deviceTree.enable = true;
+}

--- a/nxp/imx8mq-evk/overlay.nix
+++ b/nxp/imx8mq-evk/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  inherit (final.callPackage ./bsp/imx8mq-boot.nix {pkgs = final;}) imx8m-boot;
+}


### PR DESCRIPTION
###### Description of changes
Added support for following NXP evaluation platform
- iMX8 MPlus 
- iMX8 MQuad 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

