### PR TITLE
surface: linux 6.9.9 -> 6.9.12

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.9.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.9.x/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.9.9";
+  version = "6.9.12";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "1f8y88rif3z5lp1bq00g66fd0xs1227qlqkxd2zs6fdjgr45pq1b";
+    sha256 = "08ngskni7d9wi93vlwcmbdg7sb2jl1drhhzn62k9nsrg1r7crrss";
     ignoreConfigErrors=true;
   };
 


### PR DESCRIPTION
###### Description of changes

Update linux for surface to 6.9.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input


Cc: @tracteurblinde 