### PR TITLE
surface: iptsd: Prevent emtpy config file, restart properly.

### DIFF
--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -16,8 +16,8 @@ in
     enable = mkEnableOption "Enable IPTSd for Microsoft Surface";
 
     config = mkOption {
-      type = types.attrs;
-      default = { };
+      type = types.nullOr types.attrs;
+      default = null;
       description = ''
         Values to wrote to iptsd.conf, first key is section, second key is property.
         See the example config; https://github.com/linux-surface/iptsd/blob/v1.4.0/etc/iptsd.conf
@@ -41,8 +41,12 @@ in
         path = with pkgs; [ iptsd ];
         script = "iptsd $(iptsd-find-hidraw)";
         wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ (if (cfg.config != null) then iptsConfFile else "") ];
       };
-      environment.etc."iptsd/iptsd.conf".source = "${iptsConfFile}";
+    })
+
+    (mkIf (cfg.config != null) {
+      environment.etc."iptsd.conf".source = "${iptsConfFile}";
     })
   ];
 }

--- a/microsoft/surface/common/ipts/default.nix
+++ b/microsoft/surface/common/ipts/default.nix
@@ -41,7 +41,7 @@ in
         path = with pkgs; [ iptsd ];
         script = "iptsd $(iptsd-find-hidraw)";
         wantedBy = [ "multi-user.target" ];
-        restartTriggers = [ (if (cfg.config != null) then iptsConfFile else "") ];
+        restartTriggers = lib.optional (cfg.config != null) iptsConfFile;
       };
     })
 


### PR DESCRIPTION
###### Description of changes
This improves and corrects my previous configuration option from #788 .

1. It ensures no configuration file is written if no configuration is specified, previously an empty file was always written (which iptsd handles gracefully, falling back to built in defaults).
2. It ensures proper restarting of iptsd when the configuration is changed.
3. It corrects the config path from `/etc/iptsd/iptsd.conf` to `/etc/iptsd.conf`.

The third item was a bug in #788 that got through my testing because I also had an environment variable set that can overwrite the location from which the config is read.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input -> Yep, definitely see it printing it loaded the file now.

