### PR TITLE
microsoft/surface/common: update linux-surface kernel to 6.10.10

### DIFF
--- a/microsoft/surface/common/kernel/linux-6.10.x/default.nix
+++ b/microsoft/surface/common/kernel/linux-6.10.x/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.10.5";
+  version = "6.10.10";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "02yckkh6sxvcrwzbqgmw4jhqhxmbvz87xn9wm6bwwka3w2r9x41h";
+    sha256 = "sha256-5ofnNbXrnvttZ7QkM8k/yRGBBqmVUU8GJlKHO16Am80=";
     ignoreConfigErrors=true;
   };
 

--- a/microsoft/surface/common/kernel/linux-6.10.x/patches.nix
+++ b/microsoft/surface/common/kernel/linux-6.10.x/patches.nix
@@ -110,10 +110,6 @@
     patch = patchSrc + "/0006-ithc.patch";
   }
   {
-    name = "ms-surface/0007-surface-sam";
-    patch = patchSrc + "/0007-surface-sam.patch";
-  }
-  {
     name = "ms-surface/0008-surface-sam-over-hid";
     patch = patchSrc + "/0008-surface-sam-over-hid.patch";
   }

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "arch-6.10.3-1";
-    hash = "sha256-T7voXofI5W+YodHB2DtNSKKc4iUlN3NS0onP4TKFvQM=";
+    rev = "arch-6.10.10-1";
+    hash = "sha256-F6AcXiL3qP9UWMEjZM/1lkT0y6tc/dQBnEYisw8M2TE=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes

Updates the kernel for Microsoft Surface devices to version 6.10.10 (the latest linux-surface release). This also removes the [SAM patch](https://github.com/linux-surface/linux-surface/blob/master/patches/6.10/0007-surface-sam.patch) due to it already being included in the 6.10 kernel and causing a build failure.

Output of `sensors` with the SAM patch removed:

```sh
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +41.0°C  (high = +100.0°C, crit = +100.0°C)
Core 0:        +35.0°C  (high = +100.0°C, crit = +100.0°C)
Core 4:        +41.0°C  (high = +100.0°C, crit = +100.0°C)
Core 8:        +40.0°C  (high = +100.0°C, crit = +100.0°C)
Core 9:        +40.0°C  (high = +100.0°C, crit = +100.0°C)
Core 10:       +40.0°C  (high = +100.0°C, crit = +100.0°C)
Core 11:       +40.0°C  (high = +100.0°C, crit = +100.0°C)
Core 12:       +38.0°C  (high = +100.0°C, crit = +100.0°C)
Core 13:       +38.0°C  (high = +100.0°C, crit = +100.0°C)
Core 14:       +38.0°C  (high = +100.0°C, crit = +100.0°C)
Core 15:       +39.0°C  (high = +100.0°C, crit = +100.0°C)

nvme-pci-0200
Adapter: PCI adapter
Composite:    +35.9°C  (low  =  -0.1°C, high = +85.8°C)
                       (crit = +87.8°C)
Sensor 1:     +35.9°C  (low  = -273.1°C, high = +65261.8°C)

iwlwifi_1-virtual-0
Adapter: Virtual device
temp1:        +38.0°C  

BAT1-virtual-0
Adapter: Virtual device
in0:           8.68 V  

surface_fan-virtual-0
Adapter: Virtual device
fan1:        2998 RPM
```

###### Things done

- [X] Tested the changes in your own NixOS Configuration
  - NOTE: changes were tested using a Surface Pro 9
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

