### PR TITLE
surface pro intel: thermald configuration

### DIFF
--- a/microsoft/surface/surface-pro-intel/default.nix
+++ b/microsoft/surface/surface-pro-intel/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 
 # This module is intended to support the Surface Pro range, specifically those with Intel CPUs.
 # It's expected it will work equally well on many other Surface models, but they may need further
@@ -15,4 +15,9 @@
 
   microsoft-surface.ipts.enable = true;
   microsoft-surface.surface-control.enable = true;
+
+  services.thermald = lib.mkDefault {
+    enable = true;
+    configFile = ./thermal-conf.xml;
+  };
 }

--- a/microsoft/surface/surface-pro-intel/thermal-conf.xml
+++ b/microsoft/surface/surface-pro-intel/thermal-conf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ThermalConfiguration>
+<Platform>
+	<Name>Surface Pro Intel Thermal Workaround</Name>
+	<ProductName>*</ProductName>
+	<Preference>QUIET</Preference>
+	<ThermalZones>
+		<ThermalZone>
+			<Type>cpu</Type>
+			<TripPoints>
+				<TripPoint>
+					<SensorType>x86_pkg_temp</SensorType>
+					<Temperature>65000</Temperature>
+					<type>passive</type>
+					<ControlType>SEQUENTIAL</ControlType>
+					<CoolingDevice>
+						<index>1</index>
+						<type>rapl_controller</type>
+						<influence>100</influence>
+						<SamplingPeriod>10</SamplingPeriod>
+					</CoolingDevice>
+				</TripPoint>
+			</TripPoints>
+		</ThermalZone>
+	</ThermalZones>
+</Platform>
+</ThermalConfiguration>


### PR DESCRIPTION
###### Description of changes
added thermald configuration that has been optimized for the surface pro intel series. fixes thermal throttling issues, especially when holding 100% cpu for long periods.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

