### PR TITLE
Add 'mkDefault' to several settings for Asus Zephyrus GA402X

### DIFF
--- a/asus/zephyrus/ga402x/nvidia/default.nix
+++ b/asus/zephyrus/ga402x/nvidia/default.nix
@@ -27,16 +27,16 @@ in {
 
   hardware = {
     ## Enable the Nvidia card, as well as Prime and Offload:
-    amdgpu.initrd.enable = lib.mkDefault true;
+    amdgpu.initrd.enable = mkDefault true;
 
     nvidia = {
       modesetting.enable = true;
-      nvidiaSettings = true;
+      nvidiaSettings = mkDefault true;
 
       prime = {
         offload = {
-          enable = true;
-          enableOffloadCmd = true;
+          enable = mkDefault true;
+          enableOffloadCmd = mkDefault true;
         };
         amdgpuBusId = "PCI:101:0:0";
         nvidiaBusId = "PCI:1:0:0";

--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -51,7 +51,7 @@ in {
           enableUserService = mkDefault true;
         };
 
-        supergfxd.enable = true;
+        supergfxd.enable = mkDefault true;
 
         udev = {
           extraHwdb = ''


### PR DESCRIPTION
###### Description of changes

Provide mkdefault for Nvidia Settings for ASUS Zephyrus GA402X.
This is because it has to be disabled (currently) for Nvidia Driver 560.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

