### PR TITLE
16ach6h: re-enable edid for internal display only

### DIFF
--- a/lenovo/legion/16ach6h/edid/default.nix
+++ b/lenovo/legion/16ach6h/edid/default.nix
@@ -10,7 +10,9 @@ in
 {
   hardware.firmware = [ chip_edid ];
 
-  boot.kernelParams = [ "drm.edid_firmware=edid/16ach6h.bin" ];
+  # For some reason, the internal display is sometimes eDP-1, and sometimes it's eDP-2
+  boot.kernelParams = [ "drm.edid_firmware=eDP-1:edid/16ach6h.bin,eDP-2:edid/16ach6h.bin" ];
+
   # This fails at the moment, https://github.com/NixOS/nixos-hardware/issues/795
   # Extra refresh rates seem to work regardless
   # boot.initrd.extraFiles."lib/firmware/edid/16ach6h.bin".source = pkgs.runCommandLocal "chip_edid" { } "cp ${./16ach6h.bin} $out";

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -8,8 +8,7 @@
     ../../../../common/gpu/nvidia/prime.nix
     ../../../../common/pc/laptop
     ../../../../common/pc/laptop/ssd
-    # This seems to break extra monitor modes
-    # ../edid
+    ../edid
   ];
 
   # Still needs to load at some point if we want X11 to work


### PR DESCRIPTION
###### Description of changes

With the recent #890, my internal display's refresh rate is restricted to 60 hz, and without it, my external monitor doesn't display anything (likely due to forcing it to an unsupported resolution/refresh rate).

This makes both the internal display and external monitors work correctly.

@yaoshiu feel free to test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

