### PR TITLE
cpu/amd/zenpower: new

### DIFF
--- a/common/cpu/amd/zenpower.nix
+++ b/common/cpu/amd/zenpower.nix
@@ -1,0 +1,10 @@
+{ lib, config, ... }:
+{
+  # Enables the zenpower sensor in lieu of the k10temp sensor on Zen CPUs https://git.exozy.me/a/zenpower3
+  # On Zen CPUs zenpower produces much more data entries
+
+  imports = [ ./. ];
+  boot.blacklistedKernelModules = [ "k10temp" ];
+  boot.extraModulePackages = [ config.boot.kernelPackages.zenpower ];
+  boot.kernelModules = [ "zenpower" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -241,6 +241,7 @@
 
       common-cpu-amd = import ./common/cpu/amd;
       common-cpu-amd-pstate = import ./common/cpu/amd/pstate.nix;
+      common-cpu-amd-zenpower = import ./common/cpu/amd/zenpower.nix;
       common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
       common-cpu-intel = import ./common/cpu/intel;
       common-cpu-intel-comet-lake = import ./common/cpu/intel/comet-lake;


### PR DESCRIPTION
###### Description of changes
The zenpower module provides much more detailed data than k10temp on Zen CPUs. Use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

