### PR TITLE
Add dell precision 5490

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ See code for all available configurations.
 | [Dell Optiplex 3050](dell/optiplex/3050)                               | `<nixos-hardware/dell/optiplex/3050>`                   |
 | [Dell Poweredge R7515](dell/poweredge/r7515)                           | `<nixos-hardware/dell/poweredge/r7515>`                 |
 | [Dell Precision 3541](dell/precision/3541)                             | `<nixos-hardware/dell/precision/3541>`                  |
+| [Dell Precision 5490](dell/precision/5490)                             | `<nixos-hardware/dell/precision/5490>`                  |
 | [Dell Precision 5530](dell/precision/5530)                             | `<nixos-hardware/dell/precision/5530>`                  |
 | [Dell Precision 7520](dell/precision/7520)                             | `<nixos-hardware/dell/precision/7520>`                  |
 | [Dell XPS 13 7390](dell/xps/13-7390)                                   | `<nixos-hardware/dell/xps/13-7390>`                     |

--- a/dell/precision/5490/README.md
+++ b/dell/precision/5490/README.md
@@ -1,15 +1,15 @@
 # Dell Precision 5490
 
-The internal monitor needs Linux Kernel >= 6.7 so enabling hybrid graphics does not work out of the box in 24.05. Setting
+Linux kernel versions prior to 6.7 may not function correctly with the internal monitor, as official support was introduced in version 6.7 (https://www.phoronix.com/news/Linux-6.7-Intel-Meteor-Lake-Gfx). You can enable experimental support by adding the following parameter:
 
 ```
 boot.kernelParams = [ "i915.force_probe=7d55" ];
 ```
 
-helped but introduced some screen tearing.
+However, this may lead to some screen tearing.
 
-Setting
+If possible, you might benefit from a newer kernel, for example:
 ```
 boot.kernelPackages = pkgs.linuxPackages_latest;
 ```
-in nixos-stable worked with no problems.
+as it seems to work without any issues.

--- a/dell/precision/5490/README.md
+++ b/dell/precision/5490/README.md
@@ -1,0 +1,15 @@
+# Dell Precision 5490
+
+The internal monitor needs Linux Kernel >= 6.7 so enabling hybrid graphics does not work out of the box in 24.05. Setting
+
+```
+boot.kernelParams = [ "i915.force_probe=7d55" ];
+```
+
+helped but introduced some screen tearing.
+
+Setting
+```
+boot.kernelPackages = pkgs.linuxPackages_latest;
+```
+in nixos-stable worked with no problems.

--- a/dell/precision/5490/default.nix
+++ b/dell/precision/5490/default.nix
@@ -7,6 +7,7 @@
   # or even better: boot.kernelParams = pkgs.linuxPackages_latest;
   boot.kernelParams = [ "i915.force_probe=7d55" ];
 
+  hardware.nvidia.open = true;
   hardware.nvidia.prime = {
     intelBusId = "PCI:0:2:0";
     nvidiaBusId = "PCI:1:0:0";

--- a/dell/precision/5490/default.nix
+++ b/dell/precision/5490/default.nix
@@ -1,13 +1,11 @@
-{ lib, ... }:
+{ config, lib, ... }:
 {
   imports = [
-    ../../../common/gpu/nvidia
+    ../../../common/gpu/nvidia/ada-lovelace
   ];
 
-  # or even better: boot.kernelParams = pkgs.linuxPackages_latest;
-  boot.kernelParams = [ "i915.force_probe=7d55" ];
+  boot.kernelParams = lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.7") [ "i915.force_probe=7d55" ];
 
-  hardware.nvidia.open = true;
   hardware.nvidia.prime = {
     intelBusId = "PCI:0:2:0";
     nvidiaBusId = "PCI:1:0:0";

--- a/dell/precision/5490/default.nix
+++ b/dell/precision/5490/default.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+{
+  imports = [
+    ../../../common/gpu/nvidia
+  ];
+
+  # or even better: boot.kernelParams = pkgs.linuxPackages_latest;
+  boot.kernelParams = [ "i915.force_probe=7d55" ];
+
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
         dell-optiplex-3050 = import ./dell/optiplex/3050;
         dell-poweredge-r7515 = import ./dell/poweredge/r7515;
         dell-precision-3541 = import ./dell/precision/3541;
+        dell-precision-5490 = import ./dell/precision/5490;
         dell-precision-5530 = import ./dell/precision/5530;
         dell-precision-5560 = import ./dell/precision/5560;
         dell-precision-7520 = import ./dell/precision/7520;


### PR DESCRIPTION
###### Description of changes

Add minimal configuration for dell precision 5490.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

