### PR TITLE
lenovo: fix unstable wifi on Yoga laptops

### DIFF
--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -14,5 +14,10 @@
   # energy savings
   boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
 
+  # Fix for unstable wifi connection on Lenovo laptops
+  boot.extraModprobeConfig = ''
+    options rtw89_pci disable_clkreq=y disable_aspm_l1=y disable_aspm_l1ss=y
+  '';
+
   hardware.bluetooth.enable = true;
 }


### PR DESCRIPTION
###### Description of changes
Add extra modprobe options to fix unstable wifi on Yoga laptops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

