### PR TITLE
Create lenovo-thinkpad-t14-gen5 entry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,7 @@
       lenovo-thinkpad-t14-amd-gen2 = import ./lenovo/thinkpad/t14/amd/gen2;
       lenovo-thinkpad-t14-amd-gen3 = import ./lenovo/thinkpad/t14/amd/gen3;
       lenovo-thinkpad-t14-amd-gen4 = import ./lenovo/thinkpad/t14/amd/gen4;
+      lenovo-thinkpad-t14-amd-gen5 = import ./lenovo/thinkpad/t14/amd/gen5;
       lenovo-thinkpad-t14s = import ./lenovo/thinkpad/t14s;
       lenovo-thinkpad-t14s-amd-gen1 = import ./lenovo/thinkpad/t14s/amd/gen1;
       lenovo-thinkpad-t14s-amd-gen4 = import ./lenovo/thinkpad/t14s/amd/gen4;

--- a/lenovo/thinkpad/t14/amd/gen5/default.nix
+++ b/lenovo/thinkpad/t14/amd/gen5/default.nix
@@ -1,0 +1,12 @@
+{ lib, pkgs, config, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../../common/cpu/amd/pstate.nix
+  ];
+
+  # For the Qualcomm NFA765 [17cb:1103] wireless network controller
+  # See https://bugzilla.redhat.com/show_bug.cgi?id=2047878
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
+}


### PR DESCRIPTION
###### Description of changes

Add a hardware target for Lenovo Thinkpad T14 Gen5, which uses the same settings as Gen4...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

