### PR TITLE
lenovo/z/gen2/z13: Add modem fcc unlock

### DIFF
--- a/lenovo/thinkpad/z/gen2/z13/default.nix
+++ b/lenovo/thinkpad/z/gen2/z13/default.nix
@@ -6,4 +6,11 @@
   ];
 
   environment.etc."asound.conf".source = ./asound.conf;
+
+  networking.networkmanager.fccUnlockScripts = [
+    {
+      id = "2c7c:030a";
+      path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/2c7c:030a";
+    }
+  ];
 }


### PR DESCRIPTION
###### Description of changes

Add modem fcc unlock script for ThinkPad Z13 Gen2

```bash
$ lsusb | grep 2c7c:030a
Bus 001 Device 003: ID 2c7c:030a Quectel Wireless Solutions Co., Ltd. Quectel EM05-G
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

