### PR TITLE
Add Thinkpad X13 Gen1 AMD variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ See code for all available configurations.
 | [Lenovo ThinkPad X1 Nano Gen 1](lenovo/thinkpad/x1-nano/gen1)          | `<nixos-hardware/lenovo/thinkpad/x1-nano/gen1>`         |
 | [Lenovo ThinkPad X13 Yoga](lenovo/thinkpad/x13/yoga)                   | `<nixos-hardware/lenovo/thinkpad/x13/yoga>`             |
 | [Lenovo ThinkPad X13 Yoga (3th Gen)](lenovo/thinkpad/x13/yoga/3th-gen) | `<nixos-hardware/lenovo/thinkpad/x13/yoga/3th-gen>`     |
-| [Lenovo ThinkPad X13](lenovo/thinkpad/x13)                             | `<nixos-hardware/lenovo/thinkpad/x13>`                  |
+| [Lenovo ThinkPad X13 (Intel)](lenovo/thinkpad/x13/intel)               | `<nixos-hardware/lenovo/thinkpad/x13/intel>`            |
+| [Lenovo ThinkPad X13 (AMD)](lenovo/thinkpad/x13/amd)                   | `<nixos-hardware/lenovo/thinkpad/x13/amd>`              |
 | [Lenovo ThinkPad X140e](lenovo/thinkpad/x140e)                         | `<nixos-hardware/lenovo/thinkpad/x140e>`                |
 | [Lenovo ThinkPad X200s](lenovo/thinkpad/x200s)                         | `<nixos-hardware/lenovo/thinkpad/x200s>`                |
 | [Lenovo ThinkPad X220](lenovo/thinkpad/x220)                           | `<nixos-hardware/lenovo/thinkpad/x220>`                 |
@@ -249,8 +250,8 @@ See code for all available configurations.
 | [Microsoft Surface Range (Common Modules)](microsoft/surface/common)   | `<nixos-hardware/microsoft/surface/common>`             |
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                     | `<nixos-hardware/microsoft/surface-pro/3>`              |
 | [Morefine M600](morefine/m600)                                         | `<nixos-hardware/morefine/m600>`                        |
-| [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                        | `<nixos-hardware/nxp/imx8mp-evk>`                 |
-| [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                        | `<nixos-hardware/nxp/imx8mq-evk>`                 |
+| [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                        | `<nixos-hardware/nxp/imx8mp-evk>`                       |
+| [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                        | `<nixos-hardware/nxp/imx8mq-evk>`                       |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)             | `<nixos-hardware/hardkernel/odroid-hc4>`                |
 | [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)               | `<nixos-hardware/hardkernel/odroid-h3>`                 |
 | [Omen 15-en0010ca](omen/15-en0010ca)                                   | `<nixos-hardware/omen/15-en0010ca>`                     |

--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,8 @@
       lenovo-thinkpad-x1-extreme-gen4 = import ./lenovo/thinkpad/x1-extreme/gen4;
       lenovo-thinkpad-x1-nano = import ./lenovo/thinkpad/x1-nano;
       lenovo-thinkpad-x1-nano-gen1 = import ./lenovo/thinkpad/x1-nano/gen1;
-      lenovo-thinkpad-x13 = import ./lenovo/thinkpad/x13;
+      lenovo-thinkpad-x13 = import ./lenovo/thinkpad/x13/intel;
+      lenovo-thinkpad-x13-amd = import ./lenovo/thinkpad/x13/amd;
       lenovo-thinkpad-x13-yoga = import ./lenovo/thinkpad/x13/yoga;
       lenovo-thinkpad-x13-yoga-3th-gen = import ./lenovo/thinkpad/x13/yoga/3th-gen;
       lenovo-thinkpad-x140e = import ./lenovo/thinkpad/x140e;

--- a/lenovo/thinkpad/x13/OLD-BEHAVIOUR-DEPRECATED.md
+++ b/lenovo/thinkpad/x13/OLD-BEHAVIOUR-DEPRECATED.md
@@ -1,0 +1,12 @@
+# Thinkpad X13 Deprecations
+
+## Overview
+
+The X13 has multiple variants. Originally, the configs only supported Intel
+hardware.
+
+## How to update
+
+If you previously imported the module under `lenovo/thinkpad/x13`, you can now
+import `lenovo/thinkpad/x13/intel` instead. Users with the AMD variant should
+import `lenovo/thinkpad/x13/amd`.

--- a/lenovo/thinkpad/x13/amd/default.nix
+++ b/lenovo/thinkpad/x13/amd/default.nix
@@ -1,0 +1,6 @@
+{ ... }: {
+  imports = [
+    ../common.nix
+    ../../../../common/cpu/amd
+  ];
+}

--- a/lenovo/thinkpad/x13/common.nix
+++ b/lenovo/thinkpad/x13/common.nix
@@ -1,0 +1,10 @@
+{ ... }: {
+  imports = [
+    ../.
+    ../../../common/pc/laptop/acpi_call.nix
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # Somehow psmouse does not load automatically on boot for me
+  boot.initrd.kernelModules = [ "psmouse" ];
+}

--- a/lenovo/thinkpad/x13/default.nix
+++ b/lenovo/thinkpad/x13/default.nix
@@ -1,12 +1,8 @@
-{ ... }: {
-  # Reference to hardware: https://certification.ubuntu.com/hardware/202004-27844
-  imports = [
-    ../.
-    ../../../common/cpu/intel
-    ../../../common/pc/laptop/acpi_call.nix
-    ../../../common/pc/laptop/ssd
+{
+  assertions = [
+    {
+      assertion = false;
+      message = "Importing the x13/ (default.nix) directly is deprecated! See https://github.com/NixOS/nixos-hardware/blob/master/lenovo/thinkpad/x13/OLD-BEHAVIOUR-DEPRECATED.md for more details.";
+    }
   ];
-
-  # Somehow psmouse does not load automatically on boot for me
-  boot.initrd.kernelModules = [ "psmouse" ];
 }

--- a/lenovo/thinkpad/x13/intel/default.nix
+++ b/lenovo/thinkpad/x13/intel/default.nix
@@ -1,0 +1,7 @@
+{ ... }: {
+  # Reference to hardware: https://certification.ubuntu.com/hardware/202004-27844
+  imports = [
+    ../common.nix
+    ../../../../common/cpu/intel
+  ];
+}

--- a/lenovo/thinkpad/x13/yoga/default.nix
+++ b/lenovo/thinkpad/x13/yoga/default.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }: {
   imports = [
-    ../.
+    ../intel
     ../../yoga.nix
   ];
 


### PR DESCRIPTION
###### Description of changes
Add Thinkpad X13 Gen1 variant for AMD CPU, which is the model I own. https://ubuntu.com/certified/202006-27979/20.04%20LTS.

This change moves some of the config files for the Intel variant, but leaves the Flake output `lenovo-thinkpad-x13` as-is to avoid breakage.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

