### PR TITLE
Added config for Huawei Matebook X Pro (2020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ See code for all available configurations.
 | [HP Elitebook 845g8](hp/elitebook/845/g8)                              | `<nixos-hardware/hp/elitebook/845/g8>`                  |
 | [HP Elitebook 845g9](hp/elitebook/845/g9)                              | `<nixos-hardware/hp/elitebook/845/g9>`                  |
 | [HP Notebook 14-df0023](hp/notebook/14-df0023)                         | `<nixos-hardware/hp/notebook/14-df0023>`                |
+| [Huawei Matebook X Pro (2020)](huawei/machc-wa)                        | `<nixos-hardware/huawei/machc-wa>`                      |
 | [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)            | `<nixos-hardware/nxp/imx8qm-mek>`                       |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                                  | `<nixos-hardware/intel/nuc/8i7beh>`                     |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)              | `<nixos-hardware/lenovo/ideapad/15arh05>`               |

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
       hp-elitebook-845g7 = import ./hp/elitebook/845/g7;
       hp-elitebook-845g8 = import ./hp/elitebook/845/g8;
       hp-elitebook-845g9 = import ./hp/elitebook/845/g9;
+      huawei-machc-wa = import ./huawei/machc-wa;
       hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
       intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
       lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;

--- a/huawei/machc-wa/README.md
+++ b/huawei/machc-wa/README.md
@@ -1,0 +1,3 @@
+# Huawei Matebook X Pro (2020)
+
+This is a very standard device that needs little configuration. The module mainly imports the common modules for its CPU, GPU, SSD etc. and enables ppd for power management. Nvidia prime offload is also enabled. This configuration should work with all Matebook X Pro models from 2020 (MACHC-WA*) other than MACHC-WAH9L as it does not contain the Nvidia GPU.

--- a/huawei/machc-wa/default.nix
+++ b/huawei/machc-wa/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: {
+  imports = [
+    ../../common/cpu/intel
+    ../../common/cpu/intel/comet-lake
+    ../../common/gpu/nvidia
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/hidpi.nix
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+  ];
+
+  hardware.nvidia = {
+    modesetting.enable = lib.mkDefault true;
+    open = lib.mkDefault false;
+    nvidiaSettings = lib.mkDefault true;
+    prime = {
+      intelBusId = "PCI:0:2:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+  };
+
+  services.power-profiles-daemon.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
Created a config file for Huawei Matebook X Pro (2020). This file should work on all versions other than MACHC-WAH9L as that one does not include the Nvidia MX250 dGPU.
