### PR TITLE
only incrase font size for older kernel

### DIFF
--- a/common/hidpi.nix
+++ b/common/hidpi.nix
@@ -1,6 +1,18 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  # Starting with kernel 6.8, the console font is set in the kernel automatically to a 16x32 font:
+  # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dfd19a5004eff03755967086aa04254c3d91b8ec
+  oldKernel = lib.versionOlder config.boot.kernelPackages.kernel.version "6.8";
+in
 {
   # Just set the console font, don't mess with the font settings
-  console.font = lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz";
-  console.earlySetup = lib.mkDefault true;
+  console.font = lib.mkIf oldKernel (
+    lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz"
+  );
+  console.earlySetup = lib.mkIf oldKernel (lib.mkDefault true);
 }


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

