### PR TITLE
surface: linux 6.8.9 -> 6.9.3

### DIFF
--- a/microsoft/surface/common/kernel/default.nix
+++ b/microsoft/surface/common/kernel/default.nix
@@ -5,7 +5,7 @@ let
 
 in {
   imports = [
-    ./linux-6.8.x
+    ./linux-6.9.x
   ];
 
   options.microsoft-surface.kernelVersion = mkOption {

--- a/microsoft/surface/common/kernel/linux-6.9.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.9.x/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.8.9";
+  version = "6.9.3";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "sha256-+QXxI46nqOhTFLrPKDMC6AlwBgENJfzqcm0N4OpbybY=";
+    sha256 = "1bnzxparybwh320019pr2msaapas41dhjmvg4gy791rn05jc88f3";
     ignoreConfigErrors=true;
   };
 

--- a/microsoft/surface/common/kernel/linux-6.9.x/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.9.x/patches.nix
@@ -86,59 +86,63 @@
     };
   }
   {
-    name = "ms-surface/0001-surface3-oemb";
-    patch = patchSrc + "/0001-surface3-oemb.patch";
+    name = "ms-surface/0001-secureboot";
+    patch = patchSrc + "/0001-secureboot.patch";
   }
   {
-    name = "ms-surface/0002-mwifiex";
-    patch = patchSrc + "/0002-mwifiex.patch";
+    name = "ms-surface/0002-surface3-oemb";
+    patch = patchSrc + "/0002-surface3-oemb.patch";
   }
   {
-    name = "ms-surface/0003-ath10k";
-    patch = patchSrc + "/0003-ath10k.patch";
+    name = "ms-surface/0003-mwifiex";
+    patch = patchSrc + "/0003-mwifiex.patch";
   }
   {
-    name = "ms-surface/0004-ipts";
-    patch = patchSrc + "/0004-ipts.patch";
+    name = "ms-surface/0004-ath10k";
+    patch = patchSrc + "/0004-ath10k.patch";
   }
   {
-    name = "ms-surface/0005-ithc";
-    patch = patchSrc + "/0005-ithc.patch";
+    name = "ms-surface/0005-ipts";
+    patch = patchSrc + "/0005-ipts.patch";
   }
   {
-    name = "ms-surface/0006-surface-sam";
-    patch = patchSrc + "/0006-surface-sam.patch";
+    name = "ms-surface/0006-ithc";
+    patch = patchSrc + "/0006-ithc.patch";
   }
   {
-    name = "ms-surface/0007-surface-sam-over-hid";
-    patch = patchSrc + "/0007-surface-sam-over-hid.patch";
+    name = "ms-surface/0007-surface-sam";
+    patch = patchSrc + "/0007-surface-sam.patch";
   }
   {
-    name = "ms-surface/0008-surface-button";
-    patch = patchSrc + "/0008-surface-button.patch";
+    name = "ms-surface/0008-surface-sam-over-hid";
+    patch = patchSrc + "/0008-surface-sam-over-hid.patch";
   }
   {
-    name = "ms-surface/0009-surface-typecover";
-    patch = patchSrc + "/0009-surface-typecover.patch";
+    name = "ms-surface/0009-surface-button";
+    patch = patchSrc + "/0009-surface-button.patch";
   }
   {
-    name = "ms-surface/0010-surface-shutdown";
-    patch = patchSrc + "/0010-surface-shutdown.patch";
+    name = "ms-surface/0010-surface-typecover";
+    patch = patchSrc + "/0010-surface-typecover.patch";
   }
   {
-    name = "ms-surface/0011-surface-gpe";
-    patch = patchSrc + "/0011-surface-gpe.patch";
+    name = "ms-surface/0011-surface-shutdown";
+    patch = patchSrc + "/0011-surface-shutdown.patch";
   }
   {
-    name = "ms-surface/0012-cameras";
-    patch = patchSrc + "/0012-cameras.patch";
+    name = "ms-surface/0012-surface-gpe";
+    patch = patchSrc + "/0012-surface-gpe.patch";
   }
   {
-    name = "ms-surface/0013-amd-gpio";
-    patch = patchSrc + "/0013-amd-gpio.patch";
+    name = "ms-surface/0013-cameras";
+    patch = patchSrc + "/0013-cameras.patch";
   }
   {
-    name = "ms-surface/0014-rtc";
-    patch = patchSrc + "/0014-rtc.patch";
+    name = "ms-surface/0014-amd-gpio";
+    patch = patchSrc + "/0014-amd-gpio.patch";
+  }
+  {
+    name = "ms-surface/0015-rtc";
+    patch = patchSrc + "/0015-rtc.patch";
   }
 ]

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "arch-6.8.6-1";
-    hash = "sha256-kLnHcYFeQ7/8lbSL4p9D2aC4V/Ib1tU225UOkRcNnH4=";
+    rev = "arch-6.9.3-1";
+    hash = "sha256-HoG7MuWAtiTAX9CJeqCGrfkfoue7XLtSMF6zjx4z7i8=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes

- Update linux from 6.8.9 to 6.9.3
- Update linux-surface patches from arch-6.8.6-1 to arch-6.9.3-1
- Update patch list

- [X] Tested on Surface Laptop 4 AMD


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

