### PR TITLE
offload broke, changed to reverseSync

### DIFF
--- a/asus/zephyrus/ga503/default.nix
+++ b/asus/zephyrus/ga503/default.nix
@@ -9,6 +9,9 @@
   ];
 
   hardware.nvidia.prime = {
+    reverseSync.enable = true;
+    # Enable if using an external GPU        
+    allowExternalGpu = false;
     amdgpuBusId = "PCI:7:0:0";
     nvidiaBusId = "PCI:1:0:0";
   };


### PR DESCRIPTION
offload broke, reverseSync makes screen work again

###### Description of changes
reverseSync module doesn't exist, could be separate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

