### PR TITLE
Add configuration for Lenovo IdeaPad 5 Pro 16ACH6

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ See code for all available configurations.
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                                  | `<nixos-hardware/intel/nuc/8i7beh>`                     |
 | [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                       | `<nixos-hardware/lenovo/ideapad/15alc6>`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)              | `<nixos-hardware/lenovo/ideapad/15arh05>`               |
+| [Lenovo IdeaPad 5 Pro 16ach6](lenovo/ideapad/16ach6)                   | `<nixos-hardware/lenovo/ideapad/16ach6>`                |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                             | `<nixos-hardware/lenovo/ideapad/z510>`                  |
 | [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                         | `<nixos-hardware/lenovo/ideapad/slim-5>`                |
 | [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)                 | `<nixos-hardware/lenovo/ideapad/s145-15api>`            |

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
       intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
       lenovo-ideapad-15alc6 = import ./lenovo/ideapad/15alc6;
       lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;
+      lenovo-ideapad-16ach6 = import ./lenovo/ideapad/16ach6;
       lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;
       lenovo-ideapad-slim-5 = import ./lenovo/ideapad/slim-5;
       lenovo-ideapad-s145-15api = import ./lenovo/ideapad/s145-15api;

--- a/lenovo/ideapad/16ach6/README.md
+++ b/lenovo/ideapad/16ach6/README.md
@@ -1,0 +1,41 @@
+# Lenovo IdeaPad 5 Pro 16ACH6
+
+This laptop comes with an AMD CPU+GPU and dedicated NVIDIA graphics. Unlike the similarly named [Legion 5 Pro 16ACH6*H*](../../legion/16ach6h/), there is no direct dedicated graphics setting.
+
+The `nvidia.hardware.powerManagement.enable` option is not enabled in this configuration, since it seemed to cause issues when waking up from suspend, while also not providing much in terms of power saving. I've tested with `finegrained` both enabled and disabled, and it caused the screen to go dark a few moments after waking up from suspend. Most times this only happened once and the screen came back after a few moments, but on some occasions it kept occurring repeatedly.
+
+This device also has a "battery conservation mode", which charges the battery to only ~60%. This mode can be enabled using [TLP](https://linrunner.de/tlp/settings/bc-vendors.html#lenovo-non-thinkpad-series):
+
+```nix
+services.power-profiles-daemon.enable = false;
+services.tlp.enable = true;
+services.tlp.settings = {
+  # Enable battery conservation mode
+  # Run `sudo tlp fullcharge` to enable a full charge until next reboot,
+  # and `sudo tlp setcharge` to reset to conservation mode.
+  START_CHARGE_THRESH_BAT0 = 0;
+  STOP_CHARGE_THRESH_BAT0 = 1;
+};
+```
+
+## Device information
+
+Details from `tlp-stat`:
+
+```
+System         = LENOVO IdeaPad 5 Pro 16ACH6 82L5
+BIOS           = GSCN35WW
+EC Firmware    = 1.35
+OS Release     = NixOS 23.11 (Tapir)
+Kernel         = 6.6.10 #1-NixOS SMP PREEMPT_DYNAMIC Fri Jan  5 14:19:45 UTC 2024 x86_64
+Init system    = systemd
+Boot mode      = UEFI
+Suspend mode   = [s2idle]
+```
+
+`lspci` output:
+
+```
+01:00.0 3D controller: NVIDIA Corporation GA107M [GeForce RTX 3050 Mobile] (rev a1)
+05:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Cezanne [Radeon Vega Series / Radeon Vega Mobile Series] (rev c4)
+```

--- a/lenovo/ideapad/16ach6/default.nix
+++ b/lenovo/ideapad/16ach6/default.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  hardware.nvidia = {
+    modesetting.enable = true;
+    prime = {
+      amdgpuBusId = "PCI:5:0:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add configuration for the Lenovo IdeaPad 5 Pro 16ACH6 laptop. It only includes the common modules and sets up Nvidia prime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I've been testing this on my fork for months, but just noticed I hadn't created the PR yet while upgrading to 24.05 :see_no_evil: 