### PR TITLE
minisforum/v3: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ See code for all available configurations.
 | [Microsoft Surface Pro 3](microsoft/surface-pro/3)                     | `<nixos-hardware/microsoft/surface-pro/3>`              |
 | [Microsoft Surface Pro 9](microsoft/surface-pro/9)                     | `<nixos-hardware/microsoft/surface-pro/9>`              |
 | [Morefine M600](morefine/m600)                                         | `<nixos-hardware/morefine/m600>`                        |
+| [Minisforum V3](minisforum/v3)                                         | `<nixos-hardware/minisforum/v3>`                        |
 | [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                        | `<nixos-hardware/nxp/imx8mp-evk>`                       |
 | [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                        | `<nixos-hardware/nxp/imx8mq-evk>`                       |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)             | `<nixos-hardware/hardkernel/odroid-hc4>`                |
@@ -327,15 +328,15 @@ See code for all available configurations.
 | [Samsung Series 9 NP900X3C](samsung/np900x3c)                          | `<nixos-hardware/samsung/np900x3c>`                     |
 | [StarFive VisionFive v1](starfive/visionfive/v1)                       | `<nixos-hardware/starfive/visionfive/v1>`               |
 | [StarFive VisionFive 2](starfive/visionfive/v2)                        | `<nixos-hardware/starfive/visionfive/v2>`               |
-| [StarLabs StarLite 5 (I5)](starlabs/starlite/i5)                    | `<nixos-hardware/starlabs/starlite/i5>`                 |
+| [StarLabs StarLite 5 (I5)](starlabs/starlite/i5)                       | `<nixos-hardware/starlabs/starlite/i5>`                 |
 | [Supermicro A1SRi-2758F](supermicro/a1sri-2758f)                       | `<nixos-hardware/supermicro/a1sri-2758f>`               |
 | [Supermicro M11SDV-8C-LN4F](supermicro/m11sdv-8c-ln4f)                 | `<nixos-hardware/supermicro/m11sdv-8c-ln4f>`            |
 | [Supermicro X10SLL-F](supermicro/x10sll-f)                             | `<nixos-hardware/supermicro/x10sll-f>`                  |
 | [Supermicro X12SCZ-TLN4F](supermicro/x12scz-tln4f)                     | `<nixos-hardware/supermicro/x12scz-tln4f>`              |
 | [System76 (generic)](system76)                                         | `<nixos-hardware/system76>`                             |
 | [System76 Darter Pro 6](system76/darp6)                                | `<nixos-hardware/system76/darp6>`                       |
-| [System76 Gazelle 18](system76/gaze18)                             | `<nixos-hardware/system76/gaze18>`                      |
-| [System76 Galago Pro 5](system76/galp5-1650)                           | `<nixos-hardware/system76/galp5-1650>`                  | 
+| [System76 Gazelle 18](system76/gaze18)                                 | `<nixos-hardware/system76/gaze18>`                      |
+| [System76 Galago Pro 5](system76/galp5-1650)                           | `<nixos-hardware/system76/galp5-1650>`                  |
 | [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                        | `<nixos-hardware/toshiba/swanky>`                       |
 | [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                       | `<nixos-hardware/tuxedo/infinitybook/v4>`               |
 | [TUXEDO Aura 15 - Gen1](tuxedo/aura/15/gen1)                           | `<nixos-hardware/tuxedo/aura/15/gen1>`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -244,6 +244,7 @@
         microsoft-surface-pro-3 = import ./microsoft/surface-pro/3;
         microsoft-surface-pro-9 = import ./microsoft/surface-pro/9;
         milkv-pioneer = import ./milkv/pioneer;
+        minisforum-v3 = import ./minisforum/v3;
         morefine-m600 = import ./morefine/m600;
         msi-b350-tomahawk = import ./msi/b350-tomahawk;
         msi-b550-a-pro = import ./msi/b550-a-pro;

--- a/minisforum/v3/audio.nix
+++ b/minisforum/v3/audio.nix
@@ -1,0 +1,47 @@
+{ ... }:
+{
+  # Fix microphone.
+  # Based on https://github.com/mudkipme/awesome-minisforum-v3/issues/10#issuecomment-2317474057 (Volume control workaround doesn't work on Arch) 
+  boot.extraModprobeConfig = ''
+    options snd-hda-intel model=alc256-asus-aio
+  '';
+
+  # Based on https://github.com/mudkipme/awesome-minisforum-v3/issues/9#issue-2407782714 (volume control fixes for arch)
+  services.pipewire.wireplumber.extraConfig."alsa-soft-mixer"."monitor.alsa.rules" = [
+    {
+      # Enable soft-mixer.
+      # Fix global volume control.
+      actions.update-props."api.alsa.soft-mixer" = true;
+      matches = [
+        {
+          "device.name" = "~alsa_card.*";
+        }
+      ];
+    }
+    {
+      # Disable soft-mixer for input devices.
+      actions.update-props."api.alsa.soft-mixer" = false;
+      matches = [
+        {
+          "device.name" = "~alsa_card.*";
+          "node.name" = "~alsa_input.*";
+        }
+      ];
+    }
+    {
+      # Disable audio session suspension.
+      # Fix bug with plugged in headphones.
+      # Based on https://github.com/mudkipme/awesome-minisforum-v3?tab=readme-ov-file#disable-audio-session-suspension (Disable audio session suspension)
+      actions.update-props."session.suspend-timeout-seconds" = "0";
+      matches = [
+        {
+          "node.name" = "~alsa_input.*";
+        }
+        {
+          "node.name" = "~alsa_output.*";
+        }
+      ];
+    }
+  ];
+
+}

--- a/minisforum/v3/default.nix
+++ b/minisforum/v3/default.nix
@@ -1,0 +1,12 @@
+{ ... }:
+{
+  imports = [
+    ./sensors.nix
+    ./audio.nix
+    ./power.nix
+
+    ../../common/gpu/amd/default.nix
+    ../../common/cpu/amd/default.nix
+    ../../common/pc/laptop/default.nix
+  ];
+}

--- a/minisforum/v3/dsdt.patch
+++ b/minisforum/v3/dsdt.patch
@@ -1,0 +1,31 @@
+--- dsdt.dsl	2024-08-10 06:24:09.143777067 +0200
++++ patched/dsdt.dsl	2024-08-10 04:58:50.191036154 +0200
+@@ -18,7 +18,7 @@
+  *     Compiler ID      "INTL"
+  *     Compiler Version 0x20220331 (539099953)
+  */
+-DefinitionBlock ("", "DSDT", 2, "ALASKA", "A M I ", 0x01072009)
++DefinitionBlock ("", "DSDT", 2, "ALASKA", "A M I ", 0x01072019)
+ {
+     External (_SB_.APTS, MethodObj)    // 1 Arguments
+     External (_SB_.AWAK, MethodObj)    // 1 Arguments
+@@ -7341,7 +7341,7 @@
+ 
+         Device (CIND)
+         {
+-            Name (_HID, "ID9001")  // _HID: Hardware ID
++            Name (_HID, "INT33D3")  // _HID: Hardware ID
+             Name (_CID, "PNP0C60" /* Display Sensor Device */)  // _CID: Compatible ID
+             Method (_STA, 0, Serialized)  // _STA: Status
+             {
+@@ -7364,8 +7364,8 @@
+     {
+         Device (STS)
+         {
+-            Name (_HID, EisaId ("SMOCF05"))  // _HID: Hardware ID
+-            Name (_CID, EisaId ("SMOCF05"))  // _CID: Compatible ID
++            Name (_HID, EisaId ("SMO8B30"))  // _HID: Hardware ID
++            Name (_CID, EisaId ("SMO8B30"))  // _CID: Compatible ID
+             Name (_UID, Zero)  // _UID: Unique ID
+             Method (_STA, 0, NotSerialized)  // _STA: Status
+             {

--- a/minisforum/v3/power.nix
+++ b/minisforum/v3/power.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+
+  # From "Optimizing power draw (under Linux)": https://github.com/mudkipme/awesome-minisforum-v3/issues/5#issue-2391536450
+  boot.kernelParams = [ "pcie_aspm.policy=powersupersave" ];
+  systemd.services.enable-aspm = {
+    wantedBy = [ "default.target" ];
+    serviceConfig = {
+      ExecStart = "${pkgs.bash}/bin/bash ${pkgs.callPackage ./src.nix { }}/aspm_v3.sh";
+      Restart = "no";
+    };
+
+    path = with pkgs; [
+      bc
+      pciutils
+    ];
+  };
+
+}

--- a/minisforum/v3/sensors.nix
+++ b/minisforum/v3/sensors.nix
@@ -1,0 +1,44 @@
+{ pkgs, lib, ... }:
+{
+
+  # Enable IIO for brightness and accelerometer sensors
+  hardware.sensor.iio.enable = lib.mkDefault true;
+
+  services.fprintd.enable = lib.mkDefault true;
+  
+  # Override ACPI DSDT to fix the accelerometer.
+  # A driver already exists for a similar sensor.
+  # This overrides the IDs to make the existing driver work.
+  # From Accelerometer on Linux https://github.com/mudkipme/awesome-minisforum-v3/issues/2#issuecomment-2279282784
+  boot.initrd.prepend =
+    let
+      minisforum-acpi-override = pkgs.stdenv.mkDerivation {
+        name = "minisforum-acpi-override";
+        CPIO_PATH = "kernel/firmware/acpi";
+
+        src = pkgs.callPackage ./src.nix {};
+        patches = [ ./dsdt.patch ];
+
+        nativeBuildInputs = with pkgs; [
+          acpica-tools
+          cpio
+        ];
+
+        installPhase = ''
+          mkdir -p $CPIO_PATH
+          iasl -tc ./dsdt.dsl
+          cp ./dsdt.aml $CPIO_PATH
+          find kernel | cpio -H newc --create > acpi_override
+          cp acpi_override $out    
+        '';
+      };
+    in
+    [ (toString minisforum-acpi-override) ];
+
+  # Fix inverted accelerometer rotation.
+  services.udev.extraHwdb = ''
+    sensor:modalias:acpi:SMO8B30*:dmi:*svnMicroComputer*:pnV3:*
+      ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, -1, 0; 0, 0, -1
+  '';
+
+}

--- a/minisforum/v3/src.nix
+++ b/minisforum/v3/src.nix
@@ -1,0 +1,8 @@
+# Outsource (MIT License) for aspm_v3.sh and dsdt.dsl
+{ fetchFromGitHub, ... }:
+fetchFromGitHub {
+  owner = "eum3l";
+  repo = "minisforum-v3-nixos-hardware";
+  rev = "7a94dbac701640cef91ec5b1873868a512718f09";
+  hash = "sha256-V23Vuw/DV0l2c0m2hBnjZ2uey0KMeAdymnlLqXbFFUM=";
+}


### PR DESCRIPTION
###### Description of changes

> Add fixes and power settings for the Minisforum V3 3-in-1 Tablet

+ Accelerometer fixes
  + ACPI DSDT patch (Is there a better way of doing this?)
  + udev rules to fix inverted values
+ Power settings
  + Enable ASPM (Should the script even be added or behind an option?)
  + Set policy to `powersupersave`
+ Audio fixes
  + Alsa rules
  + modprobe config for microphone

###### References on mudkipme/awesome-minisforum-v3

+ [#5 - Optimizing power draw](https://github.com/mudkipme/awesome-minisforum-v3/issues/5#issue-2391536450)
+ [#2 - Accelerometer](https://github.com/mudkipme/awesome-minisforum-v3/issues/2#issuecomment-2279282784)
+ [#9 - volume control fixes](https://github.com/mudkipme/awesome-minisforum-v3/issues/9#issue-2407782714)
+ [#10 - volume control workaround](https://github.com/mudkipme/awesome-minisforum-v3/issues/10#issuecomment-2317474057)
+ [Disable audio session suspension](https://github.com/mudkipme/awesome-minisforum-v3?tab=readme-ov-file#disable-audio-session-suspension)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

