### PR TITLE
Add config for ASUS TUF FX506HM

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                     | `<nixos-hardware/asus/zephyrus/ga503>`                  |
 | [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                   | `<nixos-hardware/asus/zephyrus/gu603h>`                 |
 | [Asus TUF FX504GD](asus/fx504gd)                                       | `<nixos-hardware/asus/fx504gd>`                         |
+| [Asus TUF FX506HM](asus/fx506hm)                                       | `<nixos-hardware/asus/fx506hm>`                         |
 | [Asus TUF FA507RM](asus/fa507rm)                                       | `<nixos-hardware/asus/fa507rm>`                         |
 | [Asus TUF FA507NV](asus/fa507nv)                                       | `<nixos-hardware/asus/fa507nv>`                         |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                   | `<nixos-hardware/beagleboard/pocketbeagle>`             |

--- a/asus/fx506hm/README.md
+++ b/asus/fx506hm/README.md
@@ -1,0 +1,28 @@
+<!-- vim: set fenc=utf-8 ts=2 sw=2 sts=-1 sr et si tw=0 fdm=marker fmr={{{,}}}: -->
+# [ASUS TUF Gaming F15 FX506HM (2021)](https://www.asus.com/laptops/for-gaming/tuf-gaming/2021-asus-tuf-gaming-f15/)
+
+This imports common modules for the Intel CPU and iGPU, Nvidia and PRIME render offloading, basic laptop configs, basic SSD configs and configs for ASUS batteries.
+
+On top of that, it sets the right PCI bus IDs for the iGPU and dGPU to make PRIME work well and enables modesetting.
+
+## Useful other things to consider in your configuration
+### Battery charging limit
+Due to the common module for ASUS batteries, you can make your battery only charge up to a certain percentage to improve its life. You can place something similar to the following in your configuration to enable it:
+
+```nix
+hardware.asus.battery =
+{
+  chargeUpto             = 85;   # Maximum level of charge for your battery, as a percentage.
+  enableChargeUptoScript = true; # Whether to add charge-upto to environment.systemPackages. `charge-upto 85` temporarily sets the charge limit to 85%.
+};
+```
+
+### OpenRGB
+You can use OpenRGB to control the RGB keyboard on this laptop. There's also plugins for it to get some extra RGB lighting modes if you wish. You can place the following in your configuration to enable it:
+
+```nix
+boot.kernelModules               = [ "i2c-dev" ];
+hardware.i2c.enable              = true;
+services.udev.packages           = [ pkgs.openrgb ];
+services.hardware.openrgb.enable = true;
+```

--- a/asus/fx506hm/default.nix
+++ b/asus/fx506hm/default.nix
@@ -9,7 +9,7 @@
     ../../common/pc/laptop
     ../../common/pc/ssd
     ../battery.nix
-  ]
+  ];
 
   hardware.nvidia =
   {

--- a/asus/fx506hm/default.nix
+++ b/asus/fx506hm/default.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+{
+  imports =
+  [
+    ../../common/cpu/intel
+    ../../common/gpu/nvidia
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../battery.nix
+  ]
+
+  hardware.nvidia =
+  {
+    modesetting.enable = lib.mkDefault true;
+
+    prime =
+    {
+      intelBusId  = "PCI:0:2:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
       asus-battery = import ./asus/battery.nix;
       asus-ally-rc71l = import ./asus/ally/rc71l;
       asus-fx504gd = import ./asus/fx504gd;
+      asus-fx506hm = import ./asus/fx506hm;
       asus-fa507nv = import ./asus/fa507nv;
       asus-fa507rm = import ./asus/fa507rm;
       asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;


### PR DESCRIPTION
###### Description of changes
I was already doing something like this in my configuration for a while and I decided it'd be best to publish it to this repo as well, so that other people can make use of it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

###### Others
Sorry for going off-topic but, I was wondering, do these configs get into the hardware scan NixOS does when generating a config, or is it up to the user to manually use these?