### PR TITLE
common/gpu/nvidia/default.nix: the PR was merged for modesettings

### DIFF
--- a/common/gpu/nvidia/default.nix
+++ b/common/gpu/nvidia/default.nix
@@ -3,6 +3,4 @@
 {
   imports = [ ../24.05-compat.nix ];
   services.xserver.videoDrivers = lib.mkDefault [ "nvidia" ];
-  # TODO: this will be a default after https://github.com/NixOS/nixpkgs/pull/326369
-  hardware.nvidia.modesetting.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
The NVIDIA modesetting is now enabled by default for driver versions 535 and above this option is no longer needed.

###### Description of changes

Removes `hardware.nvidia.modesetting.enable = lib.mkDefault true;` as the PR was merged and it is no longer needed to be set by nixos-hardware.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

