### PR TITLE
Add module for MSI B350 Tomahawk

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ See code for all available configurations.
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          |
 | [LENOVO Yoga 7 Slim Gen8](lenovo/yoga/7/slim/gen8)                     | `<nixos-hardware/lenovo/yoga/7/slim/gen8>`              |
 | [MSI B550-A PRO](msi/b550-a-pro)                                       | `<nixos-hardware/msi/b550-a-pro>`                       |
+| [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                 | `<nixos-hardware/msi/b350-tomahawk>`                    |
 | [MSI GS60 2QE](msi/gs60)                                               | `<nixos-hardware/msi/gs60>`                             |
 | [MSI GL62/CX62](msi/gl62)                                              | `<nixos-hardware/msi/gl62>`                             |
 | [Microchip Icicle Kit](microchip/icicle-kit)                           | `<nixos-hardware/microchip/icicle-kit>`                 |

--- a/flake.nix
+++ b/flake.nix
@@ -184,6 +184,7 @@
       microsoft-surface-common = import ./microsoft/surface/common;
       microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
       morefine-m600 = import ./morefine/m600;
+      msi-b350-tomahawk = import ./msi/b350-tomahawk;
       msi-b550-a-pro = import ./msi/b550-a-pro;
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;

--- a/msi/b350-tomahawk/default.nix
+++ b/msi/b350-tomahawk/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/pc/ssd
+    ../../common/pc
+  ];
+
+  boot.kernelModules = ["nct6775"];
+}


### PR DESCRIPTION
###### Description of changes
Added module for MSI B350 Tomahawk Motherboard

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

