### PR TITLE
update macbookpro14,1 profile to 24.05 release (2024)

### DIFF
--- a/apple/macbook-pro/14-1/README.md
+++ b/apple/macbook-pro/14-1/README.md
@@ -1,17 +1,26 @@
-# MacBook Pro 14,1
+# MacBook Pro 14,1, NixOS 24.01 (2024)
 
 ## Audio
-
-Audio is a lost cause. Bribe an Apple or Cirrus engineer for the datasheet. ;)
-
-## Thunderbolt
-
-The thunderbolt module will oops upon system resume, and subsequently refuse to work until next reboot.
-
-## Suspend/Resume
-
-The d3cold state needs to be disabled on the NVME controller for it to wake up.
+ [ ] Still broken, use usb/hdmi instead, nixos pkg needed: https://github.com/davidjo/snd_hda_macbookpro
 
 ## Bluetooth
-The Bluetooth UART (/dev/ttyS0) is created and then deleted by udev in early boot.
-Hack around it by reloading the 8250_dw module, causing it to be re-created.
+ [ ] Still broken, even (hacky) workaround does not work any more with latest driver updates
+
+## Touchpad 
+ [x] Working, including 'disable while typing' usable quirk
+
+## Thunderbolt
+ [x] Working
+
+## NVME
+ [x] Working, older NVME / Controller may need workaround for resume
+
+## Suspend/Resume
+ [ ] Thunderbolt, WIFI, NVME may still need reboot (sometimes).
+
+## Wifi
+ [x] Working (2,4Ghz & 5Ghz supported), WEP3 currently broken b/c old brcm fw 
+
+## Resources
+- https://github.com/Dunedan/mbp-2016-linux?tab=readme-ov-file
+- https://gist.github.com/roadrunner2/1289542a748d9a104e7baec6a92f9cd7

--- a/apple/macbook-pro/14-1/default.nix
+++ b/apple/macbook-pro/14-1/default.nix
@@ -1,51 +1,89 @@
-{ config, lib, pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
   imports = [
-    ../.
+    ../../../common/cpu/intel/kaby-lake
+    ../../../common/gpu/intel
+    ../../../common/hidpi.nix
+    ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../../common/pc/laptop/acpi_call.nix
   ];
 
-  ##
-  # Make the keyboard work in stage1
+  # Make the keyboard work in stage1, enable iommu
   # https://www.kernelconfig.io/config_keyboard_applespi
-  ##
-  boot.initrd.kernelModules = [ "applespi" "spi_pxa2xx_platform" "intel_lpss_pci" "applesmc" ];
 
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.0") pkgs.linuxPackages_latest;
-
-  ##
-  # Disable d3cold on the NVME controller so the machine can actually
-  # wake up.
-  # https://github.com/Dunedan/mbp-2016-linux
-  ##
-  systemd.services.disable-nvme-d3cold = {
-    description = "Disables d3cold on the NVME controller";
-    before      = [ "suspend.target" ];
-    path        = [ pkgs.bash pkgs.coreutils ];
-
-    serviceConfig.Type = "oneshot";
-    serviceConfig.ExecStart = "${./disable-nvme-d3cold.sh}";
-    serviceConfig.TimeoutSec = 0;
-
-    wantedBy = [ "multi-user.target" "suspend.target" ];
+  boot = {
+    initrd.kernelModules = ["applespi" "spi_pxa2xx_platform" "intel_lpss_pci" "applesmc" ];
+    kernelParams = [ "intel_iommu=on" ];
+    kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.0") pkgs.linuxPackages_latest;
   };
 
-  ##
+  # Touchpad quirks to make "disable-while-typing" actually work
+  services.libinput.enable = true;
+  environment.etc."libinput/local-overrides.quirks".text = ''
+    [MacBook(Pro) SPI Touchpads]
+    MatchName=*Apple SPI Touchpad*
+    ModelAppleTouchpad=1
+    AttrTouchSizeRange=200:150
+    AttrPalmSizeThreshold=1100
+
+    [MacBook(Pro) SPI Keyboards]
+    MatchName=*Apple SPI Keyboard*
+    AttrKeyboardIntegration=internal
+
+    [MacBookPro Touchbar]
+    MatchBus=usb
+    MatchVendor=0x05AC
+    MatchProduct=0x8600
+    AttrKeyboardIntegration=internal
+  '';
+
+  # Wifi, CPU Microcode FW updates 
+  networking.enableB43Firmware = lib.mkDefault true;
+  hardware = { 
+    enableRedistributableFirmware = lib.mkDefault true;
+    cpu.intel.updateMicrocode = lib.mkDefault true;
+  };
+
+  # Bluetooth, only needed if kernel lacks support - custom kernel build
+  # boot.kernelPatches = [
+  #  {
+  #    name = "bcrm-config";
+  #    patch = null;
+  #    extraConfig = ''
+  #      BT_HCIUART_BCM y '';
+  #  }
+  # ];
+  
+  ##  [Workaround seems not to work anymore! Any Ideas?]
   # For some reason /dev/ttyS0 is created, and then removed by udev. We need this
   # for bluetooth, and the only way to get it again is to reload 8502_dw. Luckily,
   # nothing else uses it.
+  ## 
+  # systemd.services.btattach-bcm2e7c = lib.mkIf config.hardware.bluetooth.enable {
+  #  before = [ "bluetooth.target" ];
+  #  after = [ "sys-devices-platform-serial8250-tty-ttyS1.device" ];
+  #  path = [ pkgs.bash pkgs.kmod pkgs.bluez ];
+  #  serviceConfig.Type = "simple";
+  #  serviceConfig.ExecStart = "${./btfix.sh}";
+  #  wantedBy = [ "multi-user.target" ];
+  # };
+
+  ## [Enable only if needed!]
+  # Disable d3cold on older NVME controller, only if needed
+  # https://github.com/Dunedan/mbp-2016-linux
   ##
-  systemd.services.btattach-bcm2e7c = lib.mkIf config.hardware.bluetooth.enable {
-    before = [ "bluetooth.target" ];
-
-    # Hacky, as it's a different device,  but this always comes after ttyS0
-    after = [ "sys-devices-platform-serial8250-tty-ttyS1.device" ];
-    path = [ pkgs.bash pkgs.kmod pkgs.bluez ];
-
-    serviceConfig.Type = "simple";
-    serviceConfig.ExecStart = "${./btfix.sh}";
-
-    wantedBy = [ "multi-user.target" ];
-  };
+  #systemd.services.disable-nvme-d3cold = {
+  #  description = "Disables d3cold on the NVME controller";
+  #  before      = [ "suspend.target" ];
+  #  path        = [ pkgs.bash pkgs.coreutils ];
+  #  serviceConfig.Type = "oneshot";
+  #  serviceConfig.ExecStart = "${./disable-nvme-d3cold.sh}";
+  #  serviceConfig.TimeoutSec = 0;
+  #  wantedBy = [ "multi-user.target" "suspend.target" ];
+  #};
 }


### PR DESCRIPTION
###### Description of changes

update macbookpro14,1 profile to 24.05 release (2024)
- comment out broken workarounds, add replacements
- fix libinput for (hypersensitive/broken) touchpad 
- pin down propper cpu, gpu, acpi, ... support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

