### PR TITLE
amd/cpu/raphael-igpu: enable scatter/gather for kernel 6.6+

### DIFF
--- a/common/cpu/amd/raphael/igpu.nix
+++ b/common/cpu/amd/raphael/igpu.nix
@@ -1,9 +1,15 @@
-{ lib, pkgs, config, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 
 {
   # Sets the kernel version to the latest kernel to make the usage of the iGPU possible if your kernel version is too old
   # Disables scatter/gather which was introduced with kernel version 6.2
   # It produces completely white or flashing screens when enabled while using the iGPU of Ryzen 7000-series CPUs (Raphael)
+  # This issue is not seen in kernel 6.6 or newer versions
 
   imports = [ ../. ];
 
@@ -12,8 +18,9 @@
       kernelPackages = pkgs.linuxPackages_latest;
     })
 
-    (lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.2") {
-      kernelParams = ["amdgpu.sg_display=0"];
-    })
+    (lib.mkIf (
+      (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.2")
+      && (lib.versionOlder config.boot.kernelPackages.kernel.version "6.6")
+    ) { kernelParams = [ "amdgpu.sg_display=0" ]; })
   ];
 }


### PR DESCRIPTION
###### Description of changes
Scatter/gather was introduced in 6.2 kernel and caused flickering and various issues when running iGPU on Ryzen 7000-series CPUs. This issue is not observed in kernel 6.6 or newer versions so we can enable it for kernel 6.6 and newer versions.

Closes #918

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

