### PR TITLE
gpd-win-max-2-2023/bmi260: 0.0.2 -> 1.0.0

### DIFF
--- a/gpd/win-max-2/2023/bmi260/default.nix
+++ b/gpd/win-max-2/2023/bmi260/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 with lib;
 
@@ -28,6 +28,9 @@ in
 
   config = mkIf config.hardware.sensor.iio.bmi260.enable {
     boot.extraModulePackages = [ bmi260 ];
-    boot.kernelModules = [ "bmi260_core" "bmi260_i2c" ];
+    boot.kernelModules = [
+      "bmi260_core"
+      "bmi260_i2c"
+    ];
   };
 }

--- a/gpd/win-max-2/2023/bmi260/package.nix
+++ b/gpd/win-max-2/2023/bmi260/package.nix
@@ -1,28 +1,26 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchurl
-, kernel
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
 }:
 
 stdenv.mkDerivation (finalAttr: {
   pname = "bmi260";
-  version = "0.0.2";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "hhd-dev";
     repo = finalAttr.pname;
     rev = "v${finalAttr.version}";
-    hash = "sha256-J0npD75QqOGY1QUoznBjQ+jX28gq5u6b0JZOseclwE8=";
+    hash = "sha256-EFous0pPpCuVoCsFz6/4NryQRSH9Jw9Qng+RY1hiX1c=";
   };
 
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = [
-    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
+  makeFlags = [ "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   installPhase = ''
     runHook preInstall
@@ -34,8 +32,11 @@ stdenv.mkDerivation (finalAttr: {
 
   meta = with lib; {
     homepage = "https://github.com/hhd-dev/bmi260";
-    description = "A kernel module driver for the Bosch BMI260 IMU";
-    license = with licenses; [ bsd3 gpl2Only ];
+    description = "A kernel driver for the Bosch BMI260 IMU";
+    license = with licenses; [
+      bsd3
+      gpl2Only
+    ];
     maintainers = with maintainers; [ Cryolitia ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes

Upstream: https://github.com/hhd-dev/bmi260/releases/tag/v1.0.0

Reformat with `nixfmt-rfc-style`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

