### PR TITLE
starlabs: init, add starlite 5 tablet

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ See code for all available configurations.
 | [Samsung Series 9 NP900X3C](samsung/np900x3c)                          | `<nixos-hardware/samsung/np900x3c>`                     |
 | [StarFive VisionFive v1](starfive/visionfive/v1)                       | `<nixos-hardware/starfive/visionfive/v1>`               |
 | [StarFive VisionFive 2](starfive/visionfive/v2)                        | `<nixos-hardware/starfive/visionfive/v2>`               |
+| [StarLabs StarLite 5 (I5)](starlabs/starlite/i5)                    | `<nixos-hardware/starlabs/starlite/i5>`                 |
 | [Supermicro A1SRi-2758F](supermicro/a1sri-2758f)                       | `<nixos-hardware/supermicro/a1sri-2758f>`               |
 | [Supermicro M11SDV-8C-LN4F](supermicro/m11sdv-8c-ln4f)                 | `<nixos-hardware/supermicro/m11sdv-8c-ln4f>`            |
 | [Supermicro X10SLL-F](supermicro/x10sll-f)                             | `<nixos-hardware/supermicro/x10sll-f>`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -266,6 +266,7 @@
       samsung-np900x3c = import ./samsung/np900x3c;
       starfive-visionfive-v1 = import ./starfive/visionfive/v1;
       starfive-visionfive-2 = import ./starfive/visionfive/v2;
+      starlabs-starlite-i5 = import ./starlabs/starlite/i5;
       supermicro = import ./supermicro;
       supermicro-a1sri-2758f = import ./supermicro/a1sri-2758f;
       supermicro-m11sdv-8c-ln4f = import ./supermicro/m11sdv-8c-ln4f;

--- a/starlabs/README.md
+++ b/starlabs/README.md
@@ -1,0 +1,10 @@
+# [Star Labs](https://starlabs.systems)
+
+Star Labs machines are made for mainline Linux and most things just work!
+
+ID new hardware based on product_sku. For example, on the StarLite 5:
+
+```console
+$ cat /sys/class/dmi/id/product_sku
+I5
+```

--- a/starlabs/starlite/i5/README.md
+++ b/starlabs/starlite/i5/README.md
@@ -1,0 +1,5 @@
+# [Star Labs StarLite 5 Tablet (I5)](https://starlabs.systems)
+
+Star Labs machines are made for mainline Linux and most things just work!
+
+The StarLite 5 is their first tablet, and the only hardware configuration oddity is an accelerometer that needs enabling and adjusting to rotate the display correctly. See the vendor's note at [support.starlabs.systems](https://support.starlabs.systems/kb/guides/starlite-fixing-rotation-on-older-kernel).

--- a/starlabs/starlite/i5/default.nix
+++ b/starlabs/starlite/i5/default.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, ... }:
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # Turn on IIO for accelerometer screen rotation.
+  hardware.sensor.iio.enable = lib.mkDefault true;
+
+  # Accelerometer is mounted to display with inverted Y axis. Adjust!
+  services.udev.extraHwdb = ''
+    sensor:modalias:acpi:KIOX000A*:dmi:*:*
+      ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Add profile for Star Labs' StarLite 5 tablet. Screen rotation is basically the only thing that didn't work out of the box--this fixes that.

@samueldr's suggestion in https://github.com/NixOS/nixos-hardware/issues/871 to identify profiles based on product_sku seemed like a good one, so that's what I'm doing here!

###### Things done

Verified proper behavior on my own hardware running Plasma v6 with this branch as flake input.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

