### PR TITLE
common-gpu-nvidia: expose architecture modules in `nixosModules`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -321,6 +321,12 @@
         common-gpu-nvidia-sync = import ./common/gpu/nvidia/prime-sync.nix;
         common-gpu-nvidia-nonprime = import ./common/gpu/nvidia;
         common-gpu-nvidia-disable = import ./common/gpu/nvidia/disable.nix;
+        common-gpu-nvidia-ada-lovelace = import ./common/gpu/nvidia/ada-lovelace;
+        common-gpu-nvidia-ampere = import ./common/gpu/nvidia/ampere;
+        common-gpu-nvidia-kepler = import ./common/gpu/nvidia/kepler;
+        common-gpu-nvidia-maxwell = import ./common/gpu/nvidia/maxwell;
+        common-gpu-nvidia-pascal = import ./common/gpu/nvidia/pascal;
+        common-gpu-nvidia-turing = import ./common/gpu/nvidia/turing;
         common-hidpi = import ./common/hidpi.nix;
         common-pc = import ./common/pc;
         common-pc-hdd = import ./common/pc/hdd;


### PR DESCRIPTION
###### Description of changes

The architecture-specific modules for `common-gpu-nvidia` are used in the
various hardware modules for specific hardware depending on what is needed.

This works well, but it would be nice to have these exposed through the flake
`nixosModules` so that users using "generic" systems can still access these
modules in the same manner as all the others. Such as in my case, I have a
desktop system running an Nvidia Ampere GPU, but have to access the
`common/gpu/nvidia/ampere` module through its path since it is not exposed in
the flake itself.

I did not add these to the `README` since none of the other `common-gpu-nvidia`
modules are presented there. I opted to follow the trend. I can add them all if
suggested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
