### PR TITLE
tests: fix unused importPath in unfreeNixpkgs function

### DIFF
--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -62,7 +62,7 @@
 
           unfreeNixpkgs =
             importPath:
-            import inputs.nixos-unstable-small {
+            import importPath {
               config = {
                 allowBroken = true;
                 allowUnfree = true;
@@ -71,7 +71,7 @@
               overlays = [ ];
               inherit system;
             };
-          nixpkgsUnstable = unfreeNixpkgs inputs'.nixos-unstable-small;
+          nixpkgsUnstable = unfreeNixpkgs inputs.nixos-unstable-small;
           nixpkgsStable = unfreeNixpkgs inputs.nixos-stable;
 
           checksForNixpkgs =


### PR DESCRIPTION
###### Description of changes

The nixpkgs used to test profiles was (likely mistakenly) hardcoded to `nixos-unstable-small`, and as a result both nixpkgs{Unstable,Stable} used the same nixpkgs version. This causes unexpected assertion failures with `(lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.11")`

This PR unhardcodes the value and resolves the potential issue.

Note that this fails 3 tests at the time of writing, namely `x86_64-linux.nixos-stable-lenovo-legion-16ach6h{,-hybrid,-nvidia}`, all because of a non-existent `hardware.display` option in stable nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

