### PR TITLE
framework/16-inch: Mark keyboard as internal for libinput

### DIFF
--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -26,4 +26,14 @@
 
   # Enable keyboard customization
   hardware.keyboard.qmk.enable = lib.mkDefault true;
+
+  # Allow `services.libinput.touchpad.disableWhileTyping` to work correctly.
+  # Set unconditionally because libinput can also be configured dynamically via
+  # gsettings.
+  environment.etc."libinput/local-overrides.quirks".text = ''
+    [Serial Keyboards]
+    MatchUdevType=keyboard
+    MatchName=Framework Laptop 16 Keyboard Module - ANSI Keyboard
+    AttrKeyboardIntegration=internal
+  '';
 }


### PR DESCRIPTION
This addition tells libinput that the built-in keyboard is indeed internal, allowing the "Disable-While-Typing" setting to take effect.

The method is explained at https://linuxtouchpad.org/libinput/2022/05/07/disable-while-typing.html.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

