### PR TITLE
common/gpu/24.05-compat: don't create conflicts with user configuration

### DIFF
--- a/common/gpu/24.05-compat.nix
+++ b/common/gpu/24.05-compat.nix
@@ -1,37 +1,13 @@
 {
-  config,
   lib,
   ...
 }:
 {
   # Backward-compat for 24.05, can be removed after we drop 24.05 support
-  options = {
-    hardware.graphics = lib.optionalAttrs (lib.versionOlder lib.version "24.11pre") {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-      };
-      enable32Bit = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-      };
-      extraPackages = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default = [];
-      };
-      extraPackages32 = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default = [];
-      };
-    };
-  };
-
-  config = {
-    hardware.opengl = lib.optionalAttrs (lib.versionOlder lib.version "24.11pre") {
-      enable = config.hardware.graphics.enable;
-      driSupport32Bit = config.hardware.graphics.enable32Bit;
-      extraPackages = config.hardware.graphics.extraPackages;
-      extraPackages32 = config.hardware.graphics.extraPackages32;
-    };
-  };
+  imports = lib.optionals (lib.versionOlder lib.version "24.11pre") [
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "enable" ] [ "hardware" "opengl" "enable" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages" ] [ "hardware" "opengl" "extraPackages" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages32" ] [ "hardware" "opengl" "extraPackages32" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "enable32Bit" ] [ "hardware" "opengl" "driSupport32Bit" ])
+  ];
 }


### PR DESCRIPTION
fixes https://github.com/NixOS/nixos-hardware/issues/1000

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

