### PR TITLE
asus-rog-strix-x570: add nct6775 kernel module for temperature and fan sensor

### DIFF
--- a/asus/rog-strix/x570e/default.nix
+++ b/asus/rog-strix/x570e/default.nix
@@ -9,6 +9,8 @@
     ../../../common/pc/ssd
   ];
 
-  # Bluetooth driver for Intel AX200 802.11ax
-  boot.kernelModules = [ "btintel" ];
+  boot.kernelModules = [
+    "btintel" # Bluetooth driver for Intel AX200 802.11ax
+    "nct6775" # Temperature and Fan Sensor for Nuvoton NCT6798D-R
+  ];
 }


### PR DESCRIPTION
asus-rog-strix-x570: add nct6775 kernel module for temperature and fan sensor

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

