### PR TITLE
protectli vp4670

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ See code for all available configurations.
 | [PINE64 Pinebook Pro](pine64/pinebook-pro/)                            | `<nixos-hardware/pine64/pinebook-pro>`                  |
 | [PINE64 RockPro64](pine64/rockpro64/)                                  | `<nixos-hardware/pine64/rockpro64>`                     |
 | [PINE64 STAR64](pine64/star64/)                                        | `<nixos-hardware/pine64/star64>`                        |
+| [Protectli VP4670](protectli/vp4670/)                                  | `<nixos-hardware/protectli/vp4670>`                     |
 | [Purism Librem 13v3](purism/librem/13v3)                               | `<nixos-hardware/purism/librem/13v3>`                   |
 | [Purism Librem 15v3](purism/librem/13v3)                               | `<nixos-hardware/purism/librem/15v3>`                   |
 | [Purism Librem 5r4](purism/librem/5r4)                                 | `<nixos-hardware/purism/librem/5r4>`                    |

--- a/common/cpu/intel/comet-lake/default.nix
+++ b/common/cpu/intel/comet-lake/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [ ../. ];
+
+  boot.kernelParams = [
+    "i915.enable_guc=2"
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -204,6 +204,7 @@
       pine64-pinebook-pro = import ./pine64/pinebook-pro;
       pine64-rockpro64 = import ./pine64/rockpro64;
       pine64-star64 = import ./pine64/star64;
+      protectli-vp4670 = import ./protectli/vp4670;
       purism-librem-13v3 = import ./purism/librem/13v3;
       purism-librem-15v3 = import ./purism/librem/15v3;
       purism-librem-5r4 = import ./purism/librem/5r4;

--- a/flake.nix
+++ b/flake.nix
@@ -229,6 +229,7 @@
       common-cpu-amd-pstate = import ./common/cpu/amd/pstate.nix;
       common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
       common-cpu-intel = import ./common/cpu/intel;
+      common-cpu-intel-comet-lake = import ./common/cpu/intel/comet-lake;
       common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only.nix;
       common-cpu-intel-kaby-lake = import ./common/cpu/intel/kaby-lake;
       common-cpu-intel-sandy-bridge = import ./common/cpu/intel/sandy-bridge;

--- a/protectli/vp4670/default.nix
+++ b/protectli/vp4670/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ../../common/cpu/intel/comet-lake
+  ];
+
+  boot.initrd.kernelModules = [
+    "sdhci_pci" # 16G eMMC on board
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Added support for Protectli VP4670 [1], along with a module for its CPU, which is a Comet Lake 10810U [2].

[1] https://eu.protectli.com/product/vp4670/
[2] https://ark.intel.com/content/www/us/en/ark/products/201888/intel-core-i7-10810u-processor-12m-cache-up-to-4-90-ghz.html

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

