### PR TITLE
Add Dell XPS 13 9340 and Meteor Lake

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See code for all available configurations.
 | [Dell XPS 13 9300](dell/xps/13-9300)                                   | `<nixos-hardware/dell/xps/13-9300>`                     |
 | [Dell XPS 13 9310](dell/xps/13-9310)                                   | `<nixos-hardware/dell/xps/13-9310>`                     |
 | [Dell XPS 13 9333](dell/xps/13-9333)                                   | `<nixos-hardware/dell/xps/13-9333>`                     |
+| [Dell XPS 13 9340](dell/xps/13-9340)                                   | `<nixos-hardware/dell/xps/13-9340>`                     |
 | [Dell XPS 13 9343](dell/xps/13-9343)                                   | `<nixos-hardware/dell/xps/13-9343>`                     |
 | [Dell XPS 13 9350](dell/xps/13-9350)                                   | `<nixos-hardware/dell/xps/13-9350>`                     |
 | [Dell XPS 13 9360](dell/xps/13-9360)                                   | `<nixos-hardware/dell/xps/13-9360>`                     |

--- a/common/gpu/intel/meteor-lake/default.nix
+++ b/common/gpu/intel/meteor-lake/default.nix
@@ -1,0 +1,17 @@
+{pkgs, lib, config, ...}: let inherit(lib) mkDefault mkIf; in {
+  imports = [ ../. ];
+
+	# only needed to support the i915 driver, can be found using `nix-shell -p pciutils --run "lspci -nn" | grep -oP "VGA.*:\K[0-9a-f]{4}"`
+	options.hardware.intelgpu.deviceID = lib.mkOption { description = "Intel GPU to probe"; };
+
+	config = {
+		# i915 is buggy on meteor lake, xe should be the default
+		hardware.intelgpu.driver = mkDefault "xe";
+
+		# xe driver requires newer kernel
+		boot.kernelPackages = mkIf(config.hardware.intelgpu.driver=="xe")( mkDefault pkgs.linuxPackages_latest );
+
+		# workaround that gets the i915 driver working, for those that wish to use it
+		boot.kernelParams = mkIf(config.hardware.intelgpu.driver=="i915")[ "i915.force_probe=${config.hardware.intelgpu.deviceID}" ];
+	};
+}

--- a/dell/xps/13-9340/default.nix
+++ b/dell/xps/13-9340/default.nix
@@ -1,0 +1,16 @@
+{ pkgs, lib, ... }: let inherit(lib) mkDefault; in {
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+		../../../common/gpu/intel/meteor-lake
+  ];
+
+  # Allows for updating firmware via `fwupdmgr`.
+  services.fwupd.enable = mkDefault true;
+
+  # This will save you money and possibly your life!
+  services.thermald.enable = mkDefault true;
+
+	hardware.intelgpu.deviceID = "7d55";
+}


### PR DESCRIPTION
###### Description of changes
Support for the Dell XPS 13 9340, with configuration that applies to all Meteor Lake (Core Ultra) CPUs cleanly separated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

