### PR TITLE
surface: linux 6.8.6 -> 6.8.9

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.8.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.8.x/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.8.6";
+  version = "6.8.9";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "sha256-nnIyMtYDq0Xr8EPDRxTEjyd6sZXCmry4Ry8qTDpaGZU=";
+    sha256 = "sha256-+QXxI46nqOhTFLrPKDMC6AlwBgENJfzqcm0N4OpbybY=";
     ignoreConfigErrors=true;
   };
 


### PR DESCRIPTION
###### Description of changes

Update linux to 6.8.9 for surface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

