### PR TITLE
surface: linux 6.6.13 -> 6.6.25

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.6.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.6.x/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.6.13";
+  version = "6.6.25";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "sha256-iLiefdQerU46seQRyLuNWSV1rPgVzx3zwNxX4uiCwLw=";
+    sha256 = "0i0zvqlj02rm6wpbidji0rn9559vrpfc1b8gbfjk70lhhyz11llr";
     ignoreConfigErrors=true;
   };
 


### PR DESCRIPTION
###### Description of changes

Update linux to 6.6.25 for surface.

NOTE: This is not intended to replace #878, but rather to provide an updated 6.6 kernel in the meanwhile

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

