### PR TITLE
enable acpi.ec_no_wakeup in Thinkpad T14 AMD Gen 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T14 AMD Gen 2](lenovo/thinkpad/t14/amd/gen2)          | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen2>`         |
 | [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)          | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`         |
 | [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)          | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         |
+| [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)          | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                             | `<nixos-hardware/lenovo/thinkpad/t14>`                  |
 | [Lenovo ThinkPad T14s AMD Gen 1](lenovo/thinkpad/t14s/amd/gen1)        | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`        |
 | [Lenovo ThinkPad T14s AMD Gen 4](lenovo/thinkpad/t14s/amd/gen4)        | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen4>`        |

--- a/lenovo/thinkpad/t14/amd/gen5/default.nix
+++ b/lenovo/thinkpad/t14/amd/gen5/default.nix
@@ -6,6 +6,10 @@
     ../../../../../common/cpu/amd/pstate.nix
   ];
 
+  # Embedded controller wake-ups drain battery in s2idle on this device
+  # See https://lore.kernel.org/all/ZnFYpWHJ5Ml724Nv@ohnotp/
+  boot.kernelParams = [ "acpi.ec_no_wakeup=1" ];
+
   # For the Qualcomm NFA765 [17cb:1103] wireless network controller
   # See https://bugzilla.redhat.com/show_bug.cgi?id=2047878
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.16") pkgs.linuxPackages_latest;


### PR DESCRIPTION
###### Description of changes

This PR should remove constant battery drain specific to this device (and others, but I only have this one to test) as suggested in e.g.

- https://bbs.archlinux.org/viewtopic.php?id=298895
- https://bbs.archlinux.org/viewtopic.php?id=234913

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration (<https://github.com/kowale/homelab/commit/a46e5dea72e70b5d65e9956993947a5c624040c0#diff-37d03cb9538bb32044b321a8a2cad7aafe9ec114d6b9f83e1d40e917edcc14f4R46> is working on my machine. Before this commit, I had to keep my laptop charging at all times, as it would drain in a few hours, even on suspend, unless fully shutdown. After this commit, I can leave my laptop with its lid closed for 10 hours at the expense of about 4% of battery!)
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` (I was already using this nixos-hardware input in my config, so counting this as done, as it should be identical, right?)

