### PR TITLE
gpu/intel: cleanup vdpau variable

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -26,10 +26,6 @@
       config.hardware.intelgpu.driver
     ];
 
-    environment.variables = {
-      VDPAU_DRIVER = lib.mkIf config.hardware.graphics.enable (lib.mkDefault "va_gl");
-    };
-
     hardware.graphics.extraPackages = with pkgs; [
       (
         if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then


### PR DESCRIPTION
###### Description of changes
#1014 removed the "va_gl" driver library, but did not remove the `VDPAU_DRIVER` environment variable that overrides the VDPAU driver library selection to `libvdpau-va-gl`.

This is a problem, because if I try to run `vdpauinfo` on a hybrid graphics laptop with Intel + Nvidia, that variable points to a now nonexistent libvdpau library, so the command fails. It is reasonable to expect the user to manually provide the environment variable themselves if needed alongside the no longer recommended `libvdpau-va-gl`

----------

Note: With my hybrid graphics laptop on Xorg, `vdpauinfo` tries to select "va_gl" even without the environment variable (and also just doesn't work at all when forced to "nvidia"). On Wayland it correctly selects the Nvidia VDPAU library without any envionment variable override and works properly. In my case you can see setting the environment variable was not enough to get it working on Xorg. However, If others experience issues automatically selecting the right backend ([common](https://wiki.archlinux.org/title/Hardware_video_acceleration#Configuration)) we could to set the `VDPAU_DRIVER="nvidia"` in the nvidia library, but users may desire VDPAU on a amd integrated gpu (without an unnecessary VA-API translation library) instead of on dedicated Nvidia by default.
 ###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

