### PR TITLE
gpu/amd: Remove `loadInInitrd` option

### DIFF
--- a/asus/zephyrus/ga402x/nvidia/default.nix
+++ b/asus/zephyrus/ga402x/nvidia/default.nix
@@ -26,7 +26,7 @@ in {
 
   hardware = {
     ## Enable the Nvidia card, as well as Prime and Offload:
-    amdgpu.loadInInitrd = true;
+    amdgpu.initrd.enable = lib.mkDefault true;
 
     nvidia = {
       modesetting.enable = true;

--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -1,24 +1,15 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 {
-  options.hardware.amdgpu.loadInInitrd = lib.mkEnableOption (lib.mdDoc
-    "loading `amdgpu` kernelModule at stage 1. (Add `amdgpu` to `boot.initrd.kernelModules`)"
-  ) // {
-    default = true;
-  };
-
   imports = [ ../24.05-compat.nix ];
-  config = lib.mkMerge [
-    {
-      services.xserver.videoDrivers = lib.mkDefault [ "modesetting" ];
+  config = {
+    services.xserver.videoDrivers = lib.mkDefault [ "modesetting" ];
 
-      hardware.graphics = {
-        enable = lib.mkDefault true;
-        enable32Bit = lib.mkDefault true;
-      };
-    }
-    (lib.mkIf config.hardware.amdgpu.loadInInitrd {
-      boot.initrd.kernelModules = [ "amdgpu" ];
-    })
-  ];
+    hardware.graphics = {
+      enable = lib.mkDefault true;
+      enable32Bit = lib.mkDefault true;
+    };
+
+    hardware.amdgpu.initrd.enable = lib.mkDefault true;
+  };
 }

--- a/lenovo/legion/15ach6h/hybrid/default.nix
+++ b/lenovo/legion/15ach6h/hybrid/default.nix
@@ -20,7 +20,7 @@
   services.xserver.videoDrivers = [ "nvidia" ];
 
   hardware = {
-    amdgpu.loadInInitrd = lib.mkDefault false;
+    amdgpu.initrd.enable = false;
 
     nvidia = {
       modesetting.enable = lib.mkDefault true;

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -22,7 +22,7 @@
   services.xserver.videoDrivers = [ "nvidia" ];
 
   hardware = {
-    amdgpu.loadInInitrd = lib.mkDefault false;
+    amdgpu.initrd.enable = false;
 
     nvidia = {
       modesetting.enable = lib.mkDefault true;

--- a/lenovo/yoga/7/14ARH7/nvidia/default.nix
+++ b/lenovo/yoga/7/14ARH7/nvidia/default.nix
@@ -18,7 +18,7 @@ in {
 
   hardware = {
     ## Enable the Nvidia card, as well as Prime and Offload:
-    amdgpu.loadInInitrd = true;
+    amdgpu.initrd.enable = true;
 
     nvidia = {
       modesetting.enable = true;


### PR DESCRIPTION
###### Description of changes

Option is now in nixpkgs under `hardware.amdgpu.initrd.enable` as of NixOS/nixpkgs@6a0b6a6b74a71be7c37b9d8bc4472cf087aff709

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tests completed at eval time only.

