### PR TITLE
asus/zenbook/ux371: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See code for all available configurations.
 | [Asus TUF FX506HM](asus/fx506hm)                                       | `<nixos-hardware/asus/fx506hm>`                         |
 | [Asus TUF FA507RM](asus/fa507rm)                                       | `<nixos-hardware/asus/fa507rm>`                         |
 | [Asus TUF FA507NV](asus/fa507nv)                                       | `<nixos-hardware/asus/fa507nv>`                         |
+| [Asus Zenbook Flip S13 UX371](asus/zenbook/ux371/)                     | `<nixos-hardware/asus/zenbook/ux371>`                   |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                   | `<nixos-hardware/beagleboard/pocketbeagle>`             |
 | [Deciso DEC series](deciso/dec)                                        | `<nixos-hardware/deciso/dec>`                           |
 | [Dell G3 3779](dell/g3/3779)                                           | `<nixos-hardware/dell/g3/3779>`                         |

--- a/asus/zenbook/ux371/README.md
+++ b/asus/zenbook/ux371/README.md
@@ -1,0 +1,47 @@
+# Asus Zenbook Flip S13
+
+This is tested on an [UX371](https://www.asus.com/laptops/for-home/zenbook/zenbook-flip-s-ux371-11th-gen-intel/).
+
+## Tested Hardware
+
+```bash
+lspci -nn
+0000:00:00.0 Host bridge [0600]: Intel Corporation 11th Gen Core Processor Host Bridge/DRAM Registers [8086:9a14] (rev 01)
+0000:00:02.0 VGA compatible controller [0300]: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] [8086:9a49] (rev 01)
+0000:00:04.0 Signal processing controller [1180]: Intel Corporation TigerLake-LP Dynamic Tuning Processor Participant [8086:9a03] (rev 01)
+0000:00:07.0 PCI bridge [0604]: Intel Corporation Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #0 [8086:9a23] (rev 01)
+0000:00:07.1 PCI bridge [0604]: Intel Corporation Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #1 [8086:9a25] (rev 01)
+0000:00:08.0 System peripheral [0880]: Intel Corporation GNA Scoring Accelerator module [8086:9a11] (rev 01)
+0000:00:0a.0 Signal processing controller [1180]: Intel Corporation Tigerlake Telemetry Aggregator Driver [8086:9a0d] (rev 01)
+0000:00:0d.0 USB controller [0c03]: Intel Corporation Tiger Lake-LP Thunderbolt 4 USB Controller [8086:9a13] (rev 01)
+0000:00:0d.2 USB controller [0c03]: Intel Corporation Tiger Lake-LP Thunderbolt 4 NHI #0 [8086:9a1b] (rev 01)
+0000:00:0e.0 RAID bus controller [0104]: Intel Corporation Volume Management Device NVMe RAID Controller [8086:9a0b]
+0000:00:12.0 Serial controller [0700]: Intel Corporation Tiger Lake-LP Integrated Sensor Hub [8086:a0fc] (rev 20)
+0000:00:14.0 USB controller [0c03]: Intel Corporation Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller [8086:a0ed] (rev 20)
+0000:00:14.2 RAM memory [0500]: Intel Corporation Tiger Lake-LP Shared SRAM [8086:a0ef] (rev 20)
+0000:00:14.3 Network controller [0280]: Intel Corporation Wi-Fi 6 AX201 [8086:a0f0] (rev 20)
+0000:00:15.0 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #0 [8086:a0e8] (rev 20)
+0000:00:15.1 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #1 [8086:a0e9] (rev 20)
+0000:00:16.0 Communication controller [0780]: Intel Corporation Tiger Lake-LP Management Engine Interface [8086:a0e0] (rev 20)
+0000:00:1d.0 System peripheral [0880]: Intel Corporation RST VMD Managed Controller [8086:09ab]
+0000:00:1f.0 ISA bridge [0601]: Intel Corporation Tiger Lake-LP LPC Controller [8086:a082] (rev 20)
+0000:00:1f.3 Multimedia audio controller [0401]: Intel Corporation Tiger Lake-LP Smart Sound Technology Audio Controller [8086:a0c8] (rev 20)
+0000:00:1f.4 SMBus [0c05]: Intel Corporation Tiger Lake-LP SMBus Controller [8086:a0a3] (rev 20)
+0000:00:1f.5 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP SPI Controller [8086:a0a4] (rev 20)
+10000:e0:1d.0 PCI bridge [0604]: Intel Corporation Tiger Lake-LP PCI Express Root Port #9 [8086:a0b0] (rev 20)
+10000:e1:00.0 Non-Volatile memory controller [0108]: Sandisk Corp WD Black SN750 / PC SN730 / Red SN700 NVMe SSD [15b7:5006]
+```
+
+## Updating Firmware
+
+First enable `fwupd` in your config
+
+```nix
+services.fwupd.enable = true;
+```
+
+Then run
+
+```bash
+ $ fwupdmgr update
+```

--- a/asus/zenbook/ux371/default.nix
+++ b/asus/zenbook/ux371/default.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+{
+  imports = [
+    ../../../common/cpu/intel/tiger-lake
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+    ../../battery.nix
+  ];
+
+  boot.kernelParams = lib.mkIf (config.hardware.intelgpu.driver == "xe") [
+    "i915.force_probe=!9a49"
+    "xe.force_probe=9a49"
+  ];
+
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+  services.thermald.enable = lib.mkDefault true;
+  powerManagement.cpuFreqGovernor = lib.mkDefault "powersave";
+}

--- a/common/cpu/intel/cpu-only.nix
+++ b/common/cpu/intel/cpu-only.nix
@@ -1,6 +1,4 @@
 { config, lib, ... }:
-
 {
-  hardware.cpu.intel.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }

--- a/common/cpu/intel/tiger-lake/default.nix
+++ b/common/cpu/intel/tiger-lake/default.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+{
+  imports = [ ../. ];
+  config = lib.mkMerge [
+    (lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.8") {
+      hardware.intelgpu.driver = "xe";
+    })
+    (lib.mkIf (config.hardware.intelgpu.driver == "i915") {
+      boot.kernelParams = [ "i915.enable_guc=3" ];
+    })
+  ];
+}

--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -1,32 +1,64 @@
-{ config, lib, pkgs, ... }:
-
 {
-  options.hardware.intelgpu.loadInInitrd = lib.mkEnableOption (lib.mdDoc
-    "loading `i195` kernelModule at stage 1. (Add `i915` to `boot.initrd.kernelModules`)"
-  ) // {
-    default = true;
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  options.hardware.intelgpu.driver = lib.mkOption {
+    description = "Intel GPU driver to use";
+    type = lib.types.enum [
+      "i915"
+      "xe"
+    ];
+    default = "i915";
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf config.hardware.intelgpu.loadInInitrd { 
-      boot.initrd.kernelModules = [ "i915" ]; 
-    })
-    {
-      environment.variables = {
-        VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
-      };
+  options.hardware.intelgpu.loadInInitrd =
+    lib.mkEnableOption (
+      lib.mdDoc "Load the Intel GPU kernel module at stage 1 boot. (Added to `boot.initrd.kernelModules`)"
+    )
+    // {
+      default = true;
+    };
 
-      hardware.opengl.extraPackages = with pkgs; [
-        (if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)
-        libvdpau-va-gl
-        intel-media-driver
-      ];
+  config = {
+    boot.initrd.kernelModules = [ config.hardware.intelgpu.driver ];
 
-      hardware.opengl.extraPackages32 = with pkgs.driversi686Linux; [
-        (if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)
-        libvdpau-va-gl
-        intel-media-driver
-      ];
-    }
-  ];
+    environment.variables = {
+      VDPAU_DRIVER = lib.mkIf config.hardware.opengl.enable (lib.mkDefault "va_gl");
+    };
+
+    hardware.opengl.extraPackages = with pkgs; [
+      (
+        if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then
+          vaapiIntel
+        else
+          intel-vaapi-driver
+      )
+      libvdpau-va-gl
+      intel-media-driver
+    ];
+
+    hardware.opengl.extraPackages32 = with pkgs.driversi686Linux; [
+      (
+        if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then
+          vaapiIntel
+        else
+          intel-vaapi-driver
+      )
+      libvdpau-va-gl
+      intel-media-driver
+    ];
+
+    assertions = [
+      {
+        assertion = (
+          config.hardware.intelgpu.driver != "xe"
+          || lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.8"
+        );
+        message = "Intel Xe GPU driver is not supported on kernels earlier than 6.8. Update or use the i915 driver.";
+      }
+    ];
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;
       asus-rog-strix-g513im = import ./asus/rog-strix/g513im;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
+      asus-zenbook-ux371 = import ./asus/zenbook/ux371;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;
       asus-zephyrus-ga402x = import ./asus/zephyrus/ga402x;


### PR DESCRIPTION
###### Description of changes

This laptop uses the tiger-lake chipset which didn't have a chipset folder, so I added it and added handling for loading the new Intel Iris Xe graphics driver over i915 if the kernel is new enough.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

