### PR TITLE
surface: fix isVersionOf check

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -8,7 +8,7 @@ in {
     ./kernel
   ];
 
-  microsoft-surface.kernelVersion = mkDefault "6.6";
+  microsoft-surface.kernelVersion = mkDefault "6.9";
 
   # Seems to be required to properly enable S0ix "Modern Standby":
   boot.kernelParams = mkDefault [ "mem_sleep_default=deep" ];

--- a/microsoft/surface/common/kernel/linux-package.nix
+++ b/microsoft/surface/common/kernel/linux-package.nix
@@ -48,7 +48,7 @@ let
 
   isVersionOf = kernelVersion: version:
     # Test if the provided version is considered one of the list of versions from above:
-    elem version (versionsOf version);
+    elem kernelVersion (versionsOf version);
 
 in {
   inherit linuxPackage repos surfacePatches versionsOf isVersionOf versionsOfEnum;


### PR DESCRIPTION
###### Description of changes

Fixes a kernel version check for Surface devices. Currently, `isVersionOf` is always `true` instead of testing `kernelVersion`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

