### PR TITLE
common/pc: remove libinput.enable

### DIFF
--- a/common/pc/default.nix
+++ b/common/pc/default.nix
@@ -4,6 +4,4 @@
   boot.blacklistedKernelModules = lib.optionals (!config.hardware.enableRedistributableFirmware) [
     "ath3k"
   ];
-
-  services.xserver.libinput.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
###### Description of changes

Has been default in nixpkgs for a long time now.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

