### PR TITLE
Lenovo Ideapads 16IAH8 corrected hardware, added 16AHP9

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For questions and discussions, come join us in the [nixos-anywhere matrix](https
 See code for all available configurations.
 
 | Model                                                                  | Path                                                    |
-|------------------------------------------------------------------------|---------------------------------------------------------|
+| ---------------------------------------------------------------------- | ------------------------------------------------------- |
 | [Acer Aspire 4810T](acer/aspire/4810t)                                 | `<nixos-hardware/acer/aspire/4810t>`                    |
 | [Airis N990](airis/n990)                                               | `<nixos-hardware/airis/n990>`                           |
 | [Apple iMac 14.2](apple/imac/14-2)                                     | `<nixos-hardware/apple/imac/14-2>`                      |
@@ -98,8 +98,8 @@ See code for all available configurations.
 | [Asus ROG Strix X570-E GAMING](asus/rog-strix/x570e)                   | `<nixos-hardware/asus/rog-strix/x570e>`                 |
 | [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                     | `<nixos-hardware/asus/zephyrus/ga401>`                  |
 | [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                     | `<nixos-hardware/asus/zephyrus/ga402>`                  |
-| [Asus ROG Zephyrus G14 GA402X* (2023)](asus/zephyrus/ga402x/amdgpu)    | `<nixos-hardware/asus/zephyrus/ga402x/amdgpu>`          |
-| [Asus ROG Zephyrus G14 GA402X* (2023)](asus/zephyrus/ga402x/nvidia)    | `<nixos-hardware/asus/zephyrus/ga402x/nvidia>`          |
+| [Asus ROG Zephyrus G14 GA402X\* (2023)](asus/zephyrus/ga402x/amdgpu)   | `<nixos-hardware/asus/zephyrus/ga402x/amdgpu>`          |
+| [Asus ROG Zephyrus G14 GA402X\* (2023)](asus/zephyrus/ga402x/nvidia)   | `<nixos-hardware/asus/zephyrus/ga402x/nvidia>`          |
 | [Asus ROG Zephyrus G15 GA502](asus/zephyrus/ga502)                     | `<nixos-hardware/asus/zephyrus/ga502>`                  |
 | [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                     | `<nixos-hardware/asus/zephyrus/ga503>`                  |
 | [Asus ROG Zephyrus G16 GU605MY](asus/zephyrus/gu605my)                 | `<nixos-hardware/asus/zephyrus/gu605my>`                |
@@ -195,6 +195,8 @@ See code for all available configurations.
 | [Lenovo IdeaPad 5 Pro 16ach6](lenovo/ideapad/16ach6)                   | `<nixos-hardware/lenovo/ideapad/16ach6>`                |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                             | `<nixos-hardware/lenovo/ideapad/z510>`                  |
 | [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                         | `<nixos-hardware/lenovo/ideapad/slim-5>`                |
+| [Lenovo IdeaPad Slim 5 16iah8](lenovo/ideapad/16iah8)                  | `<nixos-hardware/lenovo/ideapad/16iah8`                 |
+| [Lenovo IdeaPad 2-in-1 16ahp9](lenovo/ideapad/16ah09)                  | `<nixos-hardware/lenovo/ideapad/16ahp9`                 |
 | [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)                 | `<nixos-hardware/lenovo/ideapad/s145-15api>`            |
 | [Lenovo Legion 5 15ach6h](lenovo/legion/15ach6h)                       | `<nixos-hardware/lenovo/legion/15ach6h>`                |
 | [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                     | `<nixos-hardware/lenovo/legion/15arh05h>`               |

--- a/lenovo/ideapad/16ahp9/README.md
+++ b/lenovo/ideapad/16ahp9/README.md
@@ -1,0 +1,4 @@
+# Lenovo Ideapad 2-in-1
+
+This device supports Conservation mode which charges the battery to 79/80%. See [TLP docs](https://linrunner.de/tlp/settings/bc-vendors.html#lenovo-non-thinkpad-series) and [auto-cpu freq](https://github.com/AdnanHodzic/auto-cpufreq?tab=readme-ov-file#battery-charging-thresholds) to enable it. See specs [here](https://psref.lenovo.com/syspool/Sys/PDF/IdeaPad/IdeaPad_5_2_in_1_16AHP9/IdeaPad_5_2_in_1_16AHP9_Spec.pdf).
+

--- a/lenovo/ideapad/16ahp9/default.nix
+++ b/lenovo/ideapad/16ahp9/default.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+}

--- a/lenovo/ideapad/16iah8/README.md
+++ b/lenovo/ideapad/16iah8/README.md
@@ -1,0 +1,10 @@
+# Lenovo Ideapad Slim 5 16IAH8
+
+This device supports Conservation mode which charges the battery to 79/80%. See [TLP docs](https://linrunner.de/tlp/settings/bc-vendors.html#lenovo-non-thinkpad-series) and [auto-cpu freq](https://github.com/AdnanHodzic/auto-cpufreq?tab=readme-ov-file#battery-charging-thresholds) to enable it.
+
+`lspci`:
+```
+00:02.0 VGA compatible controller: Intel Corporation Alder Lake-P GT1 [UHD Graphics] (rev 0c)
+```
+There is no dedicated graphics card. See specs [here](https://psref.lenovo.com/syspool/Sys/PDF/IdeaPad/IdeaPad_Slim_5_16IAH8/IdeaPad_Slim_5_16IAH8_Spec.pdf).
+

--- a/lenovo/ideapad/16iah8/default.nix
+++ b/lenovo/ideapad/16iah8/default.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel/alder-lake
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+}


### PR DESCRIPTION
###### Description of changes

As descripted in #1203, my laptop (16IAH8) had the wrong CPU and GPU configuration. I added another Ideapad (16AHP9) which has both and AMD and GPU, unlike mine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

