### PR TITLE
asus/zephyrus/ga402x/shared.nix: no need to override default of mkEna…

### DIFF
--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -35,9 +35,7 @@ in {
     # The ASUS 8295 ITE device will cause an immediate wake-up when trying to suspend the laptop.
     # After the first successful hibernate, it will work as expected, however.
     # NOTE: I'm not actually sure what this device, as neither the touchpad nor the M1-M4 keys cause a wake-up.
-    ite-device.wakeup.enable = (
-      mkEnableOption "Enable power wakeup on the internal USB keyboard-like device (8295 ITE Device) on Zephyrus GA402X"
-    ) // { default = false; };
+    ite-device.wakeup.enable = mkEnableOption "Enable power wakeup on the internal USB keyboard-like device (8295 ITE Device) on Zephyrus GA402X";
   };
 
   config = mkMerge [


### PR DESCRIPTION
…bleOption

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

