### PR TITLE
Revision for Asus fa507nv

### DIFF
--- a/asus/fa507nv/default.nix
+++ b/asus/fa507nv/default.nix
@@ -1,21 +1,45 @@
-{ lib, pkgs, ... }:
-
 {
-    imports = [
-      ../../common/cpu/amd
-      ../../common/cpu/amd/raphael/igpu.nix
-      ../../common/cpu/amd/pstate.nix
-      ../../common/gpu/nvidia
-      ../../common/gpu/nvidia/prime-sync.nix
-      ../../common/hidpi.nix
-      ../../common/pc/laptop
-      ../../common/pc/ssd
-    ];
+  lib,
+  pkgs,
+  config,
+  ...
+}: {
+  imports = [
+    ../../common/cpu/amd
+    ../../common/cpu/amd/raphael/igpu.nix
+    ../../common/cpu/amd/pstate.nix
+    ../../common/gpu/nvidia
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/hidpi.nix
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../battery.nix
+  ];
 
-    boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.6") pkgs.linuxPackages_latest;
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.6") pkgs.linuxPackages_latest;
 
-    hardware.nvidia.prime = {
-      amdgpuBusId = "PCI:54:0:0";
-      nvidiaBusId = "PCI:1:0:0";
+  # The bottom 2 parts are taken from the framework 16-inch laptops configurations.
+  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+  boot.kernelParams = lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") ["rtc_cmos.use_acpi_alarm=1"];
+
+  # AMD has better battery life with PPD over TLP:
+  # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13
+  services.power-profiles-daemon.enable = lib.mkDefault true;
+
+  # Adds the missing asus functionality to Linux.
+  # https://asus-linux.org/manual/asusctl-manual/
+  services = {
+    asusd = {
+      enable = lib.mkDefault true;
+      enableUserService = lib.mkDefault true;
     };
-  }
+  };
+
+  hardware.nvidia.prime = {
+    modesetting.enable = lib.mkDefault true;
+    open = lib.mkDefault false;
+    nvidiaSettings = lib.mkDefault true;
+    amdgpuBusId = "PCI:54:0:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}

--- a/asus/fa507nv/default.nix
+++ b/asus/fa507nv/default.nix
@@ -35,11 +35,13 @@
     };
   };
 
-  hardware.nvidia.prime = {
+  hardware.nvidia = {
     modesetting.enable = lib.mkDefault true;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;
-    amdgpuBusId = "PCI:54:0:0";
-    nvidiaBusId = "PCI:1:0:0";
+    prime = {
+      amdgpuBusId = "PCI:54:0:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
   };
 }


### PR DESCRIPTION
###### Description of changes
Some of the changes can be considered opinionated but I think all of them are needed to achieve full functionality for the device.

I added the battery module and changed the NVIDIA module to the normal NVIDIA offload instead of sync. After looking at the Arch wiki turns out AMD CPU's are also supported, unlike how its stated in the NixOS wiki. So I changed it to Offload. 

Secondly I copied 2 lines from the module of Framework 16-inch laptop. The first line fixes a issue related to AMD CPU's (Its details are included in the URL in the module) and the other one is setting up PPD for power management.

Additionally I enabled asusd service. This might be considered opinionated but without this tool functionalities like keyboard color control, fan curves etc. are not easily doable.

Finally I expanded the NVIDIA configuration to include some of the required and reccomended settings like modesetting.enable and nvidiaSettings.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

