### PR TITLE
apple: init MacBookPro11,1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See code for all available configurations.
 | [Apple MacBook Air 7,X](apple/macbook-air/7)                           | `<nixos-hardware/apple/macbook-air/7>`                  |
 | [Apple MacBook Pro 8,1](apple/macbook-pro/8-1)                         | `<nixos-hardware/apple/macbook-pro/8-1>`                |
 | [Apple MacBook Pro 10,1](apple/macbook-pro/10-1)                       | `<nixos-hardware/apple/macbook-pro/10-1>`               |
+| [Apple MacBook Pro 11,1](apple/macbook-pro/11-1)                       | `<nixos-hardware/apple/macbook-pro/11-1>`               |
 | [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                       | `<nixos-hardware/apple/macbook-pro/11-5>`               |
 | [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                       | `<nixos-hardware/apple/macbook-pro/12-1>`               |
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                       | `<nixos-hardware/apple/macbook-pro/14-1>`               |

--- a/apple/macbook-pro/11-1/README.md
+++ b/apple/macbook-pro/11-1/README.md
@@ -1,0 +1,12 @@
+# Apple MacBook Pro 11,1
+
+This configuration is tested on my 13" *MacBook Pro (Retina, 13-inch, Late 2013),* model number `A1502`.
+
+The 6.11.5 kernel appears to work well with only minor adjustments on this notebook. Note that my machine has a BCM4360 wireless card (PCI-ID `14e4:43a0`) which appears to only work with the nonfree `wl` driver.
+
+## Additional resources
+
+* Linux Wireless Documentation: [List of hardware](https://wireless.docs.kernel.org/en/latest/en/users/drivers/b43.html#list-of-hardware)
+* Arch linux wiki: [MacBookPro11,x](https://wiki.archlinux.org/index.php/MacBookPro11,x)
+* Kernel patches: [MacBookPro11,x](https://bugzilla.kernel.org/buglist.cgi?quicksearch=macbookpro11)
+

--- a/apple/macbook-pro/11-1/default.nix
+++ b/apple/macbook-pro/11-1/default.nix
@@ -8,6 +8,7 @@
 
   # broadcom-wl
   hardware.enableRedistributableFirmware = lib.mkDefault true;
+  # nixos-generate-config doesn't detect this automatically.
   boot.extraModulePackages = with config.boot.kernelPackages; [ broadcom_sta ];
   boot.kernelModules = [ "wl" ];
 }

--- a/apple/macbook-pro/11-1/default.nix
+++ b/apple/macbook-pro/11-1/default.nix
@@ -1,0 +1,13 @@
+{ lib, config, ... }:
+{
+  imports = [
+    ../.
+    ../../../common/pc/laptop/ssd
+    ../../../common/cpu/intel/haswell
+  ];
+
+  # broadcom-wl
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+  boot.extraModulePackages = with config.boot.kernelPackages; [ broadcom_sta ];
+  boot.kernelModules = [ "wl" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
         apple-macbook-pro = import ./apple/macbook-pro;
         apple-macbook-pro-8-1 = import ./apple/macbook-pro/8-1;
         apple-macbook-pro-10-1 = import ./apple/macbook-pro/10-1;
+        apple-macbook-pro-11-1 = import ./apple/macbook-pro/11-1;
         apple-macbook-pro-11-5 = import ./apple/macbook-pro/11-5;
         apple-macbook-pro-12-1 = import ./apple/macbook-pro/12-1;
         apple-macbook-pro-14-1 = import ./apple/macbook-pro/14-1;


### PR DESCRIPTION
###### Description of changes
Just a simple module I wrote for my late 2013 MacBook Pro and would like to share with the community.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

