### PR TITLE
common/gpu/intel: Disable intel-ocl due to web.archive.org outage

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -49,7 +49,8 @@
         enableHybridCodec = cfg.enableHybridCodec;
       };
 
-      useIntelOcl = useIntelVaapiDriver && (config.hardware.enableAllFirmware or config.nixpkgs.config.allowUnfree or false);
+      # useIntelOcl = useIntelVaapiDriver && (config.hardware.enableAllFirmware or config.nixpkgs.config.allowUnfree or false);
+      useIntelOcl = false; # web.archive.org currently isn't serving the source; for the time being, we'll disable this
       intel-ocl = pkgs.intel-ocl;
 
       useIntelMediaDriver = cfg.vaapiDriver == "intel-media-driver" || cfg.vaapiDriver == null;


### PR DESCRIPTION
###### Description of changes

Commit message is self-explanatory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

