### PR TITLE
lenovo-yoga-6-13ALC6: add mkDefault for bluetooth

### DIFF
--- a/lenovo/yoga/6/13ALC6/default.nix
+++ b/lenovo/yoga/6/13ALC6/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ...  }:
+{ lib, pkgs, ... }:
 
 {
   imports = [
@@ -9,15 +9,18 @@
   boot.initrd.kernelModules = [ "ideapad_laptop" ];
 
   # latest kernel needed to make wifi work
-  boot.kernelPackages =  lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;
 
   # energy savings
-  boot.kernelParams = ["mem_sleep_default=deep" "pcie_aspm.policy=powersupersave"];
+  boot.kernelParams = [
+    "mem_sleep_default=deep"
+    "pcie_aspm.policy=powersupersave"
+  ];
 
   # Fix for unstable wifi connection on Lenovo laptops
   boot.extraModprobeConfig = ''
     options rtw89_pci disable_clkreq=y disable_aspm_l1=y disable_aspm_l1ss=y
   '';
 
-  hardware.bluetooth.enable = true;
+  hardware.bluetooth.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
###### Description of changes
Add mkDefault for bluetooth enabling on the Lenovo Yoga 6 13ALC6 for consistency with the codebase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

