### PR TITLE
XPS 15 7590 (nvidia) use open-source driver

### DIFF
--- a/dell/xps/15-7590/nvidia/default.nix
+++ b/dell/xps/15-7590/nvidia/default.nix
@@ -9,7 +9,7 @@
     powerManagement = {
       # Enable NVIDIA power management.
       enable = lib.mkDefault true;
-      
+
       # Enable dynamic power management.
       finegrained = lib.mkDefault true;
     };
@@ -21,5 +21,7 @@
       # Bus ID of the NVIDIA GPU.
       nvidiaBusId = lib.mkDefault "PCI:1:0:0";
     };
+
+    open = lib.mkDefault true;
   };
 }


### PR DESCRIPTION
###### Description of changes
set `hardware.nvidia.open = true;` for xps 15 7590 
This fixes error induced intentionally, see https://github.com/NixOS/nixpkgs/pull/337289#issuecomment-2314851863

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

