### PR TITLE
Fix issues with exisiting Gigabyte B550 patches

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
       friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
       friendlyarm-nanopi-r5s = import ./friendlyarm/nanopi-r5s;
       focus-m2-gen1 = import ./focus/m2/gen1;
+      gigabyte-b550 = import ./gigabyte/b550;
       google-pixelbook = import ./google/pixelbook;
       gpd-micropc = import ./gpd/micropc;
       gpd-p2-max = import ./gpd/p2-max;

--- a/gigabyte/b550/b550-fix-suspend.nix
+++ b/gigabyte/b550/b550-fix-suspend.nix
@@ -26,7 +26,7 @@
     };
     serviceConfig = {
       User            = "root";
-      ExecStart       = "-${pkgs.bash}/bin/bash -c 'if grep 'GPP8' /proc/acpi/wakeup | grep -q 'enabled'; then echo 'GPP8' > /proc/acpi/wakeup; fi''";
+      ExecStart       = "-${pkgs.bash}/bin/bash -c 'if grep 'GPP8' /proc/acpi/wakeup | grep -q 'enabled'; then echo 'GPP8' > /proc/acpi/wakeup; fi'";
       RemainAfterExit = "yes";
     };
     wantedBy = ["multi-user.target"];


### PR DESCRIPTION
###### Description of changes

This adds gigabyte-b550 to the flake outputs, it is currently missing (https://github.com/NixOS/nixos-hardware/issues/926)
This also fixes a quoting error in one of the systemd unit scripts that was causing it to fail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

