### PR TITLE
Framework 16 keyboard-wake fix

### DIFF
--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -19,6 +19,9 @@
   services.udev.extraRules = ''
     # Ethernet expansion card support
     ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0bda", ATTR{idProduct}=="8156", ATTR{power/autosuspend}="20"
+    # Disabling keyboard waking up from suspend to prevent wakeups while lid is closed due to keyboard being presssed by display flexing. 
+    ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ATTRS{idVendor}=="32ac", ATTRS{idProduct}=="0012", ATTR{power/wakeup}="disabled", ATTR{driver/1-1.1.1.4/power/wakeup}="disabled"
+    ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ATTRS{idVendor}=="32ac", ATTRS{idProduct}=="0014", ATTR{power/wakeup}="disabled", ATTR{driver/1-1.1.1.4/power/wakeup}="disabled"
   '';
 
   # Needed for desktop environments to detect/manage display brightness


### PR DESCRIPTION
###### Description of changes
Due to a firmware issue, the framework 16 will wake up with its lid closed when the display flexes upon the keyboard. This is a suggested workaround.

These questions should be answered before merging:

1. Are these device IDs consistent across different framework 16 notebooks *and different keyboard modules*? 
      - I have tested this on one more fw16, and it worked there. I think we used the same layout tho.
3. Do we want to also disable the Trackpad, and if so: how?
      - will create a review for that ...
4. This might be unexpected behavior, as it also prevents the device form waking up from keyboard input *when the lid is open*. Is that a worthwhile trade-off, and if not so: is there another way?
      -  The framework will become very hot inside a backpack, to the point where I am concerned about battery and storage health. Users on the forum reported the 82 degree warning being exceeded on the SSD. And as I pretty much never use wake by keyboard anyways, I would strongly support this workaround, while Framework figures out a firmware patch.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

