### PR TITLE
msigl65: add initial configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ See code for all available configurations.
 | [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                 | `<nixos-hardware/msi/b350-tomahawk>`                    |
 | [MSI GS60 2QE](msi/gs60)                                               | `<nixos-hardware/msi/gs60>`                             |
 | [MSI GL62/CX62](msi/gl62)                                              | `<nixos-hardware/msi/gl62>`                             |
+| [MSI GL65 10SDR-492](msi/gl65/10SDR-492)                               | `<nixos-hardware/msi/gl65/10SDR-492>`                   |
 | [Microchip Icicle Kit](microchip/icicle-kit)                           | `<nixos-hardware/microchip/icicle-kit>`                 |
 | [Microsoft Surface Go](microsoft/surface/surface-go)                   | `<nixos-hardware/microsoft/surface/surface-go>`         |
 | [Microsoft Surface Pro (Intel)](microsoft/surface/surface-pro-intel)   | `<nixos-hardware/microsoft/surface/surface-pro-intel>`  |
@@ -325,7 +326,7 @@ See code for all available configurations.
 | [Supermicro X12SCZ-TLN4F](supermicro/x12scz-tln4f)                     | `<nixos-hardware/supermicro/x12scz-tln4f>`              |
 | [System76 (generic)](system76)                                         | `<nixos-hardware/system76>`                             |
 | [System76 Darter Pro 6](system76/darp6)                                | `<nixos-hardware/system76/darp6>`                       |
-| [System76 Gazelle Gaze18](system76/gaze18)                             | `<nixos-hardware/system76/gaze18>`                       |
+| [System76 Gazelle Gaze18](system76/gaze18)                             | `<nixos-hardware/system76/gaze18>`                      |
 | [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                        | `<nixos-hardware/toshiba/swanky>`                       |
 | [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                       | `<nixos-hardware/tuxedo/infinitybook/v4>`               |
 | [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)    | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       |

--- a/flake.nix
+++ b/flake.nix
@@ -236,6 +236,7 @@
       msi-b550-a-pro = import ./msi/b550-a-pro;
       msi-gs60 = import ./msi/gs60;
       msi-gl62 = import ./msi/gl62;
+      msi-gl65-10SDR-492 = import ./msi/gl65/10SDR-492;
       nxp-imx8mp-evk = import ./nxp/imx8mp-evk;
       nxp-imx8mq-evk = import ./nxp/imx8mq-evk;
       nxp-imx8qm-mek = import ./nxp/imx8qm-mek;

--- a/msi/gl65/10SDR-492/default.nix
+++ b/msi/gl65/10SDR-492/default.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/pc/laptop/ssd
+    ../../../common/cpu/intel
+    ../../../common/gpu/intel/comet-lake
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/turing
+    ../../../common/pc/laptop
+  ];
+
+  hardware.bluetooth.enable = lib.mkDefault true;
+
+  hardware.graphics.enable = lib.mkDefault true;
+
+  hardware.nvidia = {
+    prime = {
+      # Bus ID of the Intel GPU.
+      intelBusId = lib.mkDefault "PCI:0:2:0";
+
+      # Bus ID of the NVIDIA GPU.
+      nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes
Add initial configuration for MSI GL65 laptop model. I believe this meets the criteria for Nvidia specification mentioned in #1100.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

