### PR TITLE
common/gpu/nvidia: vaapiVdpau -> libva-vdpau-driver

### DIFF
--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -3,7 +3,11 @@
 {
   imports = [ ../24.05-compat.nix ];
   services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
-  hardware.graphics.extraPackages = with pkgs; [
-    vaapiVdpau
+  hardware.graphics.extraPackages = [
+    (
+      if pkgs ? libva-vdpau-driver
+      then pkgs.libva-vdpau-driver
+      else pkgs.vaapiVdpau
+    )
   ];
 }


### PR DESCRIPTION
###### Description of changes

- `common/gpu/nvidia/default.nix` conditionally use `pkgs.libva-vdpau-driver` if it exists instead of `pkgs.vaapiVdpau` to handle upstream rename in https://github.com/NixOS/nixpkgs/pull/317542 (this fixes [Issue 1015](https://github.com/NixOS/nixos-hardware/issues/1015) )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

