### PR TITLE
nvidia: add module to initrd

### DIFF
--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [ ../24.05-compat.nix ];
+  boot.initrd.kernelModules = [ "nvidia" ];
   services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
   # TODO: this will be a default after https://github.com/NixOS/nixpkgs/pull/326369
   hardware.nvidia.modesetting.enable = lib.mkDefault true;


### PR DESCRIPTION
So it seems sometimes needed and sometimes not.
So my question is, do we always want nvidia in initrd? At least for intel, this is the way to go.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

