### PR TITLE
intel gpu: only enable xe driver starting with lunar lake

### DIFF
--- a/asus/zenbook/ux371/default.nix
+++ b/asus/zenbook/ux371/default.nix
@@ -1,8 +1,6 @@
 {
   config,
   lib,
-  pkgs,
-  inputs,
   ...
 }:
 {
@@ -12,6 +10,9 @@
     ../../../common/pc/laptop/ssd
     ../../battery.nix
   ];
+
+  # while tiger-lake in general not supported by xe, some chipsets like this one are.
+  hardware.intelgpu.driver = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.8") "xe";
 
   boot.kernelParams = lib.mkIf (config.hardware.intelgpu.driver == "xe") [
     "i915.force_probe=!9a49"


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

