### PR TITLE
lenovo-legion-15arh05h: add NVIDIA architecture

### DIFF
--- a/lenovo/legion/15arh05h/default.nix
+++ b/lenovo/legion/15arh05h/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../../common/cpu/amd
     ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/turing
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixos-hardware/issues/1100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tested with:

```diff
-    nixos-hardware.url = "github:NixOS/nixos-hardware";
+    nixos-hardware.url = "github:DontEatOreo/nixos-hardware/lenovo-legion-15arh05h-nvidia-arch";
```

Was able to rebuild, restart and log in *(on GNOME 46.4 - Wayland)*
