### PR TITLE
Lenovo 16ACH6H: use zenpower kernel module

### DIFF
--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../../../common/cpu/amd
     ../../../../common/cpu/amd/pstate.nix
+    ../../../../common/cpu/amd/zenpower.nix
     ../../../../common/gpu/amd
     ../../../../common/gpu/nvidia/prime.nix
     ../../../../common/pc/laptop


### PR DESCRIPTION
###### Description of changes
Lenovo Legion 5 pro can use zenpower kernel module. tested with mangohud, I can view cpu tdp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

