### PR TITLE
fix: Add more aliases to 24.05-compat

### DIFF
--- a/common/gpu/24.05-compat.nix
+++ b/common/gpu/24.05-compat.nix
@@ -9,5 +9,7 @@
     (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages" ] [ "hardware" "opengl" "extraPackages" ])
     (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages32" ] [ "hardware" "opengl" "extraPackages32" ])
     (lib.mkAliasOptionModule [ "hardware" "graphics" "enable32Bit" ] [ "hardware" "opengl" "driSupport32Bit" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "package" ] [ "hardware" "opengl" "package" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "package32" ] [ "hardware" "opengl" "package32" ])
   ];
 }


### PR DESCRIPTION
###### Description of changes

I had an build error (see #1045), due to a missing alias of `hardware.graphics.package` => `hardware.opengl.package`, as well as `hardware.graphics.package32` => `hardware.opengl.package32`.

I realised this was fixable on the end of `nixos-hardware`, and thus this PR was born.

I've tested it in a Flake input on my fork, and in my configuration. The build error is no longer an issue with Nixpkgs input targeted at 24.05.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

