### PR TITLE
16ach6h: Use the hardware.display module

### DIFF
--- a/lenovo/legion/16ach6h/edid/default.nix
+++ b/lenovo/legion/16ach6h/edid/default.nix
@@ -8,10 +8,16 @@ let
   '';
 in
 {
-  hardware.firmware = [ chip_edid ];
+  hardware.display = {
+    edid.packages = [ chip_edid ];
 
-  # For some reason, the internal display is sometimes eDP-1, and sometimes it's eDP-2
-  boot.kernelParams = [ "drm.edid_firmware=eDP-1:edid/16ach6h.bin,eDP-2:edid/16ach6h.bin" ];
+    outputs = {
+      # For some reason, the internal display is sometimes eDP-1, and sometimes it's eDP-2
+      "eDP-1".edid = "16ach6h.bin";
+      "eDP-2".edid = "16ach6h.bin";
+    };
+  };
+
 
   # This fails at the moment, https://github.com/NixOS/nixos-hardware/issues/795
   # Extra refresh rates seem to work regardless


### PR DESCRIPTION
###### Description of changes
Slightly abstracts the EDID implementation by using the newly introduced `hardware.display` module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

