### PR TITLE
treewide: remove uses of lib.mdDoc

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -16,9 +16,8 @@
   };
 
   options.hardware.intelgpu.loadInInitrd =
-    lib.mkEnableOption (
-      lib.mdDoc "Load the Intel GPU kernel module at stage 1 boot. (Added to `boot.initrd.kernelModules`)"
-    )
+    lib.mkEnableOption
+      "Load the Intel GPU kernel module at stage 1 boot. (Added to `boot.initrd.kernelModules`)"
     // {
       default = true;
     };

--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -1,8 +1,8 @@
 { config, lib, ... }:
 {
-  options.hardware.framework.enableKmod = lib.mkEnableOption (lib.mdDoc
+  options.hardware.framework.enableKmod = lib.mkEnableOption
     "Enable the community created Framework kernel module that allows interacting with the embedded controller from sysfs."
-  ) // {
+  // {
     # Enable by default if on new enough version of NixOS
     default = (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05");
   };

--- a/gpd/win-max-2/2023/bmi260/default.nix
+++ b/gpd/win-max-2/2023/bmi260/default.nix
@@ -18,7 +18,7 @@ in
     hardware.sensor.iio.bmi260.enable = mkOption {
       default = false;
       type = types.bool;
-      description = mdDoc ''
+      description = ''
         Enable Bosch BMI260 IMU kernel module driver.
       '';
     };

--- a/gpd/win-max-2/default.nix
+++ b/gpd/win-max-2/default.nix
@@ -15,7 +15,7 @@ in
   # NOTICE: Whenever you can limit PPT to 15W by pressing Fn + Shift to enter quiet mode.
 
   options.hardware.gpd.ppt = {
-    enable = mkEnableOption (mdDoc "Enable PPT control for device by ryzenadj.") // {
+    enable = mkEnableOption "Enable PPT control for device by ryzenadj." // {
       # Default increase PPT to the BIOS default when power adapter plugin to increase performance.
       default = true;
     };

--- a/purism/librem/5r4/default.nix
+++ b/purism/librem/5r4/default.nix
@@ -12,18 +12,18 @@ in {
       };
       wifiCard = lib.mkOption {
         type = lib.types.enum [ "redpine" "sparklan" "none" ];
-        description = lib.mdDoc ''
+        description = ''
           Which wi-fi card is installed in your phone.
 
           Phones shipped before January 2023 have redpine, newer phones have sparklan.
         '';
         default = "redpine";
       };
-      customInitrdModules = lib.mkEnableOption (lib.mdDoc "use of custom kernel modules in the initrd.");
-      installUdevPackages = lib.mkEnableOption (lib.mdDoc "installation of udev packages from librem5-base.");
-      lockdownFix = lib.mkEnableOption (lib.mdDoc "fix for orientation and proximity sensors not working after lockdown.");
+      customInitrdModules = lib.mkEnableOption "use of custom kernel modules in the initrd.";
+      installUdevPackages = lib.mkEnableOption "installation of udev packages from librem5-base.";
+      lockdownFix = lib.mkEnableOption "fix for orientation and proximity sensors not working after lockdown.";
       audio = lib.mkOption {
-        description = lib.mdDoc ''
+        description = ''
           Whether to enable and configure PulseAudio for the Librem5 modem.
 
           This is required for audio during calls to work at all.

--- a/raspberry-pi/4/digi-amp-plus.nix
+++ b/raspberry-pi/4/digi-amp-plus.nix
@@ -13,7 +13,7 @@ in
       unmuteAmp = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           "one-shot" unmute when kernel module first loads.
         '';
       };
@@ -21,7 +21,7 @@ in
       autoMuteAmp = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = lib.mdDoc ''
+        description = ''
           Unmute the amp when an ALSA device is opened by a client. Mute, with a five-second delay when the ALSA device is closed.
           (Reopening the device within the five-second close window will cancel mute.)
         '';


### PR DESCRIPTION
###### Description of changes

`lib.mdDoc` was marked deprecated in NixOS 24.05 and has been a no-op for [quite a while](https://github.com/NixOS/nixpkgs/pull/237557). Let's remove it!

Benefits: No more trace warnings during eval.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

