### PR TITLE
treewide: drop hardware.amdgpu.amdvlk option

### DIFF
--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -6,9 +6,6 @@
   ) // {
     default = true;
   };
-  options.hardware.amdgpu.amdvlk = lib.mkEnableOption (lib.mdDoc
-    "use amdvlk drivers instead mesa radv drivers"
-  );
   options.hardware.amdgpu.opencl = lib.mkEnableOption (lib.mdDoc
     "rocm opencl runtime (Install rocmPackages.clr and rocmPackages.clr.icd)"
   ) // {
@@ -26,15 +23,6 @@
     }
     (lib.mkIf config.hardware.amdgpu.loadInInitrd {
       boot.initrd.kernelModules = [ "amdgpu" ];
-    })
-    (lib.mkIf config.hardware.amdgpu.amdvlk {
-      hardware.opengl.extraPackages = with pkgs; [
-        amdvlk
-      ];
-
-      hardware.opengl.extraPackages32 = with pkgs; [
-        driversi686Linux.amdvlk
-      ];
     })
     (lib.mkIf config.hardware.amdgpu.opencl {
       hardware.opengl.extraPackages =

--- a/lenovo/legion/15ach6h/nvidia/default.nix
+++ b/lenovo/legion/15ach6h/nvidia/default.nix
@@ -9,18 +9,9 @@
   # because when writing the specialization of Dual-Direct GFX, I did not completely
   # remove all packages for amd igpu. I only removed amdgpu from
   # services.xserver.videoDrivers by overriding. This is because the specialization
-  # of nix cannot implement such an operation as canceling an import. In the end, if
-  # it is enabled in Dual-Direct GFX In the absence of amd igpu, the amdvlk package
-  # caused the proton to crash. In order to solve this problem, I add the option of
-  # whether to enable amdvlk to the configuration file of amd gpu, and open it by
-  # default, and turn it off in specialization, so as to delete amdvlk package and
-  # other packages for amd igpu in specialization. At the same time, I also added an
-  # option to amdgpu's opencl runtime.
+  # of nix cannot implement such an operation as canceling an import.
   hardware = {
     nvidia.prime.offload.enable = false;
-    amdgpu = {
-      amdvlk = false;
-      opencl = false;
-    };
+    amdgpu.opencl = false;
   };
 }

--- a/lenovo/legion/16ach6h/nvidia/default.nix
+++ b/lenovo/legion/16ach6h/nvidia/default.nix
@@ -9,18 +9,9 @@
   # because when writing the specialization of Dual-Direct GFX, I did not completely
   # remove all packages for amd igpu. I only removed amdgpu from
   # services.xserver.videoDrivers by overriding. This is because the specialization
-  # of nix cannot implement such an operation as canceling an import. In the end, if
-  # it is enabled in Dual-Direct GFX In the absence of amd igpu, the amdvlk package
-  # caused the proton to crash. In order to solve this problem, I add the option of
-  # whether to enable amdvlk to the configuration file of amd gpu, and open it by
-  # default, and turn it off in specialization, so as to delete amdvlk package and
-  # other packages for amd igpu in specialization. At the same time, I also added an
-  # option to amdgpu's opencl runtime.
+  # of nix cannot implement such an operation as canceling an import.
   hardware = {
     nvidia.prime.offload.enable = false;
-    amdgpu = {
-      amdvlk = false;
-      opencl = false;
-    };
+    amdgpu.opencl = false;
   };
 }

--- a/lenovo/legion/16achg6/nvidia/default.nix
+++ b/lenovo/legion/16achg6/nvidia/default.nix
@@ -5,9 +5,6 @@
   services.xserver.videoDrivers = [ "nvidia" ];
   hardware = {
     nvidia.prime.offload.enable = false;
-    amdgpu = {
-      amdvlk = false;
-      opencl = false;
-    };
+    amdgpu.opencl = false;
   };
 }


### PR DESCRIPTION
###### Description of changes

This is now provided in nixpkgs (see https://github.com/NixOS/nixpkgs/pull/318175).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

