### PR TITLE
Update.asus zephyrus g16 gu605my

### DIFF
--- a/asus/zephyrus/gu605my/default.nix
+++ b/asus/zephyrus/gu605my/default.nix
@@ -17,4 +17,13 @@
 
     dynamicBoost.enable = lib.mkDefault true;
   };
+
+  services = {
+    asusd.enable = lib.mkDefault true;
+
+    udev.extraHwdb = ''
+      evdev:name:*:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:*
+       KEYBOARD_KEY_ff31007c=f20    # fixes mic mute button
+    '';
+  };
 }

--- a/asus/zephyrus/gu605my/default.nix
+++ b/asus/zephyrus/gu605my/default.nix
@@ -1,16 +1,20 @@
-{ ... }:
+{ lib, ... }:
 
 {
   imports = [
     ../../../common/cpu/intel
     ../../../common/gpu/nvidia/prime.nix
-    ../../../common/gpu/nvidia/ampere
+    ../../../common/gpu/nvidia/ada-lovelace
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];
 
-  hardware.nvidia.prime = {
-    intelBusId = "PCI:0:2:0";
-    nvidiaBusId = "PCI:1:0:0";
+  hardware.nvidia = {
+    prime = {
+      intelBusId = "PCI:0:2:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+
+    dynamicBoost.enable = lib.mkDefault true;
   };
 }


### PR DESCRIPTION
###### Description of changes
- updated nvidia architecture to ada-lovelace.
- added default value nvidia dynamicBoost as it is supported by the gpu
- added default to enable asusd
- added fix in udev to correctly map the mic mute key

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

