### PR TITLE
framework/12th-gen-intel: use s2idle

### DIFF
--- a/framework/13-inch/12th-gen-intel/default.nix
+++ b/framework/13-inch/12th-gen-intel/default.nix
@@ -5,9 +5,6 @@
   ];
 
   boot.kernelParams = [
-    # For Power consumption
-    # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
-    "mem_sleep_default=deep"
     # Workaround iGPU hangs
     # https://discourse.nixos.org/t/intel-12th-gen-igpu-freezes/21768/4
     "i915.enable_psr=1"


### PR DESCRIPTION
###### Description of changes

88348cb adds a fix that describes s2idle as being better than S3 deep sleep, thus we remove this option to take advantage of improved s2idle

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

