### PR TITLE
apple/t2: deprecate enableTinyDfr option

### DIFF
--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -109,6 +109,16 @@ in
       '';
     })
     (lib.mkIf t2Cfg.enableTinyDfr {
+      warnings = [
+        ''
+          hardware.apple-t2.enableTinyDfr is deprecated since the module has been upstreamed as hardware.apple.touchBar. 
+          This option will be removed from the apple/t2 profile when NixOS 24.11 is released.
+        ''
+      ];
+      assertions = lib.optionals (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.11") [{
+        assertion = !config.hardware.apple.touchBar.enable;
+        message = "hardware.apple-t2.enableTinyDfr conflicts with hardware.apple.touchBar.enable. Please disable one of them.";
+      }];
       services.udev.packages = [ tiny-dfrPackage ];
 
       systemd.services.tiny-dfr = {


### PR DESCRIPTION
###### Description of changes
* Adds a deprecation warning to hardware.apple-t2.enableTinyDfr as it has been upstreamed to nixpkgs already. The package and option can be removed at the next release cycle to hopefully not break people's setup.

* Adds an assertion to conflict hardware.apple-t2.enableTinyDfr with hardware.apple.touchBar. Having both enabled causes both tiny-dfr to fight for the same display device.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

