### PR TITLE
hidpi: drop legacy options

### DIFF
--- a/common/hidpi.nix
+++ b/common/hidpi.nix
@@ -1,12 +1,6 @@
 { lib, pkgs, ... }:
-let
-  # This option is removed from NixOS 23.05 and up
-  nixosVersion = lib.versions.majorMinor lib.version;
-  config = if lib.versionOlder nixosVersion "23.05" then {
-    hardware.video.hidpi.enable = lib.mkDefault true;
-  } else {
-    # Just set the console font, don't mess with the font settings
-    console.font = lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz";
-    console.earlySetup = lib.mkDefault true;
-  };
-in config
+{
+  # Just set the console font, don't mess with the font settings
+  console.font = lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz";
+  console.earlySetup = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

