### PR TITLE
Fix "nividia" typo

### DIFF
--- a/common/gpu/nvidia/ada-lovelace/default.nix
+++ b/common/gpu/nvidia/ada-lovelace/default.nix
@@ -1,10 +1,10 @@
 {lib, config, ...}:
 let
-  nividiaPackage = config.hardware.nvidia.package;
+  nvidiaPackage = config.hardware.nvidia.package;
 in
 {
   imports = [ ../. ];
 
   # enable the open source drivers if the package supports it
-  hardware.nvidia.open = lib.mkOverride 990 (nividiaPackage ? open && nividiaPackage ? firmware);
+  hardware.nvidia.open = lib.mkOverride 990 (nvidiaPackage ? open && nvidiaPackage ? firmware);
 }

--- a/common/gpu/nvidia/ampere/default.nix
+++ b/common/gpu/nvidia/ampere/default.nix
@@ -1,10 +1,10 @@
 {lib, config, ...}:
 let
-  nividiaPackage = config.hardware.nvidia.package;
+  nvidiaPackage = config.hardware.nvidia.package;
 in
 {
   imports = [ ../. ];
 
   # enable the open source drivers if the package supports it
-  hardware.nvidia.open = lib.mkOverride 990 (nividiaPackage ? open && nividiaPackage ? firmware);
+  hardware.nvidia.open = lib.mkOverride 990 (nvidiaPackage ? open && nvidiaPackage ? firmware);
 }

--- a/common/gpu/nvidia/turing/default.nix
+++ b/common/gpu/nvidia/turing/default.nix
@@ -1,10 +1,10 @@
 {lib, config, ...}:
 let
-  nividiaPackage = config.hardware.nvidia.package;
+  nvidiaPackage = config.hardware.nvidia.package;
 in
 {
   imports = [ ../. ];
 
   # enable the open source drivers if the package supports it
-  hardware.nvidia.open = lib.mkOverride 990 (nividiaPackage ? open && nividiaPackage ? firmware);
+  hardware.nvidia.open = lib.mkOverride 990 (nvidiaPackage ? open && nvidiaPackage ? firmware);
 }


### PR DESCRIPTION
###### Description of changes
Fixed "nividia" typo.

###### Things done

I'm unsure if this change impact other things but looks like  "nividiaPackage" only referenced in these files.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

