### PR TITLE
microsoft/surface:  Update to kernel 6.10.10

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.10.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.10.x/default.nix
@@ -7,7 +7,7 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.10.5";
+  version = "6.10.10";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;

--- a/microsoft/surface/common/kernel/linux-6.10.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.10.x/default.nix
@@ -14,7 +14,7 @@ let
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "02yckkh6sxvcrwzbqgmw4jhqhxmbvz87xn9wm6bwwka3w2r9x41h";
+    hash = "sha256-5ofnNbXrnvttZ7QkM8k/yRGBBqmVUU8GJlKHO16Am80=";
     ignoreConfigErrors=true;
   };
 

--- a/microsoft/surface/common/kernel/linux-6.10.x/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.10.x/patches.nix
@@ -11,9 +11,9 @@
     extraStructuredConfig = with kernel; {
       STAGING_MEDIA = yes;
 
-      #
-      # Surface Aggregator Module
-      #
+      ##
+      ## Surface Aggregator Module
+      ##
       SURFACE_AGGREGATOR = module;
       # SURFACE_AGGREGATOR_ERROR_INJECTION is not set
       SURFACE_AGGREGATOR_BUS = yes;
@@ -31,6 +31,9 @@
 
       BATTERY_SURFACE = module;
       CHARGER_SURFACE = module;
+
+      SENSORS_SURFACE_TEMP = module;
+      SENSORS_SURFACE_FAN = module;
 
       ##
       ## Surface Hotplug
@@ -74,6 +77,12 @@
       ## ALS Sensor for Surface Book 3, Surface Laptop 3, Surface Pro 7
       ##
       APDS9960 = module;
+
+      ##
+      ## Build-in UFS support (required for some Surface Go devices)
+      ##
+      SCSI_UFSHCD = module;
+      SCSI_UFSHCD_PCI = module;
 
       ##
       ## Other Drivers

--- a/microsoft/surface/common/kernel/linux-6.11.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.11.x/default.nix
@@ -1,0 +1,31 @@
+ { config, lib, pkgs, ... }:
+ 
+ let
+   inherit (lib) mkIf mkOption;
+ 
+   inherit (pkgs.callPackage ../linux-package.nix { }) linuxPackage surfacePatches isVersionOf versionsOfEnum;
+ 
+   cfg = config.microsoft-surface;
+ 
+   version = "6.11.3";
+   kernelPatches = surfacePatches {
+     inherit version;
+     patchFn = ./patches.nix;
+   };
+   kernelPackages = linuxPackage {
+     inherit version kernelPatches;
+     hash = "sha256-MJCesuBDTc6XqTzZftDfq3aIoSS8Prw+z2x3beCczAs=";
+     ignoreConfigErrors=true;
+   };
+ 
+ in {
+   options.microsoft-surface.kernelVersion = mkOption {
+     type = versionsOfEnum version;
+   };
+ 
+   config = mkIf (isVersionOf cfg.kernelVersion version) {
+     boot = {
+       inherit kernelPackages;
+     };
+   };
+ }

--- a/microsoft/surface/common/kernel/linux-package.nix
+++ b/microsoft/surface/common/kernel/linux-package.nix
@@ -13,8 +13,8 @@ let
 
   linuxPackage =
     { url ? "mirror://kernel/linux/kernel/v${versions.major version}.x/linux-${version}.tar.xz",
-      sha256 ? null,
-      src ? (fetchurl { inherit url sha256; }),
+      hash ? null,
+      src ? (fetchurl { inherit url hash; }),
       version,
       modDirVersion ? (versions.pad 3 version),
       kernelPatches ? [],
@@ -24,7 +24,7 @@ let
 
       args' = {
         inherit src version modDirVersion kernelPatches;
-      } // removeAttrs args [ "url" "sha256" ];
+      } // removeAttrs args [ "url" "hash" ];
       linuxPackage = buildLinux args';
       linuxPackages' = recurseIntoAttrs (linuxPackagesFor linuxPackage);
     in linuxPackages';

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "arch-6.10.3-1";
-    hash = "sha256-T7voXofI5W+YodHB2DtNSKKc4iUlN3NS0onP4TKFvQM=";
+    rev = "arch-6.10.10-1";
+    hash = "sha256-AX48oDmzzEoYQkCmF/201opXuVofwGMUI9qvRt+YVHc=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -9,24 +9,24 @@
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:
-  linux-surface-kernel = { rev, sha256 }:
+  linux-surface-kernel = { rev, hash }:
     fetchFromGitHub {
       owner = "linux-surface";
       repo = "kernel";
-      inherit rev sha256;
+      inherit rev hash;
     };
 
   ath10k-firmware = fetchFromGitHub {
     owner = "kvalo";
     repo = "ath10k-firmware";
     rev = "c987e38cbdb90dcb4e477d5dd21de66c77996435";
-    sha256 = "16a67baxlga8vb43zbby2s7kpp4488vczg3manmr9g3wxnhhb9n3";
+    hash = "sha256-w6YFoe18vJSrVXW8zzZChNw7jxZ+rT/I2kg92tU6Rpk=";
   };
 
   surface-go-ath10k-firmware_backup = fetchFromGitHub {
     owner = "mexisme";
     repo = "linux-surface_ath10k-firmware";
     rev = "74e5409e699383d6ca2bc4da4a8433d16f3850b1";
-    sha256 = "169vgvxpgad9anmchs22fj5qm6ahzjfdnwhd8pc280q705vx6pjk";
+    hash = "sha256-AX48oDmzzEoYQkCmF/201opXuVofwGMUI9qvRt+YVHc=";
   };
 }


### PR DESCRIPTION
###### Description of changes

Update the default kernel to 6.10.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

