### PR TITLE
microsoft/surface: Deprecate option to install non-upstreamed ath10k QCA6174 firmware 

### DIFF
--- a/microsoft/surface/OLD-BEHAVIOUR-DEPRECATION.md
+++ b/microsoft/surface/OLD-BEHAVIOUR-DEPRECATION.md
@@ -45,5 +45,5 @@ Most "common" modules now have an `enable` option, which is `false` by default.
 This hasn't been finalised, partly as I now only have access to a Surface Go 1, these days, so I'm
 maybe not the best custodian of this code any longer.
 
-However, hopefully the (imminent) `surface-go/` module is a reasonable exmample, and we should be
+However, hopefully the `surface-go/` module is a reasonable exmample, and we should be
 able to gather more examples for more model specialisations over time.

--- a/microsoft/surface/README.md
+++ b/microsoft/surface/README.md
@@ -91,11 +91,17 @@ See: https://github.com/linux-surface/linux-surface/blob/master/README.md
 
 ## Wifi Firmware for Surface Go
 
-On the Surface Go, the standard firmware from the official Linux Firmware repo has issues with the
-`ath10k` QCA6174 Wifi device.
-You will see messages like "Can't ping firmware".
+On the Surface Go, the standard firmware from the official Linux Firmware repo used to have issues
+with the `ath10k` QCA6174 Wifi device.
 
-The most effective fix to-date is to remove the `board-2.bin` file or replace it with a copy of the
+This was fixed in Nov 2021:
+- https://github.com/linux-surface/linux-surface/issues/542#issuecomment-976995453
+
+### Background:
+
+With the older firmware, you would see messages like "Can't ping firmware".
+
+The most effective fix was to remove the `board-2.bin` file or replace it with a copy of the
 `board.bin` file.
 
 The derivative in `surface-go/firmware/ath10k/` can configure this, with the
@@ -106,14 +112,6 @@ _*NOTE:*_ This is destructive, as it deletes all the `board.bin` and `board-2.bi
 This is the only way (currently) to force the driver to use the new firmware.
 
 For more details, see: https://github.com/linux-surface/linux-surface/wiki/Surface-Go#wifi-firmware
-
-_*NOTE:*_ There's some work to patch the kernel to make it easier to override which firmware file
-to use for QCA6174, which would obviate this more-destructuve approach:
-- https://github.com/linux-surface/kernel/commit/22ef83836c4aa89e9eb98de9b47ed24b6c2a1d45
-
-_*NOTE:*_ There was an attempt to get this firmware incorporated into the aggregate `board-2.bin`,
-but (as of this writing) the request appears to have been ignored:
-- https://github.com/linux-surface/linux-surface/issues/41
 
 References:
 - https://github.com/jakeday/linux-surface/issues/441

--- a/microsoft/surface/TODO.org
+++ b/microsoft/surface/TODO.org
@@ -11,6 +11,8 @@
 - State "DONE"       from "DOING"      [2021-03-06 Sat 20:55]
 :END:
 * Firmware
+** DONE Remove archived kvalo/ath10k-firmware repo
+- The QCA6174 firmware appears to be in the standard Linux firmware repo, now
 ** DONE Remove old firmware binaries
    - Looks like the ath10k files aren't needed, any more
 ** DONE Create derivative for `ipts` firmware

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -16,14 +16,6 @@
       inherit rev sha256;
     };
 
-  # This repo has been obsoleted:
-  ath10k-firmware = fetchFromGitHub {
-    owner = "kvalo";
-    repo = "ath10k-firmware";
-    rev = "c987e38cbdb90dcb4e477d5dd21de66c77996435";
-    sha256 = "16a67baxlga8vb43zbby2s7kpp4488vczg3manmr9g3wxnhhb9n3";
-  };
-
   surface-go-ath10k-firmware_backup = fetchFromGitHub {
     owner = "mexisme";
     repo = "linux-surface_ath10k-firmware";

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -16,6 +16,7 @@
       inherit rev sha256;
     };
 
+  # This repo has been obsoleted:
   ath10k-firmware = fetchFromGitHub {
     owner = "kvalo";
     repo = "ath10k-firmware";

--- a/microsoft/surface/surface-go/firmware/ath10k/default.nix
+++ b/microsoft/surface/surface-go/firmware/ath10k/default.nix
@@ -13,6 +13,15 @@ in {
   };
 
   config = mkIf cfg.replace {
+    warnings = [''A working version of the ath10k QCA6174 firmware has been added to the kernel.org linux-firmware
+                  repo, making this fix obsolete.
+                  See:
+                  -  https://github.com/linux-surface/linux-surface/issues/542#issuecomment-976995453
+                  - https://github.com/linux-surface/linux-surface/wiki/Surface-Go#wi-fi-firmware
+
+                  NOTE: This module option will probably be removed in the near future.
+    ''];
+
     hardware.enableAllFirmware = true;
     hardware.firmware = [
       (pkgs.callPackage ./ath10k-replace.nix {})


### PR DESCRIPTION
###### Description of changes
ath10k firmware did not fully support QCA6174 devices.
The fixed firmware was upstreamed in Nov 2021.

This adds a deprecation warning in preparation to remove this fix, in an effort to not break anyone who hasn't updated.

I expect to make a follow-up PR to remove the code to provide the non-upstreamed firmware by the end of 2024.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

