### PR TITLE
Enable t480s gpu acceleration

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -31,7 +31,7 @@
         if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then
           vaapiIntel
         else
-          intel-vaapi-driver
+          intel-vaapi-driver.override { enableHybridCodec = true; }
       )
       intel-media-driver
     ];
@@ -41,7 +41,7 @@
         if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then
           vaapiIntel
         else
-          intel-vaapi-driver
+          intel-vaapi-driver.override { enableHybridCodec = true; }
       )
       intel-media-driver
     ];

--- a/lenovo/thinkpad/t480s/default.nix
+++ b/lenovo/thinkpad/t480s/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../../../common/cpu/intel
+    ../../../common/gpu/intel
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/ssd
     ../.


### PR DESCRIPTION
###### Description of changes

Adds support for certain hardware accelerators on the T480s's iGPU.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

