### PR TITLE
Make `nixosModules.starfive-visionfive-2` merge with sd-image

### DIFF
--- a/starfive/visionfive/v2/sd-image.nix
+++ b/starfive/visionfive/v2/sd-image.nix
@@ -5,7 +5,7 @@ in {
   imports = [
     "${modulesPath}/profiles/base.nix"
     "${modulesPath}/installer/sd-card/sd-image.nix"
-    ./default.nix
+    ./.
   ];
 
   sdImage = {


### PR DESCRIPTION
###### Description of changes

repro

```nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
  inputs.nixos-hardware.url = "github:nixos/nixos-hardware/38279034170b1e2929b2be33bdaedbf14a57bfeb";
  #inputs.nixos-hardware.url = "github:pbsds/nixos-hardware/vf2-default";
  #inputs.nixos-hardware.url = "github:pbsds/nixos-hardware/vf2-default-alt"; (this pr)

  outputs = { self, nixpkgs, nixos-hardware, ... }: {
    packages."x86_64-linux".default = (import "${nixpkgs}/nixos" {
      system = "x86_64-linux";
      configuration =
        { config, ... }: {
          imports = [
            nixos-hardware.nixosModules.starfive-visionfive-2
            "${nixos-hardware}/starfive/visionfive/v2/sd-image-installer.nix"
          ];
          sdImage.compressImage = false;
          nixpkgs.crossSystem.system = "riscv64-linux";
          system.stateVersion = "24.05";
        };
    }).config.system.build.sdImage;
  };
}
```

causes

```
error:
       … while evaluating 'strict' to select 'drvPath' on it
         at /builtin/derivation.nix:1:552:
       … while calling the 'derivationStrict' builtin
         at /builtin/derivation.nix:1:208:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: The option `boot.kernelPackages' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `/nix/store/0dgz19y045m67k3xx76rp5b8nxqci43n-source/starfive/visionfive/v2/default.nix'
       - In `/nix/store/0dgz19y045m67k3xx76rp5b8nxqci43n-source/starfive/visionfive/v2'
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

alternative fix: https://github.com/pbsds/nixos-hardware/commit/d4c8a68284b595babcf5c1026bd203649346f24c


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

