### PR TITLE
asus-rog-strix-x570: add troubleshooting notice for bluetooth device missing

### DIFF
--- a/asus/rog-strix/x570e/default.nix
+++ b/asus/rog-strix/x570e/default.nix
@@ -14,3 +14,13 @@
     "nct6775" # Temperature and Fan Sensor for Nuvoton NCT6798D-R
   ];
 }
+
+# Troubleshooting: Bluetooth device missing
+#   There is a known electrical design problem in ROG Strix X570-E Gaming motherboard:
+#   https://www.reddit.com/r/ASUS/comments/romkqq/bluetooth_and_wifi_stopped_working_rog_strix/
+#   Whenever Bluetooth device fails to list (sudo dmesg | grep Bluetooth; hciconfig).
+#   Consider:
+#     1. Turning off computer.
+#     2. Unplugging computer's power supply.
+#     3. Holding down power button for 15s.
+#     4. Bluetooth device should list then.


### PR DESCRIPTION
asus-rog-strix-x570: add troubleshooting notice for bluetooth device missing

Whenever someone is suffering with Bluetooth driver issue, the most likely place they'll look after a correct driver is here. And the proposed driver here won't work because odds are it's also a hardware/electrical issue. So I think, this is a good place to document this.

I have tested this on my computer, more than once. A bit weird, I know... I always forget why this goes bad and I end up thinking I have a software problem at NixOS again. Like, someone broke something at nixpkgs, but no.