### PR TITLE
purism librem5r4: kernel 6.6.6pureos1 -> 6.6.29pureos1, fix uboot

### DIFF
--- a/purism/librem/5r4/kernel.nix
+++ b/purism/librem/5r4/kernel.nix
@@ -6,14 +6,14 @@
 buildLinux (args
   // rec {
   defconfig = "librem5_defconfig";
-  version = "6.6.6-librem5";
+  version = "6.6.29-librem5";
   modDirVersion = version;
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "linux";
-    rev = "pureos/6.6.6pureos1";
-    hash = "sha256-LJfY45yNYgFYLCGxb+WRMYBUHnY4HCI2rkflPeaeFe0=";
+    rev = "pureos/6.6.29pureos1";
+    hash = "sha256-i8HSAJ1/Z2Ux2s3Srse+L0S1Zd/70ldpGBhIgEZ6nBw=";
   };
   kernelPatches = [ ];
   structuredExtraConfig = with lib.kernel; {

--- a/purism/librem/5r4/u-boot/default.nix
+++ b/purism/librem/5r4/u-boot/default.nix
@@ -51,6 +51,7 @@ let
       rev = "956aa590c93977992743b41c45d3c7ee5a024915"; # this is the latest commit on the upstream/librem5 branch
       hash = "sha256-MsIIlarN+WFFEzc0ptLAgS7BwJ6Cosy42xo0EwPn1AU=";
     };
+    patches = [];
     BL31 = "${arm-trusted-firmware-imx8mq}/bl31.bin";
     preConfigure = ''
       cp $BL31 .


### PR DESCRIPTION
###### Description of changes

this pr fixes building the librem5's version of uboot and also is a (long overdue...) update of the linux kernel version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

