### PR TITLE
macmini4: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See code for all available configurations.
 | [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                       | `<nixos-hardware/apple/macbook-pro/11-5>`               |
 | [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                       | `<nixos-hardware/apple/macbook-pro/12-1>`               |
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                       | `<nixos-hardware/apple/macbook-pro/14-1>`               |
+| [Apple MacMini (2010, Intel, Nvidia)](apple/macmini/4)                 | `<nixos-hardware/apple/macmini/4>`                      |
 | [Apple Macs with a T2 Chip](apple/t2)                                  | `<nixos-hardware/apple/t2>`                             |
 | [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                          | `<nixos-hardware/asus/ally/rc71l>`                      |
 | [Asus ROG Strix G513IM](asus/rog-strix/g513im)                         | `<nixos-hardware/asus/rog-strix/g513im>`                |

--- a/apple/macmini/4/default.nix
+++ b/apple/macmini/4/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkDefault;
+in
+{
+  imports = [
+    ../.
+  ];
+
+  services.xserver.videoDrivers = mkDefault [ "nvidiaLegacy340" ];
+
+  hardware.opengl = {
+    enable = mkDefault true;
+    driSupport = mkDefault true;
+    driSupport32Bit = mkDefault true;
+  };
+
+  hardware.nvidia = {
+    modesetting.enable = mkDefault true;
+    powerManagement.enable = mkDefault false;
+    powerManagement.finegrained = mkDefault false;
+    open = mkDefault false;
+    nvidiaSettings = mkDefault true;
+  };
+}

--- a/apple/macmini/default.nix
+++ b/apple/macmini/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../.
+    ../../common/cpu/intel
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
       apple-macbook-pro-11-5 = import ./apple/macbook-pro/11-5;
       apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;
       apple-macbook-pro-14-1 = import ./apple/macbook-pro/14-1;
+      apple-macmini-4-1 = import ./apple/macmini/4;
       apple-t2 = import ./apple/t2;
       asus-battery = import ./asus/battery.nix;
       asus-ally-rc71l = import ./asus/ally/rc71l;


### PR DESCRIPTION
Hello,

I own a very old MacMini (2010) and I had the idea to install NixOS on it 2 days ago.
I've been searching for how to make the Nvidia chipset working, and I've extracted the relevant part in this PR.
This is my first PR in this project, please let me know if this is OK.

```
❯ lspci
00:00.0 Host bridge: NVIDIA Corporation MCP89 HOST Bridge (rev a1)
00:00.1 RAM memory: NVIDIA Corporation MCP89 Memory Controller (rev a1)
00:01.0 RAM memory: NVIDIA Corporation Device 0d6d (rev a1)
00:01.1 RAM memory: NVIDIA Corporation Device 0d6e (rev a1)
00:01.2 RAM memory: NVIDIA Corporation Device 0d6f (rev a1)
00:01.3 RAM memory: NVIDIA Corporation Device 0d70 (rev a1)
00:02.0 RAM memory: NVIDIA Corporation Device 0d71 (rev a1)
00:02.1 RAM memory: NVIDIA Corporation Device 0d72 (rev a1)
00:03.0 ISA bridge: NVIDIA Corporation MCP89 LPC Bridge (rev a2)
00:03.1 RAM memory: NVIDIA Corporation MCP89 Memory Controller (rev a1)
00:03.2 SMBus: NVIDIA Corporation MCP89 SMBus (rev a1)
00:03.3 RAM memory: NVIDIA Corporation MCP89 Memory Controller (rev a1)
00:03.4 Co-processor: NVIDIA Corporation MCP89 Co-Processor (rev a1)
00:04.0 USB controller: NVIDIA Corporation MCP89 OHCI USB 1.1 Controller (rev a1)
00:04.1 USB controller: NVIDIA Corporation MCP89 EHCI USB 2.0 Controller (rev a2)
00:06.0 USB controller: NVIDIA Corporation MCP89 OHCI USB 1.1 Controller (rev a1)
00:06.1 USB controller: NVIDIA Corporation MCP89 EHCI USB 2.0 Controller (rev a2)
00:08.0 Audio device: NVIDIA Corporation MCP89 High Definition Audio (rev a2)
00:0a.0 SATA controller: NVIDIA Corporation MCP89 SATA Controller (AHCI mode) (rev a2)
00:0b.0 RAM memory: NVIDIA Corporation Device 0d75 (rev a1)
00:0e.0 PCI bridge: NVIDIA Corporation Device 0d9a (rev a1)
00:15.0 PCI bridge: NVIDIA Corporation Device 0d9b (rev a1)
00:16.0 PCI bridge: NVIDIA Corporation Device 0d9b (rev a1)
00:17.0 PCI bridge: NVIDIA Corporation MCP89 PCI Express Bridge (rev a1)
01:00.0 PCI bridge: Texas Instruments XIO2213A/B/XIO2221 PCI Express to PCI Bridge [Cheetah Express] (rev 01)
02:00.0 FireWire (IEEE 1394): Texas Instruments XIO2213A/B/XIO2221 IEEE-1394b OHCI Controller [Cheetah Express] (rev 01)
03:00.0 Network controller: Broadcom Inc. and subsidiaries BCM43224 802.11a/b/g/n (rev 01)
04:00.0 Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM57765 Gigabit Ethernet PCIe
04:00.1 SD Host controller: Broadcom Inc. and subsidiaries BCM57765/57785 SDXC/MMC Card Reader
05:00.0 VGA compatible controller: NVIDIA Corporation MCP89 [GeForce 320M] (rev a2)

❯ inxi -Fz
System:    Kernel: 6.6.25 x86_64 bits: 64 Desktop: N/A Distro: NixOS 24.05 (Uakari) 
Machine:   Type: Laptop System: Apple product: Macmini4,1 v: 1.0 serial: <filter> 
           Mobo: Apple model: Mac-F2208EC8 serial: <filter> UEFI: Apple v: MM41.88Z.0042.B03.1111072100 date: 11/07/11 
CPU:       Info: Dual Core model: Intel Core2 Duo P8600 bits: 64 type: MCP cache: L2: 3 MiB 
           Speed: 1596 MHz min/max: 1596/2394 MHz Core speeds (MHz): 1: 1596 2: 1593 
Graphics:  Message: No device data found. 
           Display: wayland server: X.org 1.21.1.12 driver: loaded: N/A resolution: <missing: xdpyinfo> 
           Message: No advanced graphics data found on this system. 
Audio:     Device-1: HDA NVidia driver: HDA-Intel 
           Sound Server-1: ALSA v: k6.6.25 running: yes 
           Sound Server-2: PipeWire v: 1.0.4 running: yes 
Network:   Message: No device data found. 
           IF-ID-1: enp4s0f0 state: down mac: <filter> 
           IF-ID-2: tailscale0 state: unknown speed: -1 duplex: full mac: N/A 
           IF-ID-3: wlp3s0 state: up mac: <filter> 
Bluetooth: Device-1: Apple Bluetooth USB Host Controller type: USB driver: btusb 
           Report: hciconfig ID: hci0 rfk-id: 1 state: down bt-service: enabled,running rfk-block: hardware: no software: no 
           address: <filter> 
Drives:    Local Storage: total: 473.22 GiB used: 31.26 GiB (6.6%) 
           ID-1: /dev/sda vendor: Crucial model: CT500BX500SSD1 size: 465.76 GiB 
           ID-2: /dev/sdb type: USB vendor: SanDisk model: Cruzer Facet size: 7.45 GiB 
Partition: ID-1: / size: 449.11 GiB used: 30.93 GiB (6.9%) fs: ext4 dev: /dev/sda2 
           ID-2: /boot size: 511 MiB used: 147 MiB (28.8%) fs: vfat dev: /dev/sda1 
Swap:      ID-1: swap-1 type: partition size: 7.89 GiB used: 189.5 MiB (2.3%) dev: /dev/sda3 
Sensors:   Missing: Required tool sensors not installed. Check --recommends 
Info:      Processes: 156 Uptime: N/A Memory: 3.58 GiB used: 1.34 GiB (37.4%) Init: systemd Shell: fish inxi: 3.3.04 
```

Tested successfully in https://github.com/drupol/nixos-x260/pull/77

Thanks!

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

