### PR TITLE
thinkpad/x1-extreme/gen3: add module

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X1 (11th Gen)](lenovo/thinkpad/x1/11th-gen)           | `<nixos-hardware/lenovo/thinkpad/x1/11th-gen>`          |
 | [Lenovo ThinkPad X1 (12th Gen)](lenovo/thinkpad/x1/12th-gen)           | `<nixos-hardware/lenovo/thinkpad/x1/12th-gen>`          |
 | [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2)    | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>`      |
+| [Lenovo ThinkPad X1 Extreme Gen 3](lenovo/thinkpad/x1-extreme/gen3)    | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen3>`      |
 | [Lenovo ThinkPad X1 Extreme Gen 4](lenovo/thinkpad/x1-extreme/gen4)    | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen4>`      |
 | [Lenovo ThinkPad X1 Nano Gen 1](lenovo/thinkpad/x1-nano/gen1)          | `<nixos-hardware/lenovo/thinkpad/x1-nano/gen1>`         |
 | [Lenovo ThinkPad X13 Yoga](lenovo/thinkpad/x13/yoga)                   | `<nixos-hardware/lenovo/thinkpad/x13/yoga>`             |

--- a/flake.nix
+++ b/flake.nix
@@ -204,6 +204,7 @@
         lenovo-thinkpad-x1-12th-gen = import ./lenovo/thinkpad/x1/12th-gen;
         lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
         lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
+        lenovo-thinkpad-x1-extreme-gen3 = import ./lenovo/thinkpad/x1-extreme/gen3;
         lenovo-thinkpad-x1-extreme-gen4 = import ./lenovo/thinkpad/x1-extreme/gen4;
         lenovo-thinkpad-x1-nano = import ./lenovo/thinkpad/x1-nano;
         lenovo-thinkpad-x1-nano-gen1 = import ./lenovo/thinkpad/x1-nano/gen1;

--- a/lenovo/thinkpad/x1-extreme/gen3/default.nix
+++ b/lenovo/thinkpad/x1-extreme/gen3/default.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../.
+  ];
+
+  # New ThinkPads have a different TrackPoint manufacturer/name.
+  hardware.trackpoint.device = "TPPS/2 Elan TrackPoint";
+
+  # Fix clickpad (clicking by depressing the touchpad).
+  boot.kernelParams = [ "psmouse.synaptics_intertouch=0" ];
+
+  # Set the right DPI. xdpyinfo says the screen is 677x423 mm but
+  # it actually is 344×215 mm.
+  services.xserver.monitorSection = lib.mkDefault ''
+    DisplaySize 344 215
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Add module for Lenovo Thinkpad X1 Extreme (Gen 3).

Gen 2 and Gen 4 were already there.

One thing that was new compared to either is a kernel parameter for the `psmouse` module which fixes clicking with the clickpad. The solution is described here: https://discourse.nixos.org/t/touchpad-click-not-working/12276

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
