### PR TITLE
Dell XPS 15 9530

### DIFF
--- a/dell/xps/15-9530/README.wiki
+++ b/dell/xps/15-9530/README.wiki
@@ -1,0 +1,20 @@
+= Dell XPS 15 9530 =
+
+== Tested Hardware ==
+
+* CPU: 13th Gen Intel(R) Core(TM) i9-13900H
+* RAM: 32 GB
+* HDD: 1 TiB SSD (NVME)
+* Screen: 15" 4k (3456 x 2160)
+* Graphics: NVIDIA GeForce RTX 4070 Laptop GPU, with Intel Graphics too.
+* Input: Touchscreen and trackpad.
+
+== Notes ==
+
+== NVIDIA Offload ==
+
+In order to run a program on the NVIDIA gpu, you can use the `nvidia-offload` function, for example:
+```
+nvidia-offload `nix-shell -p glxinfo --run 'glxgears'`
+```
+This is a short bash script that sets the proper environment variables and calls your command.

--- a/dell/xps/15-9530/README.wiki
+++ b/dell/xps/15-9530/README.wiki
@@ -8,6 +8,7 @@
 * Screen: 15" 4k (3456 x 2160)
 * Graphics: NVIDIA GeForce RTX 4070 Laptop GPU, with Intel Graphics too.
 * Input: Touchscreen and trackpad.
+* Fingerprint Reader: Goodix
 
 == Notes ==
 
@@ -18,3 +19,23 @@ In order to run a program on the NVIDIA gpu, you can use the `nvidia-offload` fu
 nvidia-offload `nix-shell -p glxinfo --run 'glxgears'`
 ```
 This is a short bash script that sets the proper environment variables and calls your command.
+
+== Fingerprint Reader ==
+
+I have added support for the fingerprint reader. It has however been tested on Gnome  only.
+
+- After Installation, I had to reboot once before the fingerprint options  would showin the Users module in Gnome Settings
+- You will need to register your fingerprints in the Users module in Gnome Settings
+- When logging in I suggest using your password otherwise the keyring is not unlocked at login. You can use the fingerprint reader at all other times.
+
+== Touchpad ==
+
+This is a matter of preference, but I do recommend disabling the Touchpad while typing. I hit it with my palm all the time.
+
+Since I am using Gnome, I have done this through Home-Manager using `dconf`.
+
+```
+"org/gnome/desktop/peripherals/touchpad" = {
+      disable-while-typing = true;
+    };
+```

--- a/dell/xps/15-9530/default.nix
+++ b/dell/xps/15-9530/default.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+    ./fingerprint
+  ];
+
+  # This will save you money and possibly your life!
+  services.thermald.enable = lib.mkDefault true;
+
+  # 9530 wifi is:
+  # > lspci | grep i Network
+  # - 00:14.3 Network controller: Intel Corporation Raptor Lake PCH CNVi WiFi (rev 01)
+  # > sudo lspci -vv -s 00:14.3
+  # 00:14.3 Network controller: Intel Corporation Raptor Lake PCH CNVi WiFi (rev 01)
+	# Subsystem: Intel Corporation Wi-Fi 6E AX211 160MHz
+  #
+  # WiFi speed is slow and crashes by default (https://bugzilla.kernel.org/show_bug.cgi?id=213381)
+  # disable_11ax - required until ax driver support is fixed
+  # power_save - works well on this card
+  # boot.extraModprobeConfig = ''
+  #   options iwlwifi power_save=1 disable_11ax=1
+  # '';
+
+  boot.extraModprobeConfig = ''
+    options iwlwifi power_save=1
+  '';
+}

--- a/dell/xps/15-9530/fingerprint/default.nix
+++ b/dell/xps/15-9530/fingerprint/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, lib, config, ... }: {
+
+  environment.systemPackages = [
+
+  ];
+
+  services.fprintd = {
+    enable = true;
+    tod = {
+      enable = true;
+      driver = pkgs.libfprint-2-tod1-goodix;
+    };
+
+  };
+
+  # Used to allow a password login on first login as an alternative to just a fingerprint
+  security.pam.services.login.fprintAuth = false;
+  # similarly to how other distributions handle the fingerprinting login
+  security.pam.services.gdm-fingerprint =
+    lib.mkIf (config.services.fprintd.enable) {
+      text = ''
+        auth       required                    pam_shells.so
+        auth       requisite                   pam_nologin.so
+        auth       requisite                   pam_faillock.so      preauth
+        auth       required                    ${pkgs.fprintd}/lib/security/pam_fprintd.so
+        auth       optional                    pam_permit.so
+        auth       required                    pam_env.so
+        auth       [success=ok default=1]      ${pkgs.gnome.gdm}/lib/security/pam_gdm.so
+        auth       optional                    ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so
+
+        account    include                     login
+
+        password   required                    pam_deny.so
+
+        session    include                     login
+        session    optional                    ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so auto_start
+      '';
+    };
+
+}

--- a/dell/xps/15-9530/nvidia/default.nix
+++ b/dell/xps/15-9530/nvidia/default.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+{
+  imports = [
+    ../default.nix
+    ../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  hardware.nvidia.prime = {
+    # Bus ID of the Intel GPU.
+    intelBusId = lib.mkDefault "PCI:0:2:0";
+
+    # Bus ID of the NVIDIA GPU.
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
+}


### PR DESCRIPTION
I am just beginning to create support for a Dell XPS 15 9530. 

I am not yet done with all the code, but I wanted to start the PR to ensure my work meets the needed standards. I am basing off the 9520 and have already been testing by leveraging the `common` components directly in my local config.

My first question:

The common/GPU/Nvidia component seems to overlap with what is in [the wiki](https://nixos.wiki/wiki/Nvidia) for Nvidia. If a person adds the Nvidia configuration from this repo, is that all the base configuration a consumer needs, or would they still need to follow the WIKI? I want to clarify that in the readme for this model. (It always confuses me with my other machines that consume from here.) For example, I will see people manually create the offload scripts in their config, but I know the Nvidia component will also do that.

Thank you.