### PR TITLE
framework: Add framework-laptop-kmod for 16" model as well

### DIFF
--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../kmod.nix
     ../../framework-tool.nix
   ];
 


### PR DESCRIPTION
###### Description of changes

in https://github.com/NixOS/nixos-hardware/pull/903 , the framework-laptop-kmod was added, and automatically setup for 13" models. The 16" model will also be able to take advantage of the kmod, once the 6.10 kernel patches are in place.

Kernel Patchset: https://lore.kernel.org/chrome-platform/20231005160701.19987-1-dustin@howett.net/

###### Things done

Add `kmod` import to 16" Framework `default.nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

