### PR TITLE
asus-rog-strix-x570e: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See code for all available configurations.
 | [Asus ROG Strix G513IM](asus/rog-strix/g513im)                         | `<nixos-hardware/asus/rog-strix/g513im>`                |
 | [Asus ROG Strix G713IE](asus/rog-strix/g713ie)                         | `<nixos-hardware/asus/rog-strix/g713ie>`                |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                         | `<nixos-hardware/asus/rog-strix/g733qs>`                |
+| [Asus ROG Strix X570-E GAMING](asus/rog-strix/x570e)                   | `<nixos-hardware/asus/rog-strix/x570e>`                 |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                     | `<nixos-hardware/asus/zephyrus/ga401>`                  |
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                     | `<nixos-hardware/asus/zephyrus/ga402>`                  |
 | [Asus ROG Zephyrus G14 GA402X* (2023)](asus/zephyrus/ga402x/amdgpu)    | `<nixos-hardware/asus/zephyrus/ga402x/amdgpu>`          |

--- a/asus/rog-strix/x570e/default.nix
+++ b/asus/rog-strix/x570e/default.nix
@@ -1,0 +1,14 @@
+# Motherboard: ROG STRIX X570-E GAMING
+{ ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/cpu/amd/zenpower.nix
+    ../../../common/pc/ssd
+  ];
+
+  # Bluetooth driver for Intel AX200 802.11ax
+  boot.kernelModules = [ "btintel" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
       asus-rog-strix-g513im = import ./asus/rog-strix/g513im;
       asus-rog-strix-g713ie = import ./asus/rog-strix/g713ie;
       asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
+      asus-rog-strix-x570e = import ./asus/rog-strix/x570e;
       asus-zenbook-ux371 = import ./asus/zenbook/ux371;
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;


### PR DESCRIPTION
###### Description of changes

This driver configuration fixes bluetooth for my host (asus-rog-strix-x570e).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

