### PR TITLE
Add missing default xps-15-9570 module to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
       dell-xps-15-9560 = import ./dell/xps/15-9560;
       dell-xps-15-9560-intel = import ./dell/xps/15-9560/intel;
       dell-xps-15-9560-nvidia = import ./dell/xps/15-9560/nvidia;
+      dell-xps-15-9570 = import ./dell/xps/15-9570;
       dell-xps-15-9570-intel = import ./dell/xps/15-9570/intel;
       dell-xps-15-9570-nvidia = import ./dell/xps/15-9570/nvidia;
       dell-xps-17-9700-intel = import ./dell/xps/17-9700/intel;


### PR DESCRIPTION
###### Description of changes

I've added the default XPS 9570 module to the flake.nix so it's possible to use it without being locked to one of the GPU setups provided.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

