### PR TITLE
Added missing flake reference for the Lenovo Legion 16IRX9H

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,7 @@
         lenovo-legion-16arha7 = import ./lenovo/legion/16arha7;
         lenovo-legion-16ithg6 = import ./lenovo/legion/16ithg6;
         lenovo-legion-16irx8h = import ./lenovo/legion/16irx8h;
+        lenovo-legion-16irx9h = import ./lenovo/legion/16irx9h;
         lenovo-legion-t526amr5 = import ./lenovo/legion/t526amr5;
         lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;
         lenovo-thinkpad = import ./lenovo/thinkpad;


### PR DESCRIPTION
Added missing reference mainly because I needed it personally. 

[Issue referencing the problem](https://github.com/NixOS/nixos-hardware/issues/1259) 

###### Description of Changes
added a reference to an alreaady existing module, assuming that it was left out due to a typo. 

###### Things Done

**Really not that much**

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via  Flake input
    - the only reason I even bothered to fix it was personal need and contributing it here is really just a way of pointing out the omission (merge it or edit the file in-browser, I won't feel slighted either way)

> Thanks for all your hard work here and elsewhere in Nixland! 
> Thomas Leon Highbaugh
