### PR TITLE
flake.nix: export paths instead of imported files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   outputs = _: {
     nixosModules = let
       deprecated = issue: name: value: builtins.trace "warning: ${name} flake output is deprecated and will be removed. See https://github.com/NixOS/nixos-hardware/issues/${issue} for more information" value;
+      import = path: path; # let the module system know what we are exporting
     in {
       acer-aspire-4810t = import ./acer/aspire/4810t;
       airis-n990 = import ./airis/n990;


### PR DESCRIPTION
###### Description of changes

This lets the `flake.nix` export the modules as paths instead of importing them first. This should work just as well for anyone doing `imports = [ inputs.nixos-hardware.nixosModules.foo ]`, but the key difference is that the module system knows the names of the modules imported that way.
This is important for several reasons. At least it let's the module system:
* report error locations properly (instead of `<importing module>:anon-X`)
* deduplicate multiple imports of the same module
* make `disabledModules` work.
I ran into each of those problems at some point or another. There are workarounds like specifying the file path manually instead of using the indirection of the table exported via the `flake.nix`, ... but that then also bypasses the abstraction that is supposed to be provided there.

###### Implementation

One could of course remove the 280+ `import`s in `flake.nix`, but that is quite a lot of line changes, and the git-blame on this file quite nicely answers the "when was that hardware added?" question (I know that commits can be excluded from the line history, but that is not exactly elegant either).
So instead this simply shadows the `import` function with the id function.

An alternative implementation is this:
```nix
import = path: { _file = "${path}"; key = "${path}"; imports = [ (builtins.import path) ]; };
```
But that is more verbose and don't see how it is better.

Any implementation is going to break dependents who do some sort of manual transformation of the exported modules (which I have also done in the past), but that is not part of the defined `outputs` API anyway.
Medium to long term I am pretty sure this will avoid weird bugs and breakage.

###### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

