### PR TITLE
Raspberry pi 4: Fix bluetooth

### DIFF
--- a/raspberry-pi/4/bluetooth.nix
+++ b/raspberry-pi/4/bluetooth.nix
@@ -1,0 +1,44 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".bluetooth;
+in
+{
+  options.hardware = {
+    raspberry-pi."4".bluetooth = {
+      enable = lib.mkEnableOption ''
+        configuration for bluetooth
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
+    # doesn't work for the CM module, so we exclude e.g. bcm2711-rpi-cm4.dts
+    hardware.deviceTree.filter = "bcm2711-rpi-4*.dtb";
+
+    hardware.deviceTree = {
+      overlays = [
+        {
+          name = "bluetooth-overlay";
+          dtsText = ''
+            /dts-v1/;
+            /plugin/;
+
+            / {
+                compatible = "brcm,bcm2711";
+
+                fragment@0 {
+                    target = <&uart0_pins>;
+                    __overlay__ {
+                            brcm,pins = <30 31 32 33>;
+                            brcm,pull = <2 0 0 2>;
+                    };
+                };
+            };
+          '';
+        }
+      ];
+    };
+  };
+}

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./audio.nix
     ./backlight.nix
+    ./bluetooth.nix
     ./cpu-revision.nix
     ./digi-amp-plus.nix
     ./dwc2.nix


### PR DESCRIPTION
###### Description of changes

Bluetooth don't work on raspberry pi 4 by default with the RPI kernel. The thread https://github.com/NixOS/nixpkgs/issues/123725#issuecomment-1613705556, even referenced by [the wiki](https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_4), provide a `bluetooth.nix` from [lloeki](https://github.com/lloeki) that never got the chance to be merged directly into nixos-hardware. This PR just add that `bluetooth` config. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

