### PR TITLE
E14-intel: import intel comet lake

### DIFF
--- a/common/cpu/intel/comet-lake/default.nix
+++ b/common/cpu/intel/comet-lake/default.nix
@@ -3,4 +3,6 @@
     ./cpu-only.nix
     ../../../gpu/intel/comet-lake
   ];
+
+  hardware.intelgpu.vaapiDriver = "intel-media-driver";
 }

--- a/lenovo/thinkpad/e14/intel/default.nix
+++ b/lenovo/thinkpad/e14/intel/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ../.
-    ../../../../common/cpu/intel
+    ../../../../common/cpu/intel/comet-lake
   ];
 
   services.throttled.enable = lib.mkDefault true;


### PR DESCRIPTION
The E14 has a i5-10210U which is from comet lake.

see https://www.intel.com/content/www/us/en/products/sku/195436/intel-core-i510210u-processor-6m-cache-up-to-4-20-ghz/specifications.html

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

