### PR TITLE
fix eval with 24.05

### DIFF
--- a/lenovo/legion/16ach6h/edid/default.nix
+++ b/lenovo/legion/16ach6h/edid/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, ... }:
+{
+  pkgs,
+  lib,
+  options,
+  ...
+}:
 
 let
   # This file was obtained from the display while "DDG" mode was enabled.
@@ -8,18 +13,19 @@ let
   '';
 in
 {
-  hardware.display = {
-    edid.packages = [ chip_edid ];
+  config = lib.optionalAttrs (options ? hardware.display) {
+    hardware.display = {
+      edid.packages = [ chip_edid ];
 
-    outputs = {
-      # For some reason, the internal display is sometimes eDP-1, and sometimes it's eDP-2
-      "eDP-1".edid = "16ach6h.bin";
-      "eDP-2".edid = "16ach6h.bin";
+      outputs = {
+        # For some reason, the internal display is sometimes eDP-1, and sometimes it's eDP-2
+        "eDP-1".edid = "16ach6h.bin";
+        "eDP-2".edid = "16ach6h.bin";
+      };
     };
+
+    # This fails at the moment, https://github.com/NixOS/nixos-hardware/issues/795
+    # Extra refresh rates seem to work regardless
+    # boot.initrd.extraFiles."lib/firmware/edid/16ach6h.bin".source = pkgs.runCommandLocal "chip_edid" { } "cp ${./16ach6h.bin} $out";
   };
-
-
-  # This fails at the moment, https://github.com/NixOS/nixos-hardware/issues/795
-  # Extra refresh rates seem to work regardless
-  # boot.initrd.extraFiles."lib/firmware/edid/16ach6h.bin".source = pkgs.runCommandLocal "chip_edid" { } "cp ${./16ach6h.bin} $out";
 }


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

