### PR TITLE
Unload brcmfmac_wcc (if loaded) before brcmfmac

### DIFF
--- a/apple/macbook-pro/12-1/default.nix
+++ b/apple/macbook-pro/12-1/default.nix
@@ -17,7 +17,7 @@
     # Also brcmfmac could randomly crash on resume from sleep.
     powerUpCommands = lib.mkBefore "${pkgs.kmod}/bin/modprobe brcmfmac";
     powerDownCommands = lib.mkBefore ''
-      ${pkgs.kmod}/bin/lsmod | ${pkgs.gnugrep}/bin/grep -q "^brcmfmac_wcc" && ${pkgs.kmod}/bin/rmmod -f -v brcmfmac_wcc
+      ${pkgs.kmod}/bin/rmmod -f -v brcmfmac_wcc 2>/dev/null || true
       ${pkgs.kmod}/bin/rmmod brcmfmac
       '';
   };

--- a/apple/macbook-pro/12-1/default.nix
+++ b/apple/macbook-pro/12-1/default.nix
@@ -16,7 +16,10 @@
     # https://bugzilla.kernel.org/show_bug.cgi?id=101681#c116.
     # Also brcmfmac could randomly crash on resume from sleep.
     powerUpCommands = lib.mkBefore "${pkgs.kmod}/bin/modprobe brcmfmac";
-    powerDownCommands = lib.mkBefore "${pkgs.kmod}/bin/rmmod brcmfmac";
+    powerDownCommands = lib.mkBefore ''
+      ${pkgs.kmod}/bin/lsmod | ${pkgs.gnugrep}/bin/grep -q "^brcmfmac_wcc" && ${pkgs.kmod}/bin/rmmod -f -v brcmfmac_wcc
+      ${pkgs.kmod}/bin/rmmod brcmfmac
+      '';
   };
 
   # USB subsystem wakes up MBP right after suspend unless we disable it.


### PR DESCRIPTION
Module brcmfmac cannot be unloaded with rmmod when brcmfmac_wcc is loaded. This leads brcmfmac to crash on wake up.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

