### PR TITLE
ga401: use mkDefault for dynamicBoost

### DIFF
--- a/asus/zephyrus/ga401/default.nix
+++ b/asus/zephyrus/ga401/default.nix
@@ -15,7 +15,7 @@
     # This will also cause "PCI-Express Runtime D3 Power Management" to be enabled by default
     modesetting.enable = lib.mkDefault true;
 
-    dynamicBoost.enable = true;
+    dynamicBoost.enable = lib.mkDefault true;
     
     prime = {
       amdgpuBusId = "PCI:4:0:0";


### PR DESCRIPTION
###### Description of changes
Dynamic boost is only supported for Ampere and would result in `nvidia-powerd` service failing to start on anything lower.
I have a G14 with 1660TI and had to disable the option with `mkForce`, which I think is pretty ugly.

[Documentation for Dynamic Boost](https://download.nvidia.com/XFree86/Linux-x86_64/515.65.01/README/dynamicboost.html)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

