### PR TITLE
TUXEDO Pulse 14 Gen3: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,4 +289,5 @@ See code for all available configurations.
 | [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                        | `<nixos-hardware/toshiba/swanky>`                       |
 | [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                       | `<nixos-hardware/tuxedo/infinitybook/v4>`               |
 | [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)    | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       |
+| [TUXEDO Pulse 14 - Gen3](tuxedo/pulse/14/gen3)                         | `<nixos-hardware/tuxedo/pulse/14/gen3>`                 |
 | [TUXEDO Pulse 15 - Gen2](tuxedo/pulse/15/gen2)                         | `<nixos-hardware/tuxedo/pulse/15/gen2>`                 |

--- a/flake.nix
+++ b/flake.nix
@@ -230,6 +230,7 @@
       toshiba-swanky = import ./toshiba/swanky;
       tuxedo-infinitybook-v4 = import ./tuxedo/infinitybook/v4;
       tuxedo-infinitybook-pro14-gen7 = import ./tuxedo/infinitybook/pro14/gen7;
+      tuxedo-pulse-14-gen3 = import ./tuxedo/pulse/14/gen3;
       tuxedo-pulse-15-gen2 = import ./tuxedo/pulse/15/gen2;
 
       common-cpu-amd = import ./common/cpu/amd;

--- a/tuxedo/pulse/14/gen3/README.md
+++ b/tuxedo/pulse/14/gen3/README.md
@@ -1,0 +1,7 @@
+# TUXEDO Pulse 14 - Gen3
+
+## About
+
+[NixOS hardware configuration](https://github.com/NixOS/nixos-hardware) for
+[TUXEDO Pulse 14 -
+Gen3](https://www.tuxedocomputers.com/en/TUXEDO-Pulse-14-Gen3).

--- a/tuxedo/pulse/14/gen3/default.nix
+++ b/tuxedo/pulse/14/gen3/default.nix
@@ -1,0 +1,9 @@
+{pkgs, ...}: {
+  imports = [
+    ../../../../common/cpu/amd
+    ../../../../common/cpu/amd/pstate.nix
+    ../../../../common/cpu/amd/raphael/igpu.nix
+    ../../../../common/pc/laptop
+    ../../../../common/pc/laptop/ssd
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Add relevant modules for TUXEDO Pulse 14 Gen3. The device is equipped with an AMD Ryzen 7 7840HS with integrated AMD Radeon M780 iGPU.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration (see https://github.com/britter/nix-configuration/commit/9e1bfbd0ac44611fc901fbb78bf3aee4926f482c)
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

