### PR TITLE
framework: fix outdated documentation on fw-ectool

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -55,7 +55,6 @@ module for your model's configuration. Otherwise, it can be added alongside the 
 
 ### fw-ectool
 
-There is a `fw-ectool` package available in nixpkgs-unstable that provides some system configuration options via the EC.
+There is a `fw-ectool` package available in nixpkgs that provides some system configuration options via the EC.
 This ectool only works with the Intel-based Framework laptops at present, as the Framework EC for AMD-based mainboards
 is based on the Zephyr port of the ChromeOS EC, which involves a slightly changed communication interface.
-


### PR DESCRIPTION
###### Description of changes

The documentation in the Framework section referenced fw-ectool only being in nixpkgs-unstable. This is no longer the case. 

###### Things done 
(It's just a documentation change, so should be fine)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

