### PR TITLE
common-cpu-intel-alder-lake: init

### DIFF
--- a/common/cpu/intel/alder-lake/cpu-only.nix
+++ b/common/cpu/intel/alder-lake/cpu-only.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../cpu-only.nix
+  ];
+}

--- a/common/cpu/intel/alder-lake/default.nix
+++ b/common/cpu/intel/alder-lake/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./cpu-only.nix
+    ../../../gpu/intel/alder-lake
+  ];
+}

--- a/common/gpu/intel/kaby-lake/default.nix
+++ b/common/gpu/intel/kaby-lake/default.nix
@@ -2,6 +2,7 @@
   imports = [ ../. ];
 
   boot.kernelParams = [
+    "i915.enable_guc=2"
     "i915.enable_fbc=1"
     "i915.enable_psr=2"
   ];

--- a/flake.nix
+++ b/flake.nix
@@ -301,6 +301,7 @@
         common-cpu-amd-zenpower = import ./common/cpu/amd/zenpower.nix;
         common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
         common-cpu-intel = import ./common/cpu/intel;
+        common-cpu-intel-alder-lake = import ./common/cpu/intel/alder-lake;
         common-gpu-intel-comet-lake =
           deprecated "992" "common-gpu-intel-comet-lake"
             (import ./common/gpu/intel/comet-lake);

--- a/flake.nix
+++ b/flake.nix
@@ -301,7 +301,6 @@
         common-cpu-amd-zenpower = import ./common/cpu/amd/zenpower.nix;
         common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
         common-cpu-intel = import ./common/cpu/intel;
-        common-cpu-intel-alder-lake = import ./common/cpu/intel/alder-lake;
         common-gpu-intel-comet-lake =
           deprecated "992" "common-gpu-intel-comet-lake"
             (import ./common/gpu/intel/comet-lake);

--- a/lenovo/thinkpad/x1/6th-gen/default.nix
+++ b/lenovo/thinkpad/x1/6th-gen/default.nix
@@ -9,6 +9,7 @@
 {
   imports = [
     ../.
+    ../../../../common/cpu/intel/kaby-lake
     ../../../../common/pc/laptop/acpi_call.nix
     ../../../../common/pc/laptop/ssd
   ];


### PR DESCRIPTION
###### Description of changes

Creates a new config for intel alder lake (using the existing gpu module). Also updates the thinkpad x1 6th gen config to import the cpu architecture-specific module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

