### PR TITLE
fix: comment out the edid module for legion-16ach6h

### DIFF
--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -8,7 +8,8 @@
     ../../../../common/gpu/nvidia/prime.nix
     ../../../../common/pc/laptop
     ../../../../common/pc/laptop/ssd
-    ../edid
+    # This seems to break extra monitor modes
+    # ../edid
   ];
 
   # Still needs to load at some point if we want X11 to work


### PR DESCRIPTION
It seems to break extra monitor modes

###### Description of changes

I've being using an extra monitor with a resolution of 2560x1440 and a maximum refresh rate of 180Hz. However only two modes 2560x1600@165Hz and 2560x1600@60Hz are available with this configuration applied. Interestingly, my Fedora system, which does not utilize this EDID, managed to work fine, with the mode 2560x1440@180Hz available. Therefore I tried comment it out and it worked perfectly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

