### PR TITLE
Remove libvdpau-va-gl and cleanup vdpau in our modules

### DIFF
--- a/asus/zephyrus/ga402x/amdgpu/default.nix
+++ b/asus/zephyrus/ga402x/amdgpu/default.nix
@@ -1,17 +1,15 @@
 { config,
   lib,
-  pkgs,
   ...
 }:
 
 let
-  inherit (lib) mkDefault mkEnableOption mkIf mkMerge;
+  inherit (lib) mkEnableOption mkIf mkMerge;
   cfg = config.hardware.asus.zephyrus.ga402x;
 
 in {
   imports = [
     ../shared.nix
-    ../../../../common/gpu/24.05-compat.nix
   ];
 
   options.hardware.asus.zephyrus.ga402x.amdgpu = {
@@ -21,19 +19,6 @@ in {
   };
 
   config = mkMerge [
-    {
-      # AMD RX680
-      services.xserver.videoDrivers = mkDefault [ "amdgpu" ];
-
-      hardware = {
-        amdgpu.loadInInitrd = true;
-        graphics.extraPackages = with pkgs; [
-          vaapiVdpau
-          libvdpau-va-gl
-        ];
-      };
-    }
-
     (mkIf cfg.amdgpu.recovery.enable {
       # Hopefully fixes for where the kernel sometimes hangs when suspending or hibernating
       #  (Though, I'm very suspicious of the Mediatek Wifi...)

--- a/asus/zephyrus/ga402x/nvidia/default.nix
+++ b/asus/zephyrus/ga402x/nvidia/default.nix
@@ -12,6 +12,7 @@ in {
     ## "prime.nix" loads this, aleady:
     # ../../../common/gpu/nvidia
     ../../../../common/gpu/nvidia/prime.nix
+
   ];
 
   # NVIDIA GeForce RTX 4060 Mobile
@@ -26,11 +27,6 @@ in {
   hardware = {
     ## Enable the Nvidia card, as well as Prime and Offload:
     amdgpu.loadInInitrd = true;
-    graphics.extraPackages = with pkgs; [
-      # Also in nvidia/default.nix
-      vaapiVdpau
-      libvdpau-va-gl
-    ];
 
     nvidia = {
       modesetting.enable = true;

--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 {
   options.hardware.amdgpu.loadInInitrd = lib.mkEnableOption (lib.mdDoc

--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -37,7 +37,6 @@
         else
           intel-vaapi-driver
       )
-      libvdpau-va-gl
       intel-media-driver
     ];
 
@@ -48,7 +47,6 @@
         else
           intel-vaapi-driver
       )
-      libvdpau-va-gl
       intel-media-driver
     ];
 

--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -4,14 +4,9 @@
   imports = [
     ../../../thinkpad/yoga.nix
     ../../../../common/gpu/amd/default.nix
-    ../../../../common/gpu/24.05-compat.nix
   ];
 
   boot.initrd.kernelModules = [ "ideapad_laptop" ];
-  hardware.graphics.extraPackages = with pkgs; [
-    vaapiVdpau
-    libvdpau-va-gl
-  ];
 
   # latest kernel needed to make wifi work
   boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;

--- a/lenovo/yoga/7/14ARH7/amdgpu/default.nix
+++ b/lenovo/yoga/7/14ARH7/amdgpu/default.nix
@@ -1,24 +1,4 @@
-# Including this file will enable the AMD-GPU driver
-
-{ lib, pkgs, ... }:
-
-let
-  inherit (lib) mkDefault;
-
-in {
-  imports = [
-    ../shared.nix
-    ../../../../../common/gpu/24.05-compat.nix
-  ];
-
-  # AMD RX680
-  services.xserver.videoDrivers = mkDefault [ "amdgpu" ];
-
-  hardware = {
-    amdgpu.loadInInitrd = true;
-    graphics.extraPackages = with pkgs; [
-      vaapiVdpau
-      libvdpau-va-gl
-    ];
-  };
+# Including this file will enable the AMD-GPU driver (in shared.nix)
+{
+  imports = [ ../shared.nix ];
 }

--- a/lenovo/yoga/7/14ARH7/nvidia/default.nix
+++ b/lenovo/yoga/7/14ARH7/nvidia/default.nix
@@ -19,10 +19,6 @@ in {
   hardware = {
     ## Enable the Nvidia card, as well as Prime and Offload:
     amdgpu.loadInInitrd = true;
-    graphics.extraPackages = with pkgs; [
-      vaapiVdpau
-      libvdpau-va-gl
-    ];
 
     nvidia = {
       modesetting.enable = true;


### PR DESCRIPTION
###### Description of changes

Initial motivation: https://github.com/NixOS/nixpkgs/issues/283083


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

