### PR TITLE
Add fingerprint support for Lenovo Legion 16ARHA7

### DIFF
--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -18,4 +18,14 @@ in
   
   # √(2560² + 1600²) px / 16 in ≃ 189 dpi
   services.xserver.dpi = 189;
+
+  # Enable fingerprint reader
+  services.fprintd = {
+    enable = true;
+    package = pkgs.fprintd-tod;
+    tod = {
+      enable = true;
+      driver = pkgs.libfprint-2-tod1-elan;
+    };
+  };
 }


### PR DESCRIPTION
###### Description of changes

(Redo of #928)
Adds support for the fingerprint reader to the Lenovo Legion Slim 7 Gen 7 AMD 16ARHA7

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

