### PR TITLE
Lenovo legion 15ach6h

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ See code for all available configurations.
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                             | `<nixos-hardware/lenovo/ideapad/z510>`                  |
 | [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                         | `<nixos-hardware/lenovo/ideapad/slim-5>`                |
 | [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)                 | `<nixos-hardware/lenovo/ideapad/s145-15api>`            |
+| [Lenovo Legion 5 15ach6h](lenovo/legion/15ach6h)                       | `<nixos-hardware/lenovo/legion/15ach6h>`                |
 | [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                     | `<nixos-hardware/lenovo/legion/15arh05h>`               |
 | [Lenovo Legion 7 Slim 15ach6](lenovo/legion/15ach6)                    | `<nixos-hardware/lenovo/legion/15ach6>`                 |
 | [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                   | `<nixos-hardware/lenovo/legion/16ach6h>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
       lenovo-ideapad-slim-5 = import ./lenovo/ideapad/slim-5;
       lenovo-ideapad-s145-15api = import ./lenovo/ideapad/s145-15api;
       lenovo-legion-15ach6 = import ./lenovo/legion/15ach6;
+      lenovo-legion-15ach6h = import ./lenovo/legion/15ach6h;
       lenovo-legion-15arh05h = import ./lenovo/legion/15arh05h;
       lenovo-legion-16ach6h = import ./lenovo/legion/16ach6h;
       lenovo-legion-16ach6h-hybrid = import ./lenovo/legion/16ach6h/hybrid;


### PR DESCRIPTION
###### Description of changes

Lenovo Legion 15ACH6H had a supported configuration in master, but was missing from flake.nix and README.md. I've added both.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

