### PR TITLE
Remove buildUBoot function from U-Boot build

### DIFF
--- a/nxp/imx8mp-evk/bsp/imx8mp-uboot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-uboot.nix
@@ -1,19 +1,57 @@
-{pkgs}:
-with pkgs; let
-  inherit buildUBoot;
-in
-  (buildUBoot {
-    pname = "imx8mp-uboot";
-    version = "2023.04";
-
-    src = fetchgit {
+{ stdenv
+, lib
+, bison
+, dtc
+, fetchgit
+, flex
+, gnutls
+, libuuid
+, ncurses
+, openssl
+, which
+, perl
+, buildPackages
+}:
+let
+  ubsrc = fetchgit {
       url = "https://github.com/nxp-imx/uboot-imx.git";
       # tag: "lf-6.1.55-2.2.0"
       rev = "49b102d98881fc28af6e0a8af5ea2186c1d90a5f";
       sha256 = "sha256-1j6X82DqezEizeWoSS600XKPNwrQ4yT0vZuUImKAVVA=";
     };
+in
+  (stdenv.mkDerivation {
+    pname = "imx8mp-uboot";
+    version = "2023.04";
+    src = ubsrc;
 
-    extraConfig = ''
+    postPatch = ''
+      patchShebangs tools
+      patchShebangs scripts
+    '';
+
+    nativeBuildInputs = [
+      bison
+      flex
+      openssl
+      which
+      ncurses
+      libuuid
+      gnutls
+      openssl
+      perl
+    ];
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    hardeningDisable = [ "all" ];
+    enableParallelBuilding = true;
+
+    makeFlags = [
+      "DTC=${lib.getExe buildPackages.dtc}"
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ];
+
+  	extraConfig = ''
       CONFIG_USE_BOOTCOMMAND=y
       CONFIG_BOOTCOMMAND="setenv ramdisk_addr_r 0x45000000; setenv fdt_addr_r 0x44000000; run distro_bootcmd; "
       CONFIG_CMD_BOOTEFI_SELFTEST=y
@@ -25,17 +63,28 @@ in
       CONFIG_CMD_CACHE=y
     '';
 
-    enableParallelBuilding = true;
-    defconfig = "imx8mp_evk_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    passAsFile = [ "extraConfig" ];
 
-    filesToInstall = [
-      "./u-boot-nodtb.bin"
-      "./spl/u-boot-spl.bin"
-      "./arch/arm/dts/imx8mp-evk.dtb"
-      ".config"
-    ];
-  })
-  .overrideAttrs (old: {
-    nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.perl];
+    configurePhase = ''
+      runHook preConfigure
+
+      make imx8mp_evk_defconfig
+      cat $extraConfigPath >> .config
+
+      runHook postConfigure
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp ./u-boot-nodtb.bin $out
+      cp ./spl/u-boot-spl.bin $out
+      cp ./arch/arm/dts/imx8mp-evk.dtb $out
+      cp .config  $out
+
+      runHook postInstall
+    '';
+
+    dontStrip = true;
   })

--- a/nxp/imx8mq-evk/bsp/imx8mq-uboot.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-uboot.nix
@@ -1,19 +1,57 @@
-{pkgs}:
-with pkgs; let
-  inherit buildUBoot;
-in
-  (buildUBoot {
-    pname = "imx8mq-uboot";
-    version = "2023.04";
-
-    src = fetchgit {
+{ stdenv
+, lib
+, bison
+, dtc
+, fetchgit
+, flex
+, gnutls
+, libuuid
+, ncurses
+, openssl
+, which
+, perl
+, buildPackages
+}:
+let
+  ubsrc = fetchgit {
       url = "https://github.com/nxp-imx/uboot-imx.git";
       # tag: "lf-6.1.55-2.2.0"
       rev = "49b102d98881fc28af6e0a8af5ea2186c1d90a5f";
       sha256 = "sha256-1j6X82DqezEizeWoSS600XKPNwrQ4yT0vZuUImKAVVA=";
     };
+in
+  (stdenv.mkDerivation {
+    pname = "imx8mq-uboot";
+    version = "2023.04";
+    src = ubsrc;
 
-    extraConfig = ''
+    postPatch = ''
+      patchShebangs tools
+      patchShebangs scripts
+    '';
+
+    nativeBuildInputs = [
+      bison
+      flex
+      openssl
+      which
+      ncurses
+      libuuid
+      gnutls
+      openssl
+      perl
+    ];
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    hardeningDisable = [ "all" ];
+    enableParallelBuilding = true;
+
+    makeFlags = [
+      "DTC=${lib.getExe buildPackages.dtc}"
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ];
+
+  	extraConfig = ''
       CONFIG_USE_BOOTCOMMAND=y
       CONFIG_BOOTCOMMAND="setenv ramdisk_addr_r 0x45000000; setenv fdt_addr_r 0x44000000; run distro_bootcmd; "
       CONFIG_CMD_BOOTEFI_SELFTEST=y
@@ -25,17 +63,28 @@ in
       CONFIG_CMD_CACHE=y
     '';
 
-    enableParallelBuilding = true;
-    defconfig = "imx8mq_evk_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    passAsFile = [ "extraConfig" ];
 
-    filesToInstall = [
-      "./u-boot-nodtb.bin"
-      "./spl/u-boot-spl.bin"
-      "./arch/arm/dts/imx8mq-evk.dtb"
-      ".config"
-    ];
-  })
-  .overrideAttrs (old: {
-    nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.perl];
+    configurePhase = ''
+      runHook preConfigure
+
+      make imx8mq_evk_defconfig
+      cat $extraConfigPath >> .config
+
+      runHook postConfigure
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp ./u-boot-nodtb.bin $out
+      cp ./spl/u-boot-spl.bin $out
+      cp ./arch/arm/dts/imx8mq-evk.dtb $out
+      cp .config  $out
+
+      runHook postInstall
+    '';
+
+    dontStrip = true;
   })


### PR DESCRIPTION
###### Description of changes

The buildUBoot function is intended for internal use and is dedicated  for Raspberry Pi platforms. With latest nixpkgs it is causing build failure in older uboot(prior to v2023.07) due to a Raspberry Pi patch.
    
Now this function is not used for the U-Boot build.

More Information:
https://github.com/NixOS/nixpkgs/pull/311614
https://github.com/NixOS/nixpkgs/pull/146634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

