### PR TITLE
fix: update fix to a closer version which fixes shutdown problems on tuxedo gen3

### DIFF
--- a/tuxedo/pulse/14/gen3/README.md
+++ b/tuxedo/pulse/14/gen3/README.md
@@ -11,5 +11,5 @@ Gen3](https://www.tuxedocomputers.com/en/TUXEDO-Pulse-14-Gen3).
 ### Shutdown and Power Issues
 
 With the Linux Kernel version `6.6.33` (NixOS 24.05) there are shutdown issues resulting in the battery not turning off
-completely. Apparently a newer Kernel (tested with `6.8.12`) fixes this (the exact version where this problem is fixed is unknown).
-This `default.nix` will upgrade to the `pkgs.linuxPackages_latest` if the kernel is older than `6.8.12`.
+completely. Apparently a newer Kernel (tested with `6.6.35`) fixes this (the exact version where this problem is fixed is unknown).
+This `default.nix` will upgrade to the `pkgs.linuxPackages_latest` if the kernel is older than `6.6.35`.

--- a/tuxedo/pulse/14/gen3/default.nix
+++ b/tuxedo/pulse/14/gen3/default.nix
@@ -14,9 +14,9 @@
 
   # Fixing a power-issue with older kernels.
   # When powered off, the battery does not turn off completely.
-  # Kernel 6.8.12 fixes this,
+  # Kernel 6.6.35 apparently does not have this issue,
   # the exact version is still unknown which fixed this.
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.8.12") (
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.6.35") (
     if (config.boot.zfs.enabled)
     then pkgs.zfs.latestCompatibleLinuxPackages
     else pkgs.linuxPackages_latest


### PR DESCRIPTION
###### Description of changes

Update to a closer kernel version which fixes the shutdown problem with Tuxedo Gen3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

