### PR TITLE
apple/t2: update to kernel 6.9

### DIFF
--- a/apple/t2/pkgs/linux-t2.nix
+++ b/apple/t2/pkgs/linux-t2.nix
@@ -5,11 +5,11 @@ let
   patchRepo = fetchFromGitHub {
     owner = "t2linux";
     repo = "linux-t2-patches";
-    rev = "7cd298e227e95bac9a704ffc8f5ff5e89a1bf4d7";
-    hash = "sha256-Oi3CwQl0IwdVc9w+pbmJjBnyqwLFhbqFwxs5o0mqtbE=";
+    rev = "8b0e51ea87f170c559c9e2f437f85367838c2fad";
+    hash = "sha256-4YFaLW4WTKdFysIJHnshEaqoiKBFegnZiw4Kv88LjIA=";
   };
 
-  version = "6.7.7";
+  version = "6.9";
   majorVersion = with lib; (elemAt (take 1 (splitVersion version)) 0);
 in
 buildLinux (args // {
@@ -22,7 +22,7 @@ buildLinux (args // {
   src = runCommand "patched-source" {} ''
     cp -r ${fetchzip {
       url = "mirror://kernel/linux/kernel/v${majorVersion}.x/linux-${version}.tar.xz";
-      hash = "sha256-j+Ufl6C1Mqjthk18GPt2e7j+i7viauOgNnVy9dJSgaM=";
+      hash = "sha256-RIxLyvF5kw/to8MjAUq2iQ4X0bGk7FY+ovE3zd0eKxM=";
     }} $out
     chmod -R u+w $out
     cd $out


### PR DESCRIPTION
###### Description of changes
This PR bumps the kernel version of `apple/t2` from `6.7.7` to `6.9`, and likewise for the patches repo. This might include stability fixes and so far my laptop has not crashed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

