### PR TITLE
Add system76 galp5-1650

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ See code for all available configurations.
 | [Supermicro X12SCZ-TLN4F](supermicro/x12scz-tln4f)                     | `<nixos-hardware/supermicro/x12scz-tln4f>`              |
 | [System76 (generic)](system76)                                         | `<nixos-hardware/system76>`                             |
 | [System76 Darter Pro 6](system76/darp6)                                | `<nixos-hardware/system76/darp6>`                       |
-| [System76 Gazelle Gaze18](system76/gaze18)                             | `<nixos-hardware/system76/gaze18>`                      |
+| [System76 Gazelle 18](system76/gaze18)                             | `<nixos-hardware/system76/gaze18>`                      |
+| [System76 Galago Pro 5](system76/galp5-1650)                           | `<nixos-hardware/system76/galp5-1650>`                  | 
 | [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                        | `<nixos-hardware/toshiba/swanky>`                       |
 | [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                       | `<nixos-hardware/tuxedo/infinitybook/v4>`               |
 | [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)    | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       |

--- a/flake.nix
+++ b/flake.nix
@@ -280,6 +280,7 @@
         supermicro-x12scz-tln4f = import ./supermicro/x12scz-tln4f;
         system76 = import ./system76;
         system76-gaze18 = import ./system76/gaze18;
+        system76-galp5-1650 = import ./system76/galp5-1650;
         system76-darp6 = import ./system76/darp6;
         toshiba-swanky = import ./toshiba/swanky;
         tuxedo-infinitybook-v4 = import ./tuxedo/infinitybook/v4;

--- a/system76/galp5-1650/default.nix
+++ b/system76/galp5-1650/default.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    ../.
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/gpu/nvidia/ampere
+  ];
+
+  boot.initrd.kernelModules = [ "nvidia" ];
+
+  hardware.graphics = {
+    enable = lib.mkDefault true;
+    enable32Bit = lib.mkDefault true;
+  };
+
+  hardware.nvidia = {
+
+    # modesetting.enable = lib.mkDefault true;
+
+    powerManagement.finegrained = lib.mkDefault true;
+
+    prime = {
+      intelBusId = "PCI:0:2:0";
+      nvidiaBusId = "PCI:23:0:0";
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Adds the system76 galp5 (1650 version in this case)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

