### PR TITLE
Framework 16: use upstream libinput keyboard detection

### DIFF
--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -30,10 +30,16 @@
   # Allow `services.libinput.touchpad.disableWhileTyping` to work correctly.
   # Set unconditionally because libinput can also be configured dynamically via
   # gsettings.
+  #
+  # This is extracted from the quirks file that is in the upstream libinput
+  # source.  Once we can assume everyone is on at least libinput 1.26.0, this
+  # local override file can be removed.
+  # https://gitlab.freedesktop.org/libinput/libinput/-/commit/566857bd98131009699c9ab6efc7af37afd43fd0
   environment.etc."libinput/local-overrides.quirks".text = ''
-    [Serial Keyboards]
+    [Framework Laptop 16 Keyboard Module]
+    MatchName=Framework Laptop 16 Keyboard Module*
     MatchUdevType=keyboard
-    MatchName=Framework Laptop 16 Keyboard Module - ANSI Keyboard
+    MatchDMIModalias=dmi:*svnFramework:pnLaptop16*
     AttrKeyboardIntegration=internal
   '';
 }


### PR DESCRIPTION
###### Description of changes

Use the upstream libinput keyboard detection quirks configuration to ensure Framework 16 laptop keyboards are detected and treated as internal keyboards. Notably, this means that non-ANSI Framework keyboards are correctly detected and treated as being internal keyboards rather than external ones.

Also add a comment noting that this configuration is part of more recent upstream libinput releases, and that it can be removed once we no longer need to support older versions of libinput. That probably means once NixOS 24.05 is out of support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

