### PR TITLE
Adding a sound speaker fix. Issue #1039

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ See code for all available configurations.
 | [Lenovo Legion 7 16achg6 (Hybrid)](lenovo/legion/16achg6/hybrid)       | `<nixos-hardware/lenovo/legion/16achg6/hybrid>`         |
 | [Lenovo Legion 7 16achg6 (Nvidia)](lenovo/legion/16achg6/nvidia)       | `<nixos-hardware/lenovo/legion/16achg6/nvidia>`         |
 | [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)          | `<nixos-hardware/lenovo/legion/16irx8h>`                |
+| [Lenovo Legion 7 Pro 16irx9h (Intel)](lenovo/legion/16irx9h)           | `<nixos-hardware/lenovo/legion/16irx9h>`                |
 | [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)             | `<nixos-hardware/lenovo/legion/16arha7>`                |
 | [Lenovo Legion T5 AMR5](lenovo/legion/t526amr5)                        | `<nixos-hardware/lenovo/legion/t526amr5>`               |
 | [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                        | `<nixos-hardware/lenovo/legion/15ich>`                  |

--- a/lenovo/legion/16irx9h/default.nix
+++ b/lenovo/legion/16irx9h/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  config,
+  ...
+}: {
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ada-lovelace
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+    ../../../common/hidpi.nix
+  ];
+
+  boot.initrd.kernelModules = ["nvidia"];
+  boot.extraModulePackages = [config.boot.kernelPackages.lenovo-legion-module config.boot.kernelPackages.nvidia_x11];
+
+  hardware = {
+    nvidia = {
+      modesetting.enable = lib.mkDefault true;
+      powerManagement.enable = lib.mkDefault true;
+      #
+      prime = {
+        intelBusId = "PCI:00:02:0";
+        nvidiaBusId = "PCI:01:00:0";
+      };
+    };
+  };
+
+  # Cooling management
+  services.thermald.enable = lib.mkDefault true;
+
+  # √(2560² + 1600²) px / 16 in ≃ 189 dpi
+  services.xserver.dpi = 189;
+}

--- a/lenovo/legion/16irx9h/default.nix
+++ b/lenovo/legion/16irx9h/default.nix
@@ -25,6 +25,13 @@
     };
   };
 
+  # Sound speaker fix, see #1039
+  boot.extraModprobeConfig = ''
+    options snd-hda-intel model=auto
+  '';
+
+  boot.blacklistedKernelModules = [ "snd_soc_avs" ];
+
   # Cooling management
   services.thermald.enable = lib.mkDefault true;
 

--- a/lenovo/legion/16irx9h/default.nix
+++ b/lenovo/legion/16irx9h/default.nix
@@ -12,12 +12,10 @@
     ../../../common/hidpi.nix
   ];
 
-  boot.initrd.kernelModules = ["nvidia"];
-  boot.extraModulePackages = [config.boot.kernelPackages.lenovo-legion-module config.boot.kernelPackages.nvidia_x11];
+  boot.extraModulePackages = [config.boot.kernelPackages.lenovo-legion-module];
 
   hardware = {
     nvidia = {
-      modesetting.enable = lib.mkDefault true;
       powerManagement.enable = lib.mkDefault true;
       #
       prime = {


### PR DESCRIPTION
###### Description of changes
I found a (temporary?) solution at:

[New Lenovo Legion 7 Pro (2023) no sound from speakers in Linux (Reddit)](https://www.reddit.com/r/LenovoLegion/comments/12752y7/comment/llwx8zj/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)

It worked to me.

I added it to my configuration file:

```
{ config, lib, pkgs, modulesPath, ... }:

{

  boot.extraModprobeConfig = ''
    options snd-hda-intel model=auto
  '';

  boot.blacklistedKernelModules = [ "snd_soc_avs" ];
}
```

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

