### PR TITLE
Remove BTRFS related setting for ThinkPad x260

### DIFF
--- a/lenovo/thinkpad/x260/default.nix
+++ b/lenovo/thinkpad/x260/default.nix
@@ -9,9 +9,4 @@
     # https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X260#Thinkpad_X260
     "i915.enable_psr=0"
   ];
-
-  # https://wiki.archlinux.org/index.php/TLP#Btrfs
-  services.tlp.settings = {
-    SATA_LINKPWR_ON_BAT = "med_power_with_dipm";
-  };
 }


### PR DESCRIPTION
###### Description of changes

Remove BTRFS related setting for ThinkPad x260

The note about BTRFS has been removed from the linked Arch wiki page in January 2021 with a comment:

> Removing note about problems with Btrfs and ALPM, since issues have been fixed in the kernel (4.15 -> https://www.spinics.net/lists/linux-btrfs/msg101833.html))

See: https://wiki.archlinux.org/index.php?title=TLP&oldid=650059


###### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

