### PR TITLE
framework: refactor kmod for improved AMD support

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -51,6 +51,17 @@ For the Framework 13 laptops, there are common configuration modules available u
 including some modules specific to AMD- or Intel-based laptops. By preference, there will already be a specialised
 module for your model's configuration. Otherwise, it can be added alongside the existing modules.
 
+## OS integration
+
+`hardware.framework.enableKmod` enables the [community-created Framework kernel
+module](https://github.com/DHowett/framework-laptop-kmod) which exposes EC functionality like battery charge limit,
+privacy switches, and system LEDs as standard driver interfaces. This enables, for example, configuring the charge limit
+using the KDE settings GUI. The option is enabled by default when NixOS `>= 24.05` and linux kernel version `>= 6.10`.
+
+On AMD Framework 13 and 16, before kernel 6.10, additional kernel patches are required for the kernel module to function
+properly. Manually setting `hardware.framework.enableKmod = true` will apply the patches, requiring a kernel
+recompilation.
+
 ## Support Tools
 
 ### fw-ectool

--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -1,17 +1,42 @@
-{ config, lib, ... }:
-{
-  options.hardware.framework.enableKmod = lib.mkEnableOption
+{ config, lib, pkgs, ... }:
+let
+  kernel_version_compatible = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.10";
+in {
+  options.hardware.framework.enableKmod = (lib.mkEnableOption
     "Enable the community created Framework kernel module that allows interacting with the embedded controller from sysfs."
-  // {
-    # Enable by default if on new enough version of NixOS
-    default = (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05");
+  ) // {
+    # enable by default on NixOS >= 24.05 and kernel >= 6.10
+    default = lib.and
+      (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05")
+      kernel_version_compatible;
   };
 
-  config = lib.mkIf config.hardware.framework.enableKmod {
-    boot.extraModulePackages = with config.boot.kernelPackages; [
+
+  config.boot = lib.mkIf config.hardware.framework.enableKmod {
+    extraModulePackages = with config.boot.kernelPackages; [
       framework-laptop-kmod
     ];
+
     # https://github.com/DHowett/framework-laptop-kmod?tab=readme-ov-file#usage
-    boot.kernelModules = [ "cros_ec" "cros_ec_lpcs" ];
+    kernelModules = [ "cros_ec" "cros_ec_lpcs" ];
+
+    # add required patch if enabled on kernel <6.10
+    kernelPatches = lib.mkIf (!kernel_version_compatible) [
+      rec {
+        name = "platform/chrome: cros_ec_lpc: add support for AMD Framework Laptops";
+        msgid = "20240403004713.130365-1-dustin@howett.net";
+        version = "3";
+        hash = "sha256-aQSyys8CMzlj9EdNhg8vtp76fg1qEwUVeJL0E+8w5HU=";
+        patch = pkgs.runCommandLocal "patch-${msgid}" {
+          nativeBuildInputs = with pkgs; [ b4 git cacert ];
+          SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+
+          outputHash = hash;
+        } ''
+          export HOME="$TMP"
+          PYTHONHASHSEED=0 ${pkgs.b4}/bin/b4 -n am -C -T -v ${version} -o- "${msgid}" > "$out"
+        '';
+      }
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Fixes #1028 

Changes several aspects of [framework-laptop-kmod](https://github.com/DHowett/framework-laptop-kmod) support:
- default value has been changed to true when NixOS >= 24.05 *and* linux kernel >=6.10; false otherwise
- adds required patch for framework AMD enablement when kernel <6.10
- add README section describing usage

Also: this may be an upstream nixpkgs issue, but the lack of a good lore.kernel.org fetcher is kind of surprising. I tried using [this sample code with `fetchpatch`](https://discourse.nixos.org/t/fetching-patches-from-lore-kernel-org/45594) initially, but got weird errors with it. I [implemented](https://git.lain.faith/haskal/dragnpkgs/src/commit/ecdf449848aaa8fe368922fb3cb28d2ce8b09be7/lib/fetchb4) a `fetchb4` fetcher for my own personal usage, which uses `b4` to download and format patches from <https://lore.kernel.org> and the skeleton of that is present in this PR using `runCommand` for simplicity

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Edit: I've been running this on my own framework 16 for a bit now and everything seems to be working fine