### PR TITLE
Add kernel version check for Lenovo 16ARHA7 speaker fix

### DIFF
--- a/lenovo/legion/16arha7/README.md
+++ b/lenovo/legion/16arha7/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This configuration includes a fix to get audio playing over the speakers, however, the volume is low. If you know of a workaround or fix, please contribute it to the repo!!
+This configuration includes a fix to get the speakers working on kernels earlier than 6.9.0. Kernels after 6.9.0 already have this patch built-in.
 
 ## Setup at the time of testing
 ```

--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   lenovo-speaker-fix = pkgs.callPackage ./audio/lenovo-16ARHA7_speaker-fix.nix {
@@ -14,7 +14,8 @@ in
     ../../../common/pc/laptop/ssd
   ];
 
-  boot.extraModulePackages = [ lenovo-speaker-fix ];
+  # Kernel 6.9 includes the speaker fix, so only install this on systems with older kernels.
+  boot.extraModulePackages = lib.mkIf (!(lib.versionOlder config.boot.kernelPackages.kernel.version "6.9")) [ lenovo-speaker-fix ];
   
   # √(2560² + 1600²) px / 16 in ≃ 189 dpi
   services.xserver.dpi = 189;


### PR DESCRIPTION
###### Description of changes

This adds a check to prevent installing the speaker fix if the kernel is later than 6.9. Kernel 6.9-rc3 introduced the fix for the speaker issue, so this patch shouldn't be needed.

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input