### PR TITLE
Add Lenovo ThinkPad P14s Gen 3 (Intel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad P14s AMD Gen 2](lenovo/thinkpad/p14s/amd/gen2)        | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen2>`        |
 | [Lenovo ThinkPad P14s AMD Gen 3](lenovo/thinkpad/p14s/amd/gen3)        | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen3>`        |
 | [Lenovo ThinkPad P14s AMD Gen 4](lenovo/thinkpad/p14s/amd/gen4)        | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen4>`        |
+| [Lenovo ThinkPad P14s Intel Gen 3](lenovo/thinkpad/p14s/intel/gen3)    | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen3>`      |
 | [Lenovo ThinkPad P16s AMD Gen 1](lenovo/thinkpad/p16s/amd/gen1)        | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen1>`        |
 | [Lenovo ThinkPad P1](lenovo/thinkpad/p1)                               | `<nixos-hardware/lenovo/thinkpad/p1>`                   |
 | [Lenovo ThinkPad P50](lenovo/thinkpad/p50)                             | `<nixos-hardware/lenovo/thinkpad/p50>`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,7 @@
       lenovo-thinkpad-p14s-amd-gen2 = import ./lenovo/thinkpad/p14s/amd/gen2;
       lenovo-thinkpad-p14s-amd-gen3 = import ./lenovo/thinkpad/p14s/amd/gen3;
       lenovo-thinkpad-p14s-amd-gen4 = import ./lenovo/thinkpad/p14s/amd/gen4;
+      lenovo-thinkpad-p14s-intel-gen3 = import ./lenovo/thinkpad/p14s/intel/gen3;
       lenovo-thinkpad-p16s-amd-gen1 = import ./lenovo/thinkpad/p16s/amd/gen1;
       lenovo-thinkpad-p50 = import ./lenovo/thinkpad/p50;
       lenovo-thinkpad-p51 = import ./lenovo/thinkpad/p51;

--- a/lenovo/thinkpad/p14s/intel/default.nix
+++ b/lenovo/thinkpad/p14s/intel/default.nix
@@ -1,0 +1,8 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../common/cpu/intel
+  ];
+}

--- a/lenovo/thinkpad/p14s/intel/gen3/default.nix
+++ b/lenovo/thinkpad/p14s/intel/gen3/default.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  hardware = {
+    intelgpu.driver = "xe";
+
+    nvidia.prime = {
+      intelBusId = "PCI:0:2:0";
+      nvidiaBusId = "PCI:3:0:0";
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add basic support for Lenovo ThinkPad P14s Gen 3 (Intel) with NVIDIA graphics.

[Lenovo PSREF](https://psref.lenovo.com/WDProduct/ThinkPad/ThinkPad_P14s_Gen_3_Intel).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

