### PR TITLE
Treewide: Add new profile for Apple MacBook Pro 8,1

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See code for all available configurations.
 | [Apple MacBook Air 3,X](apple/macbook-air/3)                           | `<nixos-hardware/apple/macbook-air/3>`                  |
 | [Apple MacBook Air 4,X](apple/macbook-air/4)                           | `<nixos-hardware/apple/macbook-air/4>`                  |
 | [Apple MacBook Air 6,X](apple/macbook-air/6)                           | `<nixos-hardware/apple/macbook-air/6>`                  |
+| [Apple MacBook Pro 8,1](apple/macbook-pro/8-1)                         | `<nixos-hardware/apple/macbook-pro/8-1>`                |
 | [Apple MacBook Pro 10,1](apple/macbook-pro/10-1)                       | `<nixos-hardware/apple/macbook-pro/10-1>`               |
 | [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                       | `<nixos-hardware/apple/macbook-pro/11-5>`               |
 | [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                       | `<nixos-hardware/apple/macbook-pro/12-1>`               |

--- a/apple/macbook-pro/8-1/README.md
+++ b/apple/macbook-pro/8-1/README.md
@@ -1,0 +1,24 @@
+# MacBook Pro 8,1
+
+## Enable unfree packages in your nix config for b43-firmware (wifi driver) to work
+
+### For b43-firmware only (Ideal)
+
+```nix
+{lib, ...}:
+
+{
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+    "b43-firmware"
+  ];
+}
+
+```
+
+### For all packages
+
+```nix
+{
+  nixpkgs.config.allowUnfree = true;
+}
+```

--- a/apple/macbook-pro/8-1/default.nix
+++ b/apple/macbook-pro/8-1/default.nix
@@ -1,0 +1,11 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/pc/laptop/ssd
+  ];
+
+  networking.enableB43Firmware = lib.mkDefault true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
       apple-macbook-air-4 = import ./apple/macbook-air/4;
       apple-macbook-air-6 = import ./apple/macbook-air/6;
       apple-macbook-pro = import ./apple/macbook-pro;
+      apple-macbook-pro-8-1 = import ./apple/macbook-pro/8-1;
       apple-macbook-pro-10-1 = import ./apple/macbook-pro/10-1;
       apple-macbook-pro-11-5 = import ./apple/macbook-pro/11-5;
       apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;


### PR DESCRIPTION
###### Description of changes

I added a new profile for Apple MacBook Pro 8,1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via Flake input