### PR TITLE
Revert "common/gpu/intel: Disable intel-ocl due to web.archive.org outage"

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -49,8 +49,7 @@
         enableHybridCodec = cfg.enableHybridCodec;
       };
 
-      # useIntelOcl = useIntelVaapiDriver && (config.hardware.enableAllFirmware or config.nixpkgs.config.allowUnfree or false);
-      useIntelOcl = false; # web.archive.org currently isn't serving the source; for the time being, we'll disable this
+      useIntelOcl = useIntelVaapiDriver && (config.hardware.enableAllFirmware or config.nixpkgs.config.allowUnfree or false);
       intel-ocl = pkgs.intel-ocl;
 
       useIntelMediaDriver = cfg.vaapiDriver == "intel-media-driver" || cfg.vaapiDriver == null;


### PR DESCRIPTION
###### Description of changes

Now that the Internet Archive is back online, this reverts commit e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input