### PR TITLE
Add Lenovo legion 16ARHA7

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See code for all available configurations.
 | [Lenovo Legion 7 16achg6 (Hybrid)](lenovo/legion/16achg6/hybrid)       | `<nixos-hardware/lenovo/legion/16achg6/hybrid>`         |
 | [Lenovo Legion 7 16achg6 (Nvidia)](lenovo/legion/16achg6/nvidia)       | `<nixos-hardware/lenovo/legion/16achg6/nvidia>`         |
 | [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)          | `<nixos-hardware/lenovo/legion/16irx8h>`                |
-| [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)							 | `<nixos-hardware/lenovo/legion/16arha7>`                |
+| [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)             | `<nixos-hardware/lenovo/legion/16arha7>`                |
 | [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                        | `<nixos-hardware/lenovo/legion/15ich>`                  |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                   | `<nixos-hardware/lenovo/thinkpad/e14/amd>`              |
 | [Lenovo ThinkPad E14 (Intel)](lenovo/thinkpad/e14/intel)               | `<nixos-hardware/lenovo/thinkpad/e14/intel>`            |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ See code for all available configurations.
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                         | `<nixos-hardware/friendlyarm/nanopc-t4>`                |
 | [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                       | `<nixos-hardware/friendlyarm/nanopi-r5s>`               |
 | [Focus M2 Gen 1](focus/m2/gen1)                                        | `<nixos-hardware/focus/m2/gen1>`                        |
-| [Gigabyte B550](gigabyte/b550)                                         | `<nixos-hardware/gigabyte/b550>`
+| [Gigabyte B550](gigabyte/b550)                                         | `<nixos-hardware/gigabyte/b550>`                        |
 | [GPD MicroPC](gpd/micropc)                                             | `<nixos-hardware/gpd/micropc>`                          |
 | [GPD P2 Max](gpd/p2-max)                                               | `<nixos-hardware/gpd/p2-max>`                           |
 | [GPD Pocket 3](gpd/pocket-3)                                           | `<nixos-hardware/gpd/pocket-3>`                         |
@@ -172,6 +172,7 @@ See code for all available configurations.
 | [Lenovo Legion 7 16achg6 (Hybrid)](lenovo/legion/16achg6/hybrid)       | `<nixos-hardware/lenovo/legion/16achg6/hybrid>`         |
 | [Lenovo Legion 7 16achg6 (Nvidia)](lenovo/legion/16achg6/nvidia)       | `<nixos-hardware/lenovo/legion/16achg6/nvidia>`         |
 | [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)          | `<nixos-hardware/lenovo/legion/16irx8h>`                |
+| [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)							 | `<nixos-hardware/lenovo/legion/16arha7>`                |
 | [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                        | `<nixos-hardware/lenovo/legion/15ich>`                  |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                   | `<nixos-hardware/lenovo/thinkpad/e14/amd>`              |
 | [Lenovo ThinkPad E14 (Intel)](lenovo/thinkpad/e14/intel)               | `<nixos-hardware/lenovo/thinkpad/e14/intel>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
       lenovo-legion-16achg6-hybrid = import ./lenovo/legion/16achg6/hybrid;
       lenovo-legion-16achg6-nvidia = import ./lenovo/legion/16achg6/nvidia;
       lenovo-legion-16aph8 = import ./lenovo/legion/16aph8;
+			lenovo-legion-16arha7 = import ./lenovo/legion/16arha7;
       lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
       lenovo-legion-16irx8h = import ./lenovo/legion/16irx8h;
       lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
       lenovo-legion-16achg6-hybrid = import ./lenovo/legion/16achg6/hybrid;
       lenovo-legion-16achg6-nvidia = import ./lenovo/legion/16achg6/nvidia;
       lenovo-legion-16aph8 = import ./lenovo/legion/16aph8;
-			lenovo-legion-16arha7 = import ./lenovo/legion/16arha7;
+      lenovo-legion-16arha7 = import ./lenovo/legion/16arha7;
       lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
       lenovo-legion-16irx8h = import ./lenovo/legion/16irx8h;
       lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;

--- a/lenovo/legion/16arha7/README.md
+++ b/lenovo/legion/16arha7/README.md
@@ -1,0 +1,15 @@
+## Introduction
+
+This configuration includes a fix to get audio playing over the speakers, however, the volume is low. If you know of a workaround or fix, please contribute it to the repo!!
+
+## Setup at the time of testing
+```
+$ nix-info -m
+ - system: `"x86_64-linux"`
+ - host os: `Linux 6.8.2-zen2, NixOS, 24.05 (Uakari), 24.05.20240403.fd281bd`
+ - multi-user?: `yes`
+ - sandbox: `yes`
+ - version: `nix-env (Nix) 2.18.2`
+ - channels(root): `""`
+ - nixpkgs: `/home/aires/.nix-defexpr/channels/nixpkgs`
+ ```

--- a/lenovo/legion/16arha7/audio/lenovo-16ARHA7_speaker-fix.nix
+++ b/lenovo/legion/16arha7/audio/lenovo-16ARHA7_speaker-fix.nix
@@ -1,0 +1,38 @@
+# Patch sourced from https://github.com/christian-bendiksen/kernel-6.8.0-63.16ARHA7.fc40
+{ pkgs, lib, kernel ? pkgs.linuxPackages_latest.kernel }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "lenovo-16ARHA7-speaker-fix-module";
+  inherit (kernel) src version postPatch nativeBuildInputs;
+
+  kernel_dev = kernel.dev;
+  kernelVersion = kernel.modDirVersion;
+
+  modulePath = "sound/pci/hda/";
+
+  buildPhase = ''
+    BUILT_KERNEL=$kernel_dev/lib/modules/$kernelVersion/build
+
+    cp $BUILT_KERNEL/Module.symvers .
+    cp $BUILT_KERNEL/.config        .
+    cp $kernel_dev/vmlinux          .
+
+    make "-j$NIX_BUILD_CORES" modules_prepare
+    make "-j$NIX_BUILD_CORES" M=$modulePath modules
+  '';
+
+  installPhase = ''
+    make \
+      INSTALL_MOD_PATH="$out" \
+      XZ="xz -T$NIX_BUILD_CORES" \
+      M="$modulePath" \
+      modules_install
+  '';
+
+	patches = [ ./lenovo_16ARHA7_sound_fix.patch ];
+
+  meta = {
+    description = "Patch to get the speakers working for Lenovo Legion Slim 7 Gen 7 AMD (16ARHA7)";
+    license = lib.licenses.gpl3;
+  };
+}

--- a/lenovo/legion/16arha7/audio/lenovo_16ARHA7_sound_fix.patch
+++ b/lenovo/legion/16arha7/audio/lenovo_16ARHA7_sound_fix.patch
@@ -1,0 +1,33 @@
+diff -rupN linux-6.8-9791-ge5eb28f6d1af/sound/pci/hda/cs35l41_hda_property.c linux-6.8-9791-ge5eb28f6d1af-patched/sound/pci/hda/cs35l41_hda_property.c
+--- linux-6.8-9791-ge5eb28f6d1af/sound/pci/hda/cs35l41_hda_property.c	2024-03-15 02:03:09.000000000 +0100
++++ linux-6.8-9791-ge5eb28f6d1af-patched/sound/pci/hda/cs35l41_hda_property.c	2024-03-17 12:23:48.183404375 +0100
+@@ -115,6 +115,8 @@ static const struct cs35l41_config cs35l
+ 	{ "17AA38B5", 2, EXTERNAL, { CS35L41_LEFT, CS35L41_RIGHT, 0, 0 }, 0, 1, -1, 0, 0, 0 },
+ 	{ "17AA38B6", 2, EXTERNAL, { CS35L41_LEFT, CS35L41_RIGHT, 0, 0 }, 0, 1, -1, 0, 0, 0 },
+ 	{ "17AA38B7", 2, EXTERNAL, { CS35L41_LEFT, CS35L41_RIGHT, 0, 0 }, 0, 1, -1, 0, 0, 0 },
++	{ "17AA3877", 2, EXTERNAL, { CS35L41_LEFT, CS35L41_RIGHT, 0, 0 }, 0, 1, -1, 0, 0, 0 },
++	{ "17AA3878", 2, EXTERNAL, { CS35L41_LEFT, CS35L41_RIGHT, 0, 0 }, 0, 1, -1, 0, 0, 0 },
+ 	{}
+ };
+ 
+@@ -503,6 +505,8 @@ static const struct cs35l41_prop_model c
+ 	{ "CSC3551", "17AA38B5", generic_dsd_config },
+ 	{ "CSC3551", "17AA38B6", generic_dsd_config },
+ 	{ "CSC3551", "17AA38B7", generic_dsd_config },
++	{ "CSC3551", "17AA3877", generic_dsd_config },
++	{ "CSC3551", "17AA3878", generic_dsd_config },
+ 	{}
+ };
+ 
+diff -rupN linux-6.8-9791-ge5eb28f6d1af/sound/pci/hda/patch_realtek.c linux-6.8-9791-ge5eb28f6d1af-patched/sound/pci/hda/patch_realtek.c
+--- linux-6.8-9791-ge5eb28f6d1af/sound/pci/hda/patch_realtek.c	2024-03-15 02:03:09.000000000 +0100
++++ linux-6.8-9791-ge5eb28f6d1af-patched/sound/pci/hda/patch_realtek.c	2024-03-17 12:18:22.241570472 +0100
+@@ -10263,6 +10263,8 @@ static const struct snd_pci_quirk alc269
+ 	SND_PCI_QUIRK(0x17aa, 0x38b5, "Legion Slim 7 16IRH8", ALC287_FIXUP_CS35L41_I2C_2),
+ 	SND_PCI_QUIRK(0x17aa, 0x38b6, "Legion Slim 7 16APH8", ALC287_FIXUP_CS35L41_I2C_2),
+ 	SND_PCI_QUIRK(0x17aa, 0x38b7, "Legion Slim 7 16APH8", ALC287_FIXUP_CS35L41_I2C_2),
++	SND_PCI_QUIRK(0x17aa, 0x3877, "Legion S7 16ARHA7", ALC287_FIXUP_CS35L41_I2C_2),
++	SND_PCI_QUIRK(0x17aa, 0x3878, "Legion S7 16ARHA7", ALC287_FIXUP_CS35L41_I2C_2),
+ 	SND_PCI_QUIRK(0x17aa, 0x38ba, "Yoga S780-14.5 Air AMD quad YC", ALC287_FIXUP_TAS2781_I2C),
+ 	SND_PCI_QUIRK(0x17aa, 0x38bb, "Yoga S780-14.5 Air AMD quad AAC", ALC287_FIXUP_TAS2781_I2C),
+ 	SND_PCI_QUIRK(0x17aa, 0x38be, "Yoga S980-14.5 proX YC Dual", ALC287_FIXUP_TAS2781_I2C),

--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+
+let
+  lenovo-speaker-fix = pkgs.callPackage ./audio/lenovo-16ARHA7_speaker-fix.nix {
+    # Make sure the module targets the same kernel as your system is using.
+    inherit (config.boot.kernelPackages) kernel;
+  };
+in
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  boot = {
+    extraModulePackages = [ lenovo-speaker-fix ];
+  };
+  
+  # √(2560² + 1600²) px / 16 in ≃ 189 dpi
+  services.xserver.dpi = 189;
+}

--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -8,16 +8,13 @@ let
 in
 {
   imports = [
-    ../../../common/cpu/amd
     ../../../common/cpu/amd/pstate.nix
     ../../../common/gpu/amd
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];
 
-  boot = {
-    extraModulePackages = [ lenovo-speaker-fix ];
-  };
+  boot.extraModulePackages = [ lenovo-speaker-fix ];
   
   # √(2560² + 1600²) px / 16 in ≃ 189 dpi
   services.xserver.dpi = 189;

--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 
 let
   lenovo-speaker-fix = pkgs.callPackage ./audio/lenovo-16ARHA7_speaker-fix.nix {


### PR DESCRIPTION
###### Description of changes

A relatively small configuration for the Lenovo Legion Slim 7 Gen 7 (AMD version) that fixes non-working speakers. This also pulls in the AMD CPU and GPU modules and sets the DPI.

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input (see https://github.com/8bitbuddhist/nix-configuration/commit/12e98d14a4b0ba6254838ae4b330422518fae099)

