### PR TITLE
lenovo/thinkpad/t480s: Automatically downgrade kernel to 6.10

### DIFF
--- a/lenovo/thinkpad/t480s/default.nix
+++ b/lenovo/thinkpad/t480s/default.nix
@@ -1,4 +1,9 @@
-{ lib, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 
 {
   imports = [
@@ -9,4 +14,10 @@
   ];
 
   services.throttled.enable = lib.mkDefault true;
+
+  # There is currently a kernel regression with the psmouse driver. As such, the kernel version is held back to 6.10.
+  # See https://bugzilla.kernel.org/show_bug.cgi?id=219352
+  boot.kernelPackages = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages "6.11") (
+    lib.warn "Linux kernel held back to 6.10 due to regression: https://bugzilla.kernel.org/show_bug.cgi?id=219352" pkgs.linuxPackages_6_10
+  );
 }


### PR DESCRIPTION
###### Description of changes

See https://bugzilla.kernel.org/show_bug.cgi?id=219352

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

