### PR TITLE
Framework: add workaround for Bluetooth device issues

### DIFF
--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../bluetooth.nix
     ../../kmod.nix
     ../../framework-tool.nix
   ];

--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
+    ../../bluetooth.nix
     ../../kmod.nix
     ../../framework-tool.nix
   ];

--- a/framework/bluetooth.nix
+++ b/framework/bluetooth.nix
@@ -9,6 +9,7 @@
   lib,
   pkgs,
   ...
+# TODO: drop this if linux 6.11 goes EOL
 }: lib.mkIf ((config.boot.kernelPackages.kernelAtLeast "6.11") && (config.boot.kernelPackages.kernelOlder "6.12")) {
   systemd.services = {
     bluetooth-rfkill-suspend = {

--- a/framework/bluetooth.nix
+++ b/framework/bluetooth.nix
@@ -1,0 +1,37 @@
+# There is apparently a bug that affects Framework computers that causes black
+# screen on resume from sleep or hibernate with kernel version 6.11.  Framework
+# have published a workaround; this applies that workaround.
+#
+# https://fosstodon.org/@frameworkcomputer/113406887743149089
+# https://github.com/FrameworkComputer/linux-docs/blob/main/hibernation/kernel-6-11-workarounds/suspend-hibernate-bluetooth-workaround.md#workaround-for-suspendhibernate-black-screen-on-resume-kernel-611
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: lib.mkIf ((config.boot.kernelPackages.kernelAtLeast "6.11") && (config.boot.kernelPackages.kernelOlder "6.12")) {
+  systemd.services = {
+    bluetooth-rfkill-suspend = {
+      description = "Soft block Bluetooth on suspend/hibernate";
+      before = ["sleep.target"];
+      unitConfig.StopWhenUnneeded = true;
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.util-linux}/bin/rfkill block bluetooth";
+        ExecStartPost = "${pkgs.coreutils}/bin/sleep 3";
+        RemainAfterExit = true;
+      };
+      wantedBy = ["suspend.target" "hibernate.target" "suspend-then-hibernate.target"];
+    };
+
+    bluetooth-rfkill-resume = {
+      description = "Unblock Bluetooth on resume";
+      after = ["suspend.target" "hibernate.target" "suspend-then-hibernate.target"];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.util-linux}/bin/rfkill unblock bluetooth";
+      };
+      wantedBy = ["suspend.target" "hibernate.target" "suspend-then-hibernate.target"];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Framework have published a workaround for a bug that affects the MediaTek Bluetooth and Wi-Fi cards used in their laptops on kernel version 6.11.  Their workaround assumes a writable /etc/systemd directory, so reimplement the workaround for NixOS.

For the Framework version of the workaround, see:
https://github.com/FrameworkComputer/linux-docs/tree/eab0148ae8223eddaed8f0cd4cd73f9399ecdb65/hibernation/kernel-6-11-workarounds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

