### PR TITLE
🛠 Fix intelgpu.loadInInitrd (it now does something)

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -16,14 +16,15 @@
   };
 
   options.hardware.intelgpu.loadInInitrd =
-    lib.mkEnableOption
-      "Load the Intel GPU kernel module at stage 1 boot. (Added to `boot.initrd.kernelModules`)"
+    lib.mkEnableOption "Load the Intel GPU kernel module at stage 1 boot. (Added to `boot.initrd.kernelModules`)"
     // {
       default = true;
     };
 
   config = {
-    boot.initrd.kernelModules = [ config.hardware.intelgpu.driver ];
+    boot.initrd.kernelModules = lib.optionals config.hardware.intelgpu.loadInInitrd [
+      config.hardware.intelgpu.driver
+    ];
 
     environment.variables = {
       VDPAU_DRIVER = lib.mkIf config.hardware.graphics.enable (lib.mkDefault "va_gl");


### PR DESCRIPTION
###### Description of changes
It seems that nobody except me used this option so nobody ever noticed that it does not work at all.

I don't know why but i915 driver seems to throw `failed to probe lspcon` on my dell precision 5540 for no reason when it tries to load early, especially considering that early loading works perfectly on my other nvidia optimus laptop: ideapad that has a crappy bios. My temporary solution to this is just disabling early loading but if anyone has any suggestions on how to fix it, tell me.

###### Things done
fixed the option.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

