### PR TITLE
Fix Lenovo Thinkpad T14s not powering off

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)          | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                             | `<nixos-hardware/lenovo/thinkpad/t14>`                  |
 | [Lenovo ThinkPad T14s AMD Gen 1](lenovo/thinkpad/t14s/amd/gen1)        | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`        |
+| [Lenovo ThinkPad T14s AMD Gen 4](lenovo/thinkpad/t14s/amd/gen4)        | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen4>`        |
 | [Lenovo ThinkPad T14s](lenovo/thinkpad/t14s)                           | `<nixos-hardware/lenovo/thinkpad/t14s>`                 |
 | [Lenovo ThinkPad T410](lenovo/thinkpad/t410)                           | `<nixos-hardware/lenovo/thinkpad/t410>`                 |
 | [Lenovo ThinkPad T420](lenovo/thinkpad/t420)                           | `<nixos-hardware/lenovo/thinkpad/t420>`                 |

--- a/flake.nix
+++ b/flake.nix
@@ -154,6 +154,7 @@
       lenovo-thinkpad-t14-amd-gen4 = import ./lenovo/thinkpad/t14/amd/gen4;
       lenovo-thinkpad-t14s = import ./lenovo/thinkpad/t14s;
       lenovo-thinkpad-t14s-amd-gen1 = import ./lenovo/thinkpad/t14s/amd/gen1;
+      lenovo-thinkpad-t14s-amd-gen4 = import ./lenovo/thinkpad/t14s/amd/gen4;
       lenovo-thinkpad-t410 = import ./lenovo/thinkpad/t410;
       lenovo-thinkpad-t420 = import ./lenovo/thinkpad/t420;
       lenovo-thinkpad-t430 = import ./lenovo/thinkpad/t430;

--- a/lenovo/thinkpad/t14s/amd/gen4/default.nix
+++ b/lenovo/thinkpad/t14s/amd/gen4/default.nix
@@ -1,0 +1,9 @@
+{ lib, pkgs, ... }:
+{
+  imports = [
+    ../.
+  ];
+
+  # Fix laptop not properly powering off during shutdown.
+  boot.kernelParams = [ "apm=power_off" ];
+}


### PR DESCRIPTION
###### Description of changes

My Lenovo Thinkpad T14s Gen 4 does not propery power off after shutdown. The display goes blank but the CPU runs very hot and the fan starts to spin up. In this state, the battery is drained within around an hour.

Adding the `apm` parameter fixes this behaviour.

Maybe someone else can chime in if they had similar problems.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

