### PR TITLE
apple/t2: bump kernel to 6.11

### DIFF
--- a/apple/t2/pkgs/linux-t2.nix
+++ b/apple/t2/pkgs/linux-t2.nix
@@ -2,19 +2,19 @@
 , ... } @ args:
 
 let
-  version = "6.10.3";
+  version = "6.11";
   majorVersion = with lib; (elemAt (take 1 (splitVersion version)) 0);
 
   patchRepo = fetchFromGitHub {
     owner = "t2linux";
     repo = "linux-t2-patches";
-    rev = "29d6f013088303623cd9f2c6f5951eb3455830a6";
-    hash = "sha256-V0dakKRPC6Hj1I+SCiZXOCwtS0mZCCAsWnGtJnFlzxU=";
+    rev = "54b4f914930d92cf0b94601b402ec93f54a76390";
+    hash = "sha256-mpGWcx+zE5kb5USE4CPGrrleZRNGxVUGxc9eQY5IIfY=";
   };
 
   kernel = fetchzip {
     url = "mirror://kernel/linux/kernel/v${majorVersion}.x/linux-${version}.tar.xz";
-    hash = "sha256-+tWXv9j5bUJN7kzFZxuL+wB1fBCyXbtyms3Q5/dTtK4=";
+    hash = "sha256-QIbHTLWI5CaStQmuoJ1k7odQUDRLsWNGY10ek0eKo8M=";
   };
 in
 buildLinux (args // {


### PR DESCRIPTION
###### Description of changes
Update kernel patches and update kernel to 6.11 for Apple T2 devices

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

