### PR TITLE
On ASUS Zephyrus GA402X, make enabling auto-suspend on the keyboard optional

### DIFF
--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -8,7 +8,7 @@ let
   inherit (lib) mkDefault mkEnableOption mkIf mkMerge version versionAtLeast versionOlder;
 
   cfg = config.hardware.asus.zephyrus.ga402x;
-  defaultAutosuspendEnable = if (versionAtLeast version "6.9") then true else false;
+  defaultAutosuspendEnable = versionAtLeast config.boot.kernelPackages.kernel.version "6.9";
 
 in {
 

--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -29,7 +29,8 @@ in {
     # enables it for kernel 6.9.x onwards.
     #
     # Note: the device name is "ASUS N-KEY Device".
-    keyboard.autosuspend.enable = (mkEnableOption "Enable auto-suspend on the internal USB keyboard (ASUS N-KEY Device) on Zephyrus GA402X"
+    keyboard.autosuspend.enable = (
+      mkEnableOption "Enable auto-suspend on the internal USB keyboard (ASUS N-KEY Device) on Zephyrus GA402X"
     ) // { default = defaultAutosuspendEnable; };
   };
 
@@ -58,19 +59,14 @@ in {
             evdev:name:*:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:*
             KEYBOARD_KEY_ff31007c=f20
           '';
-        };
-      };
-    }
-
-    (mkIf (! cfg.keyboard.autosuspend.enable) {
-      services.udev = {
-        extraRules = ''
+        extraRules = mkIf (! cfg.keyboard.autosuspend.enable) ''
           # Disable auto-suspend for the ASUS N-KEY Device, i.e. USB Keyboard
           # Otherwise on certain kernel-versions, it will tend to take 1-2 key-presses to wake-up after the device suspends
           ACTION=="add", SUBSYSTEM=="usb", TEST=="power/autosuspend", ATTR{idVendor}=="0b05", ATTR{idProduct}=="19b6", ATTR{power/autosuspend}="-1"
         '';
+        };
       };
-    })
+    }
 
     (mkIf (versionOlder version "23.11") {
       # See https://asus-linux.org/wiki/nixos/ for info about some problems

--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -24,10 +24,11 @@ in {
 
   options.hardware.asus.zephyrus.ga402x = {
     # Kernels earlier than 6.9 (possibly even earlier) tend to take 1-2 key-presses
-    # to wake-up the internal keyboard after suspending (the ASUS N-KEY USB Device).
-    #
-    # Therefore, this option disables suspend for the keyboard by default, but
+    # to wake-up the internal keyboard after the device is suspended.
+    # Therefore, this option disables auto-suspend for the keyboard by default, but
     # enables it for kernel 6.9.x onwards.
+    #
+    # Note: the device name is "ASUS N-KEY Device".
     keyboard.autosuspend.enable = (mkEnableOption "Enable auto-suspend on the internal USB keyboard (ASUS N-KEY Device) on Zephyrus GA402X"
     ) // { default = defaultAutosuspendEnable; };
   };
@@ -65,7 +66,7 @@ in {
       services.udev = {
         extraRules = ''
           # Disable auto-suspend for the ASUS N-KEY Device, i.e. USB Keyboard
-          # Otherwise on certain kernel-versions, it will tend to take 1-2 key-presses to wake-up after suspending
+          # Otherwise on certain kernel-versions, it will tend to take 1-2 key-presses to wake-up after the device suspends
           ACTION=="add", SUBSYSTEM=="usb", TEST=="power/autosuspend", ATTR{idVendor}=="0b05", ATTR{idProduct}=="19b6", ATTR{power/autosuspend}="-1"
         '';
       };

--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -59,11 +59,11 @@ in {
             evdev:name:*:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:*
             KEYBOARD_KEY_ff31007c=f20
           '';
-        extraRules = mkIf (! cfg.keyboard.autosuspend.enable) ''
-          # Disable auto-suspend for the ASUS N-KEY Device, i.e. USB Keyboard
-          # Otherwise on certain kernel-versions, it will tend to take 1-2 key-presses to wake-up after the device suspends
-          ACTION=="add", SUBSYSTEM=="usb", TEST=="power/autosuspend", ATTR{idVendor}=="0b05", ATTR{idProduct}=="19b6", ATTR{power/autosuspend}="-1"
-        '';
+          extraRules = mkIf (! cfg.keyboard.autosuspend.enable) ''
+            # Disable auto-suspend for the ASUS N-KEY Device, i.e. USB Keyboard
+            # Otherwise on certain kernel-versions, it will tend to take 1-2 key-presses to wake-up after the device suspends
+            ACTION=="add", SUBSYSTEM=="usb", TEST=="power/autosuspend", ATTR{idVendor}=="0b05", ATTR{idProduct}=="19b6", ATTR{power/autosuspend}="-1"
+          '';
         };
       };
     }


### PR DESCRIPTION
###### Description of changes

The bug that seemed to make the internal keyboard on the ASUS Zephyrus GA402X take 1-2 keypresses after suspend seems to be fixed in (at least) kernel 6.9.x.

This adds an option to select to turn the auto-suspend on or off for this device.
- On kernels before 6.9.x, default to disabling auto-suspend
- On more-recent kernels, default to enabling auto-suspend

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

