### PR TITLE
apple/t2: kernel 6.12.2 -> 6.12.4

### DIFF
--- a/apple/t2/pkgs/linux-t2.nix
+++ b/apple/t2/pkgs/linux-t2.nix
@@ -2,7 +2,7 @@
 , ... } @ args:
 
 let
-  version = "6.12.2";
+  version = "6.12.4";
   majorVersion = lib.elemAt (lib.take 1 (lib.splitVersion version)) 0;
 
   patchRepo = fetchFromGitHub {
@@ -14,7 +14,7 @@ let
 
   kernel = fetchzip {
     url = "mirror://kernel/linux/kernel/v${majorVersion}.x/linux-${version}.tar.xz";
-    hash = "sha256-2xfXs++pJiNgFCdpfYsNy3HE6rCyztbOwAlMObLCgAI=";
+    hash = "sha256-SiQzaqraT/5s6Mown8/DeOWU7VR3IG0ojvkqThO09+0=";
   };
 in
 buildLinux (args // {


### PR DESCRIPTION
###### Description of changes

Bump the kernel version to fix regressions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

