### PR TITLE
lenovo-thinkpad-z13-gen2: move to asound.conf

### DIFF
--- a/lenovo/thinkpad/z/gen2/z13/asound.conf
+++ b/lenovo/thinkpad/z/gen2/z13/asound.conf
@@ -1,0 +1,9 @@
+pcm.!default {
+	type plug
+	slave.pcm "hw:1,0"
+}
+
+ctl.!default {
+	type hw
+	card 1
+}

--- a/lenovo/thinkpad/z/gen2/z13/default.nix
+++ b/lenovo/thinkpad/z/gen2/z13/default.nix
@@ -5,15 +5,5 @@
     ../../../../../lenovo/thinkpad/z/gen2
   ];
 
-  sound.extraConfig = ''
-    pcm.!default {
-        type plug
-        slave.pcm "hw:1,0"
-    }
-
-    ctl.!default {
-        type hw
-        card 1
-    }
-  '';
+  environment.etc."asound.conf".source = ./asound.conf;
 }


### PR DESCRIPTION
###### Description of changes

`sound.*` was removed upstream in Nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
