### PR TITLE
Raspberry Pi 3: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ See code for all available configurations.
 | [Purism Librem 15v3](purism/librem/13v3)                               | `<nixos-hardware/purism/librem/15v3>`                   |
 | [Purism Librem 5r4](purism/librem/5r4)                                 | `<nixos-hardware/purism/librem/5r4>`                    |
 | [Raspberry Pi 2](raspberry-pi/2)                                       | `<nixos-hardware/raspberry-pi/2>`                       |
+| [Raspberry Pi 3](raspberry-pi/3)                                       | `<nixos-hardware/raspberry-pi/3>`                       |
 | [Raspberry Pi 4](raspberry-pi/4)                                       | `<nixos-hardware/raspberry-pi/4>`                       |
 | [Raspberry Pi 5](raspberry-pi/5)                                       | `<nixos-hardware/raspberry-pi/5>`                       |
 | [Samsung Series 9 NP900X3C](samsung/np900x3c)                          | `<nixos-hardware/samsung/np900x3c>`                     |

--- a/flake.nix
+++ b/flake.nix
@@ -239,6 +239,7 @@
       purism-librem-15v3 = import ./purism/librem/15v3;
       purism-librem-5r4 = import ./purism/librem/5r4;
       raspberry-pi-2 = import ./raspberry-pi/2;
+      raspberry-pi-3 = import ./raspberry-pi/3;
       raspberry-pi-4 = import ./raspberry-pi/4;
       raspberry-pi-5 = import ./raspberry-pi/5;
       kobol-helios4 = import ./kobol/helios4;

--- a/raspberry-pi/3/default.nix
+++ b/raspberry-pi/3/default.nix
@@ -32,7 +32,4 @@
     "console=tty0"
   ];
 
-  environment.systemPackages = with pkgs; [
-    libraspberrypi
-  ];
 }

--- a/raspberry-pi/3/default.nix
+++ b/raspberry-pi/3/default.nix
@@ -22,13 +22,12 @@
   # Enables the generation of /boot/extlinux/extlinux.conf
   boot.loader.generic-extlinux-compatible.enable = lib.mkDefault true;
 
+  # The last console argument in the list that linux can find at boot will receive kernel logs.
   # The serial ports listed here are:
-  # - ttyS0: for Tegra (Jetson TX1)
-  # - ttyAMA0: for QEMU's -machine virt
-  # https://github.com/NixOS/nixpkgs/blob/b72bde7c4a1f9c9bf1a161f0c267186ce3c6483c/nixos/modules/installer/sd-card/sd-image-aarch64.nix#L19
+  # - ttyS0: serial
+  # - tty0: hdmi
   boot.kernelParams = [
     "console=ttyS0,115200n8"
-    "console=ttyAMA0,115200n8"
     "console=tty0"
   ];
 

--- a/raspberry-pi/3/default.nix
+++ b/raspberry-pi/3/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, pkgs
+, ...
+}:
+
+{
+  boot.kernelPackages = lib.mkDefault pkgs.linuxKernel.packages.linux_rpi3;
+
+  # fix the following error :
+  # modprobe: FATAL: Module ahci not found in directory
+  # https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1350599022
+  nixpkgs.overlays = [
+    (_final: super: {
+      makeModulesClosure = x:
+        super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  # https://github.com/NixOS/nixpkgs/blob/b72bde7c4a1f9c9bf1a161f0c267186ce3c6483c/nixos/modules/installer/sd-card/sd-image-aarch64.nix#L12
+  # Use the extlinux boot loader. (NixOS wants to enable GRUB by default)
+  boot.loader.grub.enable = lib.mkDefault false;
+  # Enables the generation of /boot/extlinux/extlinux.conf
+  boot.loader.generic-extlinux-compatible.enable = lib.mkDefault true;
+
+  # The serial ports listed here are:
+  # - ttyS0: for Tegra (Jetson TX1)
+  # - ttyAMA0: for QEMU's -machine virt
+  # https://github.com/NixOS/nixpkgs/blob/b72bde7c4a1f9c9bf1a161f0c267186ce3c6483c/nixos/modules/installer/sd-card/sd-image-aarch64.nix#L19
+  boot.kernelParams = [
+    "console=ttyS0,115200n8"
+    "console=ttyAMA0,115200n8"
+    "console=tty0"
+  ];
+
+  environment.systemPackages = with pkgs; [
+    libraspberrypi
+  ];
+}

--- a/tests/run.py
+++ b/tests/run.py
@@ -81,7 +81,7 @@ def write_eval_test(f: IO[str], profiles: list[str]) -> None:
             continue
 
         system = "x86_64-linux"
-        if profile in ("raspberry-pi/4", "raspberry-pi/5"):
+        if profile in ("raspberry-pi/3", "raspberry-pi/4", "raspberry-pi/5"):
             system = "aarch64-linux"
 
         f.write(


### PR DESCRIPTION
###### Description of changes

Upstream my config for Raspberry PI 3

It's just some config that make it works for me

It's heavily inspired by the file that create sd-image for Aarch64

I don't understand everything of it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] [Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input](https://gitlab.com/pinage404/dotfiles/-/commit/2ffa280243d2f667df762e3337e7236c7666fde5)

