### PR TITLE
Dell: Add Nvidia Architectures

### DIFF
--- a/dell/g3/3779/default.nix
+++ b/dell/g3/3779/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../../common/cpu/intel
     ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/pascal
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];

--- a/dell/xps/15-9500/nvidia/default.nix
+++ b/dell/xps/15-9500/nvidia/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ../default.nix
     ../../../../common/gpu/nvidia/prime.nix
+    ../../../../common/gpu/nvidia/turing
   ];
 
   hardware.nvidia.prime = {

--- a/dell/xps/15-9510/nvidia/default.nix
+++ b/dell/xps/15-9510/nvidia/default.nix
@@ -1,5 +1,8 @@
 { lib, pkgs, ... }: {
-  imports = [ ../../../../common/gpu/nvidia/prime.nix ];
+  imports = [
+    ../../../../common/gpu/nvidia/prime.nix
+    ../../../../common/gpu/nvidia/ampere
+  ];
 
   #D-Bus service to check the availability of dual-GPU
   services.switcherooControl.enable = lib.mkDefault true;

--- a/dell/xps/15-9520/nvidia/default.nix
+++ b/dell/xps/15-9520/nvidia/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ../default.nix
     ../../../../common/gpu/nvidia/prime.nix
+    ../../../../common/gpu/nvidia/ampere
   ];
 
   hardware.nvidia.prime = {

--- a/dell/xps/15-9550/nvidia/default.nix
+++ b/dell/xps/15-9550/nvidia/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ../default.nix
     ../../../../common/gpu/nvidia/prime.nix
+    ../../../../common/gpu/nvidia/maxwell
   ];
 
   hardware.nvidia.prime = {

--- a/dell/xps/15-9560/default.nix
+++ b/dell/xps/15-9560/default.nix
@@ -5,6 +5,7 @@
     ../../../common/pc/laptop
     ./xps-common.nix
     ../../../common/gpu/nvidia
+    ../../../common/gpu/nvidia/pascal
   ];
 
   hardware.graphics.enable = true;

--- a/dell/xps/15-9560/nvidia/default.nix
+++ b/dell/xps/15-9560/nvidia/default.nix
@@ -6,6 +6,7 @@
     ../../../../common/gpu/nvidia/prime.nix
     ../../../../common/pc/laptop
     ../xps-common.nix
+    ../../../../common/gpu/nvidia/pascal
   ];
 
 

--- a/dell/xps/17-9700/nvidia/default.nix
+++ b/dell/xps/17-9700/nvidia/default.nix
@@ -5,6 +5,7 @@
     ../../../../common/cpu/intel
     ../../../../common/pc/laptop
     ../../../../common/gpu/nvidia/prime.nix
+    ../../../../common/gpu/nvidia/turing
     ../common.nix
   ];
 

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723310128,
-        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
+        "lastModified": 1725384549,
+        "narHash": "sha256-A9TMja7Ly70BOGcbcqJ0EUusQSFEQaKbrHJxNXfSFYY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
+        "rev": "366ddc33ff1b93d95ef3809d12ce0fba74c8d316",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1723938990,
-        "narHash": "sha256-9tUadhnZQbWIiYVXH8ncfGXGvkNq3Hag4RCBEMUk7MI=",
+        "lastModified": 1725001927,
+        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c42fcfbdfeae23e68fc520f9182dde9f38ad1890",
+        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixos-unstable-small": {
       "locked": {
-        "lastModified": 1723999580,
-        "narHash": "sha256-mVAwJQkqcVS+BU9i2YqDz61YQt/q0KRPz8vetezs7ZE=",
+        "lastModified": 1725361206,
+        "narHash": "sha256-/HTUg+kMaqBPGrcQBYboAMsQHIWIkuKRDldss/035Hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7bae0943064987c775f857b698522ff2db2df292",
+        "rev": "2830c7c930311397d94c0b86a359c865c081c875",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
###### Description of changes
Allows these configurations to build on latest nixpkgs.

Also update the flake.lock for tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

