### PR TITLE
fix vulkan on Gaze18

### DIFF
--- a/system76/gaze18/default.nix
+++ b/system76/gaze18/default.nix
@@ -6,7 +6,7 @@
     ../../common/gpu/nvidia/ampere
   ];
 
-  boot.initrd.kernelModules = [ "nvidia" ];
+  boot.initrd.kernelModules = [ "nvidia" "i915" "nvidia_modeset" "nvidia_drm" ];
 
   hardware.graphics = {
     enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes
Finally managed to get vulkan to work on the Gaze18

###### Things done
changed the boot.initrd.kernelModules

- [ x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

