### PR TITLE
gpd/win-mini/2024: add initial configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ See code for all available configurations.
 | [GPD Pocket 3](gpd/pocket-3)                                           | `<nixos-hardware/gpd/pocket-3>`                         |
 | [GPD WIN 2](gpd/win-2)                                                 | `<nixos-hardware/gpd/win-2>`                            |
 | [GPD WIN Max 2 2023](gpd/win-max-2/2023)                               | `<nixos-hardware/gpd/win-max-2/2023>`                   |
+| [GPD WIN Mini 2024](gpd/win-mini/2024)                                 | `<nixos-hardware/gpd/win-mini/2024>`                    |
 | [Google Pixelbook](google/pixelbook)                                   | `<nixos-hardware/google/pixelbook>`                     |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                               | `<nixos-hardware/hp/elitebook/2560p>`                   |
 | [HP Elitebook 830g6](hp/elitebook/830/g6)                              | `<nixos-hardware/hp/elitebook/830/g6>`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
       gpd-pocket-3 = import ./gpd/pocket-3;
       gpd-win-2 = import ./gpd/win-2;
       gpd-win-max-2-2023 = import ./gpd/win-max-2/2023;
+      gpd-win-mini-2024 = import ./gpd/win-mini/2024;
       hp-elitebook-2560p = import ./hp/elitebook/2560p;
       hp-elitebook-830g6 = import ./hp/elitebook/830/g6;
       hp-elitebook-845g7 = import ./hp/elitebook/845/g7;

--- a/gpd/win-mini/2024/README.md
+++ b/gpd/win-mini/2024/README.md
@@ -1,0 +1,1 @@
+# GPD Win Mini 2024

--- a/gpd/win-mini/2024/default.nix
+++ b/gpd/win-mini/2024/default.nix
@@ -8,5 +8,5 @@ with lib;
     ../../../common/gpu/amd
   ];
 
-  hardware.bluetooth.enable = true;
+  hardware.bluetooth.enable = lib.mkDefault true;
 }

--- a/gpd/win-mini/2024/default.nix
+++ b/gpd/win-mini/2024/default.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+with lib;
+{
+  imports = [
+    ./..
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+  ];
+
+  hardware.bluetooth.enable = true;
+}

--- a/gpd/win-mini/default.nix
+++ b/gpd/win-mini/default.nix
@@ -1,0 +1,17 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.hardware.gpd.ppt;
+in
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../../common/hidpi.nix
+  ];
+}


### PR DESCRIPTION
###### Description of changes
Adding support for GPD Win Mini 2024.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

