### PR TITLE
framework-12th-gen-intel: Refactor

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -1,15 +1,26 @@
 { config, lib, pkgs, ... }:
 
 {
-  boot.initrd.kernelModules = [ "i915" ];
-
-  environment.variables = {
-    VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
+  options.hardware.intelgpu.loadInInitrd = lib.mkEnableOption (lib.mdDoc
+    "loading `i195` kernelModule at stage 1. (Add `i915` to `boot.initrd.kernelModules`)"
+  ) // {
+    default = true;
   };
 
-  hardware.opengl.extraPackages = with pkgs; [
-    (if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)
-    libvdpau-va-gl
-    intel-media-driver
+  config = lib.mkMerge [
+    (lib.mkIf config.hardware.intelgpu.loadInInitrd { 
+      boot.initrd.kernelModules = [ "i915" ]; 
+    })
+    {
+      environment.variables = {
+        VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
+      };
+
+      hardware.opengl.extraPackages = with pkgs; [
+        (if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)
+        libvdpau-va-gl
+        intel-media-driver
+      ];
+    }
   ];
 }

--- a/framework/13-inch/12th-gen-intel/default.nix
+++ b/framework/13-inch/12th-gen-intel/default.nix
@@ -1,52 +1,62 @@
-{ lib, pkgs, ... }: {
+{ config, lib, pkgs, ... }:
+{
   imports = [
     ../common
     ../common/intel.nix
   ];
 
-  boot.kernelParams = [
-    # For Power consumption
-    # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
-    "mem_sleep_default=deep"
-    # Workaround iGPU hangs
-    # https://discourse.nixos.org/t/intel-12th-gen-igpu-freezes/21768/4
-    "i915.enable_psr=1"
+  config = lib.mkMerge [
+    {
+      hardware.intelgpu.loadInInitrd = lib.versionOlder config.boot.kernelPackages.kernel.version "6.2";
+    }
+    # https://community.frame.work/t/tracking-hard-freezing-on-fedora-36-with-the-new-12th-gen-system/20675/391
+    (lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.2") {
+      boot.kernelParams = [ 
+        # Workaround iGPU hangs
+        # https://discourse.nixos.org/t/intel-12th-gen-igpu-freezes/21768/4
+        "i915.enable_psr=1" 
+      ];
+    })
+    (lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") {
+      boot.blacklistedKernelModules = [ 
+        # This enables the brightness and airplane mode keys to work
+        # https://community.frame.work/t/12th-gen-not-sending-xf86monbrightnessup-down/20605/11
+        "hid-sensor-hub"
+        # This fixes controller crashes during sleep
+        # https://community.frame.work/t/tracking-fn-key-stops-working-on-popos-after-a-while/21208/32
+        (lib.mkIf (config.hardware.framework.enableKmod == false) "cros_ec_lpcs")
+      ];
+
+      boot.kernelParams = [ 
+        # For Power consumption
+        # https://kvark.github.io/linux/framework/2021/10/17/framework-nixos.html
+        # Update 04/2024: Combined with acpi_osi from framework-intel it increases the idle power-usage in my test (SebTM)
+        # (see: https://github.com/NixOS/nixos-hardware/pull/903#issuecomment-2068146658)
+        "mem_sleep_default=deep"
+      ];
+
+      # Further tweak to ensure the brightness and airplane mode keys work
+      # https://community.frame.work/t/responded-12th-gen-not-sending-xf86monbrightnessup-down/20605/67
+      systemd.services.bind-keys-driver = {
+        description = "Bind brightness and airplane mode keys to their driver";
+        wantedBy = [ "default.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          User = "root";
+        };
+        script = ''
+          ls -lad /sys/bus/i2c/devices/i2c-*:* /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*:*
+          if [ -e /sys/bus/i2c/devices/i2c-FRMW0001:00 -a ! -e /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-FRMW0001:00 ]; then
+            echo fixing
+            echo i2c-FRMW0001:00 > /sys/bus/i2c/drivers/i2c_hid_acpi/bind
+            ls -lad /sys/bus/i2c/devices/i2c-*:* /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*:*
+            echo done
+          else
+            echo no fix needed
+          fi
+        '';
+      };
+    })
   ];
-
-  boot.blacklistedKernelModules = [ 
-    # This enables the brightness and airplane mode keys to work
-    # https://community.frame.work/t/12th-gen-not-sending-xf86monbrightnessup-down/20605/11
-    "hid-sensor-hub"
-    # This fixes controller crashes during sleep
-    # https://community.frame.work/t/tracking-fn-key-stops-working-on-popos-after-a-while/21208/32
-    "cros_ec_lpcs"
-  ];
-  
-  # Further tweak to ensure the brightness and airplane mode keys work
-  # https://community.frame.work/t/responded-12th-gen-not-sending-xf86monbrightnessup-down/20605/67
-  systemd.services.bind-keys-driver = {
-    description = "Bind brightness and airplane mode keys to their driver";
-    wantedBy = [ "default.target" ];
-    after = [ "network.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      User = "root";
-    };
-    script = ''
-      ls -lad /sys/bus/i2c/devices/i2c-*:* /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*:*
-      if [ -e /sys/bus/i2c/devices/i2c-FRMW0001:00 -a ! -e /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-FRMW0001:00 ]; then
-        echo fixing
-        echo i2c-FRMW0001:00 > /sys/bus/i2c/drivers/i2c_hid_acpi/bind
-        ls -lad /sys/bus/i2c/devices/i2c-*:* /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*:*
-        echo done
-      else
-        echo no fix needed
-      fi
-    '';
-  };
-
-  # Alder Lake CPUs benefit from kernel 5.18 for ThreadDirector
-  # https://www.tomshardware.com/news/intel-thread-director-coming-to-linux-5-18
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.18") (lib.mkDefault pkgs.linuxPackages_latest);
-
 }

--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../kmod.nix
   ];
 
   # Fix TRRS headphones missing a mic

--- a/framework/13-inch/common/intel.nix
+++ b/framework/13-inch/common/intel.nix
@@ -1,15 +1,17 @@
-{ lib, pkgs, ... }: {
+{ config, lib, pkgs, ... }: {
   imports = [
     ../../../common/cpu/intel
   ];
 
-  boot.kernelParams = [
-    # Fixes a regression in s2idle, making it more power efficient than deep sleep
-    "acpi_osi=\"!Windows 2020\""
+  boot.kernelParams = [    
     # For Power consumption
     # https://community.frame.work/t/linux-battery-life-tuning/6665/156
     "nvme.noacpi=1"
-  ];
+  ] 
+  # Fixes a regression in s2idle, making it more power efficient than deep sleep
+  # Update 04/2024: It appears that s2idle-regression got fixed in newer kernel-versions (SebTM)
+  # (see: https://github.com/NixOS/nixos-hardware/pull/903#discussion_r1556096657)
+  ++ lib.lists.optional (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") "acpi_osi=\"!Windows 2020\"";
 
   # Requires at least 5.16 for working wi-fi and bluetooth.
   # https://community.frame.work/t/using-the-ax210-with-linux-on-the-framework-laptop/1844/89

--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+{
+  options.hardware.framework.enableKmod = lib.mkEnableOption (lib.mdDoc
+    "Enable the community created Framework kernel module that allows interacting with the embedded controller from sysfs."
+  ) // {
+    # Enable by default if on new enough version of NixOS
+    default = (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05");
+  };
+
+  config = lib.mkIf config.hardware.framework.enableKmod {
+    boot.extraModulePackages = with config.boot.kernelPackages; [
+      framework-laptop-kmod
+    ];
+    # https://github.com/DHowett/framework-laptop-kmod?tab=readme-ov-file#usage
+    boot.kernelModules = [ "cros_ec" "cros_ec_lpcs" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Kernel: 6.8.2
Tested with: https://github.com/NixOS/nixpkgs/pull/300781

Came across this due to backlight not restored after reboot (https://github.com/NixOS/nixpkgs/issues/178345 - wasn't related) issue and followed as I have the same issue as (https://github.com/NixOS/nixpkgs/issues/202846#issue-1464490034) 2. with the screen "flickering" (like restarting once) and then weird display issue instead like above.

With this changes and above configuration it looks like t his on initrd luks-unlock (how it should be):
![IMG_0863](https://github.com/NixOS/nixos-hardware/assets/17243347/88d5cfd3-7048-4d88-bb4a-18cf1702aecc)

Previous picture:
![photo_2024-04-08_10-09-16](https://github.com/NixOS/nixos-hardware/assets/17243347/75f59f4e-d149-4561-baed-bcdf875d79c2)
(Display issues on current master with i915 loaded in initrd)

Superseeds https://github.com/NixOS/nixos-hardware/pull/846 (fixed and package updated https://github.com/NixOS/nixpkgs/pull/300781)

Fixes https://github.com/NixOS/nixos-hardware/pull/897 for latest kernel-version (6.8) - might need to be removed completely (https://github.com/NixOS/nixos-hardware/issues/672#issuecomment-2015778670) ℹ️ (needs feedback)

Fixes https://github.com/NixOS/nixos-hardware/issues/894

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

