### PR TITLE
Add architecture-specific CPU modules

### DIFF
--- a/apple/imac/14-2/default.nix
+++ b/apple/imac/14-2/default.nix
@@ -7,7 +7,7 @@
 {
   imports = [
     ../.
-    ../../../common/gpu/intel
+    ../../../common/cpu/intel
     ../../../common/gpu/nvidia
     ../../../common/gpu/nvidia/kepler
     ../../../common/hidpi.nix

--- a/apple/imac/18-2/default.nix
+++ b/apple/imac/18-2/default.nix
@@ -6,8 +6,7 @@
 }: {
   imports = [
     ../.
-    ../../../common/gpu/intel/kaby-lake
-    ../../../common/gpu/intel
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/gpu/amd
     ../../../common/hidpi.nix
     ../../../common/pc/laptop/ssd

--- a/apple/macbook-air/3/default.nix
+++ b/apple/macbook-air/3/default.nix
@@ -3,13 +3,11 @@
 {
   imports = [ 
     ../../.
+    ../../../common/cpu/intel
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];
 
   # Built-in iSight is recognized by the generic uvcvideo kernel module
   hardware.facetimehd.enable = false;
-
-  hardware.cpu.intel.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
 }

--- a/apple/macbook-air/4/default.nix
+++ b/apple/macbook-air/4/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../.
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
   ];
 
   boot.kernelParams = [

--- a/apple/macbook-pro/14-1/default.nix
+++ b/apple/macbook-pro/14-1/default.nix
@@ -6,8 +6,7 @@
 }: {
   imports = [
     ../.
-    ../../../common/gpu/intel/kaby-lake
-    ../../../common/gpu/intel
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/hidpi.nix
     ../../../common/pc/laptop/ssd
     ../../../common/pc/laptop/acpi_call.nix

--- a/apple/macbook-pro/8-1/default.nix
+++ b/apple/macbook-pro/8-1/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../.
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc/laptop/ssd
   ];
 

--- a/asus/zenbook/ux371/default.nix
+++ b/asus/zenbook/ux371/default.nix
@@ -5,7 +5,7 @@
 }:
 {
   imports = [
-    ../../../common/gpu/intel/tiger-lake
+    ../../../common/cpu/intel/tiger-lake
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
     ../../battery.nix

--- a/common/cpu/intel/bay-trail/cpu-only.nix
+++ b/common/cpu/intel/bay-trail/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/bay-trail/default.nix
+++ b/common/cpu/intel/bay-trail/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./cpu-only.nix
+    ../../../gpu/intel/bay-trail
+  ];
+}

--- a/common/cpu/intel/braswell/cpu-only.nix
+++ b/common/cpu/intel/braswell/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/braswell/default.nix
+++ b/common/cpu/intel/braswell/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/braswell
+  ];
+}

--- a/common/cpu/intel/broadwell/cpu-only.nix
+++ b/common/cpu/intel/broadwell/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/broadwell/default.nix
+++ b/common/cpu/intel/broadwell/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/broadwell
+  ];
+}

--- a/common/cpu/intel/comet-lake/cpu-only.nix
+++ b/common/cpu/intel/comet-lake/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/comet-lake/default.nix
+++ b/common/cpu/intel/comet-lake/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/comet-lake
+  ];
+}

--- a/common/cpu/intel/elkhart-lake/cpu-only.nix
+++ b/common/cpu/intel/elkhart-lake/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/elkhart-lake/default.nix
+++ b/common/cpu/intel/elkhart-lake/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/elkhart-lake
+  ];
+}

--- a/common/cpu/intel/haswell/cpu-only.nix
+++ b/common/cpu/intel/haswell/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/haswell/default.nix
+++ b/common/cpu/intel/haswell/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/haswell
+  ];
+}

--- a/common/cpu/intel/jasper-lake/cpu-only.nix
+++ b/common/cpu/intel/jasper-lake/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/jasper-lake/default.nix
+++ b/common/cpu/intel/jasper-lake/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/jasper-lake
+  ];
+}

--- a/common/cpu/intel/kaby-lake/cpu-only.nix
+++ b/common/cpu/intel/kaby-lake/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/kaby-lake/default.nix
+++ b/common/cpu/intel/kaby-lake/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/kaby-lake
+  ];
+}

--- a/common/cpu/intel/sandy-bridge/cpu-only.nix
+++ b/common/cpu/intel/sandy-bridge/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/sandy-bridge/default.nix
+++ b/common/cpu/intel/sandy-bridge/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/sandy-bridge
+  ];
+}

--- a/common/cpu/intel/tiger-lake/cpu-only.nix
+++ b/common/cpu/intel/tiger-lake/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/tiger-lake/default.nix
+++ b/common/cpu/intel/tiger-lake/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../cpu-only.nix
+    ../../../gpu/intel/tiger-lake
+  ];
+}

--- a/dell/inspiron/5509/default.nix
+++ b/dell/inspiron/5509/default.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   imports = [
-    ../../../common/gpu/intel/tiger-lake
+    ../../../common/cpu/intel/tiger-lake
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];

--- a/dell/precision/5560/default.nix
+++ b/dell/precision/5560/default.nix
@@ -3,8 +3,7 @@
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/tiger-lake
+    ../../../common/cpu/intel/tiger-lake
     ../../../common/gpu/nvidia/turing
   ];
 

--- a/dell/precision/7520/default.nix
+++ b/dell/precision/7520/default.nix
@@ -4,7 +4,7 @@
   ...
 }: {
   imports = [
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
     ../../../common/gpu/nvidia

--- a/dell/xps/13-9300/default.nix
+++ b/dell/xps/13-9300/default.nix
@@ -6,7 +6,6 @@ let
 in {
   imports = [
     ../../../common/cpu/intel
-    ../../../common/gpu/intel
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/ssd

--- a/dell/xps/13-9360/default.nix
+++ b/dell/xps/13-9360/default.nix
@@ -1,6 +1,6 @@
 {
   imports = [
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop
   ];
 

--- a/dell/xps/13-9370/default.nix
+++ b/dell/xps/13-9370/default.nix
@@ -2,7 +2,7 @@
 
 {
   imports = [
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop
     ../../../common/pc/laptop/acpi_call.nix
   ];

--- a/dell/xps/15-9560/default.nix
+++ b/dell/xps/15-9560/default.nix
@@ -1,7 +1,6 @@
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop
     ./xps-common.nix
     ../../../common/gpu/nvidia

--- a/dell/xps/15-9560/intel/default.nix
+++ b/dell/xps/15-9560/intel/default.nix
@@ -1,7 +1,6 @@
 {
   imports = [
-    ../../../../common/cpu/intel
-    ../../../../common/gpu/intel/kaby-lake
+    ../../../../common/cpu/intel/kaby-lake
     ../../../../common/pc/laptop
     ../../../../common/gpu/nvidia/disable.nix
     ../xps-common.nix

--- a/dell/xps/15-9570/default.nix
+++ b/dell/xps/15-9570/default.nix
@@ -1,8 +1,7 @@
 { lib, ... }:
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop
     ./xps-common.nix
   ];

--- a/google/pixelbook/default.nix
+++ b/google/pixelbook/default.nix
@@ -4,6 +4,6 @@
   imports = [
     ../../common/pc/laptop
     ../../common/pc/laptop/ssd
-    ../../common/gpu/intel/kaby-lake
+    ../../common/cpu/intel/kaby-lake
   ];
 }

--- a/gpd/p2-max/default.nix
+++ b/gpd/p2-max/default.nix
@@ -2,8 +2,7 @@
   imports = [
     ../../common/pc/laptop
     ../../common/pc/laptop/ssd
-    ../../common/cpu/intel
-    ../../common/gpu/intel/kaby-lake
+    ../../common/cpu/intel/kaby-lake
     ../../common/hidpi.nix
   ];
 }

--- a/hardkernel/odroid-h3/default.nix
+++ b/hardkernel/odroid-h3/default.nix
@@ -1,5 +1,5 @@
 {
   imports = [
-    ../../common/gpu/intel/jasper-lake
+    ../../common/cpu/intel/jasper-lake
   ];
 }

--- a/hp/elitebook/2560p/default.nix
+++ b/hp/elitebook/2560p/default.nix
@@ -2,8 +2,7 @@
 with lib;
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc
     ../../../common/pc/laptop
     ../../../common/pc/laptop/hdd

--- a/hp/laptop/14s-dq2024nf/default.nix
+++ b/hp/laptop/14s-dq2024nf/default.nix
@@ -2,8 +2,7 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/tiger-lake
+    ../../../common/cpu/intel/tiger-lake
     ../../../common/pc
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd

--- a/hp/notebook/14-df0023/default.nix
+++ b/hp/notebook/14-df0023/default.nix
@@ -2,8 +2,7 @@
 with lib;
 {
   imports = [
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc
     ../../../common/pc/laptop
     ../../../common/pc/laptop/hdd

--- a/huawei/machc-wa/default.nix
+++ b/huawei/machc-wa/default.nix
@@ -5,8 +5,7 @@
   ...
 }: {
   imports = [
-    ../../common/cpu/intel
-    ../../common/gpu/intel/comet-lake
+    ../../common/cpu/intel/comet-lake
     ../../common/gpu/nvidia
     ../../common/gpu/nvidia/prime.nix
     ../../common/hidpi.nix

--- a/lenovo/thinkpad/e470/default.nix
+++ b/lenovo/thinkpad/e470/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../.
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/gpu/nvidia/prime.nix
     ../../../common/gpu/nvidia/maxwell
   ];

--- a/lenovo/thinkpad/l480/default.nix
+++ b/lenovo/thinkpad/l480/default.nix
@@ -2,7 +2,7 @@
 {
   imports = [
     ../.
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop/ssd
   ];
 

--- a/lenovo/thinkpad/p51/default.nix
+++ b/lenovo/thinkpad/p51/default.nix
@@ -3,8 +3,7 @@
     ../../../common/gpu/24.05-compat.nix
     ../../../common/gpu/nvidia/prime.nix
     ../../../common/gpu/nvidia/maxwell
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/laptop/acpi_call.nix
     ../.
   ];

--- a/lenovo/thinkpad/t420/default.nix
+++ b/lenovo/thinkpad/t420/default.nix
@@ -2,7 +2,7 @@
   imports = [
     ../.
     ../tp-smapi.nix
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc/laptop/acpi_call.nix
   ];
 }

--- a/lenovo/thinkpad/t480s/default.nix
+++ b/lenovo/thinkpad/t480s/default.nix
@@ -3,7 +3,6 @@
 {
   imports = [
     ../../../common/cpu/intel
-    ../../../common/gpu/intel
     ../../../common/pc/laptop/acpi_call.nix
     ../../../common/pc/ssd
     ../.

--- a/lenovo/thinkpad/t520/default.nix
+++ b/lenovo/thinkpad/t520/default.nix
@@ -2,7 +2,7 @@
   imports = [
     ../.
     ../tp-smapi.nix
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc/laptop/acpi_call.nix
   ];
 }

--- a/lenovo/thinkpad/w520/default.nix
+++ b/lenovo/thinkpad/w520/default.nix
@@ -2,7 +2,7 @@
   imports = [
     ../.
     ../tp-smapi.nix
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc/laptop/acpi_call.nix
   ];
 }

--- a/lenovo/thinkpad/x220/default.nix
+++ b/lenovo/thinkpad/x220/default.nix
@@ -1,7 +1,7 @@
 {
   imports = [
     ../.
-    ../../../common/gpu/intel/sandy-bridge
+    ../../../common/cpu/intel/sandy-bridge
     ../../../common/pc/laptop/hdd # TODO: reverse compat
     ../tp-smapi.nix
   ];

--- a/malibal/aon/s1/default.nix
+++ b/malibal/aon/s1/default.nix
@@ -7,7 +7,6 @@
 
     ../../../common/cpu/intel
 
-    ../../../common/gpu/intel
     ../../../common/gpu/nvidia/disable.nix
   ];
 

--- a/microsoft/surface/surface-go/default.nix
+++ b/microsoft/surface/surface-go/default.nix
@@ -13,8 +13,7 @@ in {
     ../../../common/pc
     ../../../common/pc/ssd
     # The Intel CPU module auto-includes Intel's GPU:
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/kaby-lake
+    ../../../common/cpu/intel/kaby-lake
   ];
 
   boot.kernelParams = [

--- a/msi/gl65/10SDR-492/default.nix
+++ b/msi/gl65/10SDR-492/default.nix
@@ -3,8 +3,7 @@
 {
   imports = [
     ../../../common/pc/laptop/ssd
-    ../../../common/cpu/intel
-    ../../../common/gpu/intel/comet-lake
+    ../../../common/cpu/intel/comet-lake
     ../../../common/gpu/nvidia/prime.nix
     ../../../common/gpu/nvidia/turing
     ../../../common/pc/laptop

--- a/protectli/vp4670/default.nix
+++ b/protectli/vp4670/default.nix
@@ -1,6 +1,6 @@
 {
   imports = [
-    ../../common/gpu/intel/comet-lake
+    ../../common/cpu/intel/comet-lake
   ];
 
   boot.initrd.kernelModules = [


### PR DESCRIPTION
###### Description of changes

Addresses some stuff brought up after https://github.com/NixOS/nixos-hardware/pull/1161 was merged.

Also, it turns out that the hybrid codec wasn't needed for the t480s, and it was my simultaneous changes to chromium that enabled VAAPI support. Oops.

###### Rationale

The reason why I've created so many almost-empty `cpu-only.nix` modules is to make nixos-hardware more maintainable long-term. For example, if Spectre or Meltdown are ever found to be commonly exploited in the wild, it would make sense to set `security.allowSimultaneousMultithreading = false;` for specific vulnerable architectures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

