### PR TITLE
xps13-9380: enable fwupd

### DIFF
--- a/dell/xps/13-9380/README.wiki
+++ b/dell/xps/13-9380/README.wiki
@@ -3,13 +3,7 @@
 == Firmware upgrades ==
 
 Note that this device is supported by [https://fwupd.org/ fwupd].
-To perform firmware upgrades just activate the service
-
-<code>
-services.fwupd.enable = true;
-</code>
-
-Then use <code>fwupdmgr</code> to perform updates.
+To perform firmware upgrades use <code>fwupdmgr</code> to perform updates.
 
 == Battery drain when sleeping ==
 

--- a/dell/xps/13-9380/default.nix
+++ b/dell/xps/13-9380/default.nix
@@ -11,6 +11,9 @@
   # touchpad goes over i2c
   boot.blacklistedKernelModules = [ "psmouse" ];
 
+  # Allows for updating firmware via `fwupdmgr`.
+  services.fwupd.enable = true;
+
   # This will save you money and possibly your life!
   services.thermald.enable = true;
 }


### PR DESCRIPTION
###### Description of changes
Just enabling fwupd service like on any other xps13.
Also changed the wiki mentioning how to update firmware.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

