### PR TITLE
Framework 16: udev rules for keyboard config

### DIFF
--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -19,6 +19,12 @@
   services.udev.extraRules = ''
     # Ethernet expansion card support
     ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0bda", ATTR{idProduct}=="8156", ATTR{power/autosuspend}="20"
+
+    # Allow access to the keyboard modules for programming, for example by
+    # visiting https://keyboard.frame.work with a WebHID-compatible browser.
+    #
+    # https://community.frame.work/t/responded-help-configuring-fw16-keyboard-with-via/47176/5
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="32ac", ATTRS{idProduct}=="0012", MODE="0660", GROUP="users", TAG+="uaccess", TAG+="udev-acl"
   '';
 
   # Needed for desktop environments to detect/manage display brightness


### PR DESCRIPTION
###### Description of changes

Add a udev rule to allow the keyboard modules to be reconfigured on a Framework 16 laptop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

