### PR TITLE
enable bluetooth support for Yoga 6 13ALC6.

### DIFF
--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -18,4 +18,7 @@
 
   # energy savings
   boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
+
+  # enable bluetooth support
+  hardware.bluetooth.enable = true;
 }

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -19,6 +19,5 @@
   # energy savings
   boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
 
-  # enable bluetooth support
   hardware.bluetooth.enable = true;
 }


### PR DESCRIPTION
###### Description of changes

Bluetooth Support. 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

