### PR TITLE
Add Chuwi MiniBook X

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ See code for all available configurations.
 | [Asus TUF FA507NV](asus/fa507nv)                                       | `<nixos-hardware/asus/fa507nv>`                         |
 | [Asus Zenbook Flip S13 UX371](asus/zenbook/ux371/)                     | `<nixos-hardware/asus/zenbook/ux371>`                   |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                   | `<nixos-hardware/beagleboard/pocketbeagle>`             |
+| [Chuwi MiniBook X](chuwi/minibook-x)                                   | `<nixos-hardware/chuwi/minibook-x>`                     |
 | [Deciso DEC series](deciso/dec)                                        | `<nixos-hardware/deciso/dec>`                           |
 | [Dell G3 3779](dell/g3/3779)                                           | `<nixos-hardware/dell/g3/3779>`                         |
 | [Dell Inspiron 14 5420](dell/inspiron/14-5420)                         | `<nixos-hardawre/dell/inspiron/14-5420>`                |

--- a/chuwi/minibook-x/default.nix
+++ b/chuwi/minibook-x/default.nix
@@ -1,0 +1,10 @@
+{ ... }: {
+  imports = [
+    ../../common/cpu/intel
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+    ../../common/hidpi.nix
+  ];
+  boot.kernelParams =
+    [ "fbcon=rotate:1" "video=DSI-1:panel_orientation=right_side_up" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
       asus-zephyrus-gu603h = import ./asus/zephyrus/gu603h;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
+      chuwi-minibook-x = import ./chuwi/minibook-x;
       deciso-dec = import ./deciso/dec;
       dell-e7240 = import ./dell/e7240;
       dell-g3-3779 = import ./dell/g3/3779;


### PR DESCRIPTION
###### Description of changes

Adds the Chuwi Minibook X. Fixes the display being rotated 90 degrees.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

