### PR TITLE
framework: workaround display issues on AMD GPUs

### DIFF
--- a/framework/13-inch/common/amd.nix
+++ b/framework/13-inch/common/amd.nix
@@ -5,8 +5,17 @@
     ../../../common/gpu/amd
   ];
 
-  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
-  boot.kernelParams = lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") ["rtc_cmos.use_acpi_alarm=1"] ;
+  boot.kernelParams =
+    [
+      # There seems to be an issue with panel self-refresh (PSR) that
+      # causes hangs for users.
+      #
+      # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
+      # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
+      "amdgpu.dcdebugmask=0x10"
+    ]
+    # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+    ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") ["rtc_cmos.use_acpi_alarm=1"];
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13

--- a/framework/16-inch/common/amd.nix
+++ b/framework/16-inch/common/amd.nix
@@ -5,8 +5,17 @@
     ../../../common/gpu/amd
   ];
 
-  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
-  boot.kernelParams = lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") ["rtc_cmos.use_acpi_alarm=1"] ;
+  boot.kernelParams =
+    [
+      # There seems to be an issue with panel self-refresh (PSR) that
+      # causes hangs for users.
+      #
+      # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
+      # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
+      "amdgpu.dcdebugmask=0x10"
+    ]
+    # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+    ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") ["rtc_cmos.use_acpi_alarm=1"];
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13


### PR DESCRIPTION
###### Description of changes

Framework users (including me) have issues with PSR. We can trade some battery life for stability here. So far there is no workaround except disabling PSR.

See:
- https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
- https://gitlab.freedesktop.org/drm/amd/-/issues/3647

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

