### PR TITLE
Adding Asus Zephyrus G16 GU605MY

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G14 GA402X* (2023)](asus/zephyrus/ga402x/nvidia)    | `<nixos-hardware/asus/zephyrus/ga402x/nvidia>`          |
 | [Asus ROG Zephyrus G15 GA502](asus/zephyrus/ga502)                     | `<nixos-hardware/asus/zephyrus/ga502>`                  |
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                     | `<nixos-hardware/asus/zephyrus/ga503>`                  |
+| [Asus ROG Zephyrus G16 GU605MY](asus/zephyrus/gu605my)                 | `<nixos-hardware/asus/zephyrus/gu605my>`                |
 | [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                   | `<nixos-hardware/asus/zephyrus/gu603h>`                 |
 | [Asus TUF FX504GD](asus/fx504gd)                                       | `<nixos-hardware/asus/fx504gd>`                         |
 | [Asus TUF FX506HM](asus/fx506hm)                                       | `<nixos-hardware/asus/fx506hm>`                         |

--- a/asus/zephyrus/gu605my/default.nix
+++ b/asus/zephyrus/gu605my/default.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ampere
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
       asus-zephyrus-ga502 = import ./asus/zephyrus/ga502;
       asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
       asus-zephyrus-gu603h = import ./asus/zephyrus/gu603h;
+      asus-zephyrus-gu605my = import ./asus/zephyrus/gu605my;
       beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
       chuwi-minibook-x = import ./chuwi/minibook-x;
       deciso-dec = import ./deciso/dec;


### PR DESCRIPTION
###### Description of changes
Added the configuration for my GU605MY. It's currently identical to the Zephyrus M16 GU603H and seems to be running well so far for the most part. 

###### Things done

- added module to asus/zephyrus/gu605my
- added entry to flake outputs
- added entry in README table

- [x] Tested the changes in your own NixOS Configuration
- [x] nixos Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

