### PR TITLE
Remove fonts.fontconfig.dpi in Lenovo Thinkpad X1 6th Gen QHD

### DIFF
--- a/lenovo/thinkpad/x1/6th-gen/QHD/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/QHD/default.nix
@@ -6,7 +6,6 @@
 
   # Fix font sizes in X
   services.xserver.dpi = 210;
-  fonts.fontconfig.dpi = 210;
 
   # Enable readable font on console. The example configuration that
   # follows is taliored towards western languages. To see how to


### PR DESCRIPTION
###### Description of changes

Closes #350 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

