### PR TITLE
deprecate commons/hdd

### DIFF
--- a/common/pc/hdd/default.nix
+++ b/common/pc/hdd/default.nix
@@ -1,1 +1,9 @@
-{}
+{
+  warnings = [
+    ''
+      DEPRECATED: The <nixos-hardware/common/hdd.nix> module has been deprecated.
+
+      This module has no effect and will be removed in a future release.
+    ''
+  ];
+}

--- a/common/pc/laptop/hdd/default.nix
+++ b/common/pc/laptop/hdd/default.nix
@@ -1,8 +1,6 @@
 { lib, ... }:
 
 {
-  imports = [ ../../hdd ];
-
   # Hard disk protection if the laptop falls:
   services.hdapsd.enable = lib.mkDefault true;
 }

--- a/hp/elitebook/2560p/default.nix
+++ b/hp/elitebook/2560p/default.nix
@@ -7,7 +7,6 @@ with lib;
     ../../../common/pc
     ../../../common/pc/laptop
     ../../../common/pc/laptop/hdd
-    ../../../common/pc/hdd
 
     ./network.nix
   ];

--- a/hp/notebook/14-df0023/default.nix
+++ b/hp/notebook/14-df0023/default.nix
@@ -7,7 +7,6 @@ with lib;
     ../../../common/pc
     ../../../common/pc/laptop
     ../../../common/pc/laptop/hdd
-    ../../../common/pc/hdd
   ];
 
   config = {


### PR DESCRIPTION
We havent't had anything meaningful configuration in this module for a while. So let's deprecate it.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

