### PR TITLE
Add msi B550 a pro motherboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ See code for all available configurations.
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/amdgpu)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/amdgpu>`          |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          |
 | [LENOVO Yoga 7 Slim Gen8](lenovo/yoga/7/slim/gen8)                     | `<nixos-hardware/lenovo/yoga/7/slim/gen8>`              |
+| [MSI B550-A PRO](msi/b550-a-pro)                                       | `<nixos-hardware/msi/b550-a-pro>`                       |
 | [MSI GS60 2QE](msi/gs60)                                               | `<nixos-hardware/msi/gs60>`                             |
 | [MSI GL62/CX62](msi/gl62)                                              | `<nixos-hardware/msi/gl62>`                             |
 | [Microchip Icicle Kit](microchip/icicle-kit)                           | `<nixos-hardware/microchip/icicle-kit>`                 |

--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,7 @@
       microsoft-surface-common = import ./microsoft/surface/common;
       microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
       morefine-m600 = import ./morefine/m600;
+      msi-b550-a-pro = import ./msi/b550-a-pro;
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;

--- a/msi/b550-a-pro/default.nix
+++ b/msi/b550-a-pro/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/pc/ssd
+    ../../common/pc
+  ];
+
+  boot.kernelModules = ["nct6683"];
+}


### PR DESCRIPTION
###### Description of changes

Add configuration for the msi B550 a pro motherboard.

I only tested with this specific motherboard but maybe the nct6683 chip is used on other msi B550 motheroboards I did not find this information =/

Also, I managed to run tests using `./tests/run.py 'msi/b550-a-pro'` but not `./tests/run.py '<nixos-hardware/msi/b550-a-pro>'`. Have I done any mistake ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

