### PR TITLE
Create asus-zephyrus-ga402x-amdgpu and asus-zephyrus-ga402x-nvidia entries

### DIFF
--- a/asus/zephyrus/ga402x/ATTR-SET-DEPRECATION.md
+++ b/asus/zephyrus/ga402x/ATTR-SET-DEPRECATION.md
@@ -1,0 +1,16 @@
+# Deprecation of //asus/zephyrus/ga402x/default.nix
+
+Background:
+The `asus-zephyrus-ga402x` provides an attr-set with `amdgpu` and `nvidia` entries, to allow users
+to choose whether to enable only the AMD-GPU driver, or also enable the NVidia driver with (by
+default) Prime enabled.
+
+However, this attr-set style seems to be broken by [PR #1046](https://github.com/NixOS/nixos-hardware/pull/1046),
+which exports modules as paths, instead.
+That change seems to cause an error of "value is a path while a set was expected".
+
+[PR #1053](https://github.com/NixOS/nixos-hardware/pull/1053):
+- Replaced `asus-zephyrus-ga402x.amdgpu` with a `asus-zephyrus-ga402x-amdgpu` entry.
+- Replaced `asus-zephyrus-ga402x.nvidia` with a `asus-zephyrus-ga402x-nvidia` entry.
+- Made `asus-zephyrus-ga402x` throw a deprecation error.
+- [FIXES: #1052](https://github.com/NixOS/nixos-hardware/issues/1052)

--- a/asus/zephyrus/ga402x/default.nix
+++ b/asus/zephyrus/ga402x/default.nix
@@ -1,15 +1,10 @@
-## When using from a Flake, you can access these via imports of the attr key, e.g:
-#
-# imports = [
-#   nixos-hardware.nixosModules.asus-zephyrus-ga402x.amdgpu
-# ];
-#
-## or:
-# imports = [
-#   nixos-hardware.nixosModules.asus-zephyrus-ga402x.nvidia
-# ];
+{ ... }:
 
 {
-  amdgpu = import ./amdgpu;
-  nvidia = import ./nvidia;
+  assertions = [
+    {
+      assertion = false;
+      message = "Importing asus/zephyrus/ga402x/ (default.nix) directly is deprecated! #TODO: More details";
+    }
+  ];
 }

--- a/asus/zephyrus/ga402x/default.nix
+++ b/asus/zephyrus/ga402x/default.nix
@@ -4,7 +4,7 @@
   assertions = [
     {
       assertion = false;
-      message = "Importing asus/zephyrus/ga402x/ (default.nix) directly is deprecated! #TODO: More details";
+      message = "Importing asus/zephyrus/ga402x/ (default.nix) directly is deprecated! See https://github.com/NixOS/nixos-hardware/blob/master/asus/zephyrus/ga402x/ATTR-SET-DEPRECATION.md for more details";
     }
   ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
       asus-zephyrus-ga401 = import ./asus/zephyrus/ga401;
       asus-zephyrus-ga402 = import ./asus/zephyrus/ga402;
       asus-zephyrus-ga402x = import ./asus/zephyrus/ga402x;
+      asus-zephyrus-ga402x-amdgpu = import ./asus/zephyrus/ga402x/amdgpu;
+      asus-zephyrus-ga402x-nvidia = import ./asus/zephyrus/ga402x/nvidia;
       asus-zephyrus-ga502 = import ./asus/zephyrus/ga502;
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
       asus-zephyrus-gu603h = import ./asus/zephyrus/gu603h;


### PR DESCRIPTION
###### Description of changes

This PR:
- Replaces `asus-zephyrus-ga402x.amdgpu` with a `asus-zephyrus-ga402x-amdgpu` entry.
- Replaces `asus-zephyrus-ga402x.nvidia` with a `asus-zephyrus-ga402x-nvidia` entry.
- Makes `asus-zephyrus-ga402x` throw a deprecation warning.

FIXES: #1052 

Background:
The `asus-zephyrus-ga402x` provides an attr-set with `amdgpu` and `nvidia` entries, to allow users to choose whether to enable only the AMD-GPU driver, or also enable the NVidia driver with (by default) Prime enabled.

However, this attr-set style seems to be broken by PR #1046, which exports modules as paths, instead.
That change seems to cause an error of "value is a path while a set was expected".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

