### PR TITLE
common-gpu-nvidia: drop libva-vdpau-driver, enable modesetting by default

### DIFF
--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -4,5 +4,5 @@
   imports = [ ../24.05-compat.nix ];
   services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
   # TODO: this will be a default after https://github.com/NixOS/nixpkgs/pull/326369
-  hardware.nvidia.modesetting.enable = true;
+  hardware.nvidia.modesetting.enable = lib.mkDefault true;
 }

--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -3,4 +3,6 @@
 {
   imports = [ ../24.05-compat.nix ];
   services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
+  # TODO: this will be a default after https://github.com/NixOS/nixpkgs/pull/326369
+  hardware.nvidia.modesetting.enable = true;
 }

--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -1,13 +1,6 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 
 {
   imports = [ ../24.05-compat.nix ];
   services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
-  hardware.graphics.extraPackages = [
-    (
-      if pkgs ? libva-vdpau-driver
-      then pkgs.libva-vdpau-driver
-      else pkgs.vaapiVdpau
-    )
-  ];
 }


### PR DESCRIPTION
###### Description of changes

#### Removing libva-vdpau-driver

libva-vdpau-driver has not seen a new release in over a decade and is a common cause for bugs in some applications. NixOS has also been using the now preferred nvidia-vaapi-driver since https://github.com/NixOS/nixpkgs/pull/162660, so there isn't much reason to keep this

#### Enabling modesetting by default

This is commonly required for many applications. As of https://github.com/NixOS/nixpkgs/pull/324921 this will also enable `nvidia-drm.fbdev=1`, possibly fixing issues such as https://github.com/NixOS/nixpkgs/issues/302059. This will hopefully be done upstream in NixOS as well with https://github.com/NixOS/nixpkgs/pull/326369

CC @Mic92 based on [this](https://github.com/NixOS/nixpkgs/issues/302059#issuecomment-2222143794) comment


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

