### PR TITLE
use mkDefault against 24.05 opengl default values to avoid steam conflicts

### DIFF
--- a/common/gpu/24.05-compat.nix
+++ b/common/gpu/24.05-compat.nix
@@ -28,10 +28,10 @@
 
   config = {
     hardware.opengl = lib.optionalAttrs (lib.versionOlder lib.version "24.11pre") {
-      enable = config.hardware.graphics.enable;
-      driSupport32Bit = config.hardware.graphics.enable32Bit;
-      extraPackages = config.hardware.graphics.extraPackages;
-      extraPackages32 = config.hardware.graphics.extraPackages32;
+      enable = lib.mkDefault config.hardware.graphics.enable;
+      driSupport32Bit = lib.mkDefault config.hardware.graphics.enable32Bit;
+      extraPackages = lib.mkDefault config.hardware.graphics.extraPackages;
+      extraPackages32 = lib.mkDefault config.hardware.graphics.extraPackages32;
     };
   };
 }


### PR DESCRIPTION
###### Description of changes

New-ish 24.05-compat GPU settings cause a value conflict for bools in hardware.opengl when steam from Nix is also enabled.

Without these changes:

```
      error: The option `hardware.opengl.driSupport32Bit' has conflicting definition values:
       - In `/nix/store/m0l0hp71pxhjwvqc0mdwf52xlrn0c39f-source/common/gpu/24.05-compat.nix': false
       - In `/nix/store/2lvj8bm21ymxra61dqrc4xpzr8njgywj-source/nixos/modules/programs/steam.nix': true
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

###### Things done

Used lib.mkDefault to reduce the priority of these settings lower than steam.

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

