### PR TITLE
microsoft/surface: Update to kernel 6.12.4

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -8,7 +8,7 @@ in {
     ./kernel
   ];
 
-  microsoft-surface.kernelVersion = mkDefault "6.11";
+  microsoft-surface.kernelVersion = mkDefault "6.12";
 
   # Seems to be required to properly enable S0ix "Modern Standby":
   boot.kernelParams = mkDefault [ "mem_sleep_default=deep" ];

--- a/microsoft/surface/common/kernel/linux-surface/default.nix
+++ b/microsoft/surface/common/kernel/linux-surface/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.11.4";
+  version = "6.12.4";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "0mcg1rrw9b0lwj88jkaw6ic2mks8xh8i92v90sbr2x35ljhb0m5x";
+    sha256 = "sha256-bzX4IUM9hCG+cWeZB0fHxKDEUZWPuWiDRGMBrxPXEVI=";
     ignoreConfigErrors=true;
   };
 

--- a/microsoft/surface/common/kernel/linux-surface/patches.nix
+++ b/microsoft/surface/common/kernel/linux-surface/patches.nix
@@ -119,39 +119,35 @@ CONFIG_SURFACE_BOOK1_DGPU_SWITCH= module;
     patch = patchSrc + "/0006-ithc.patch";
   }
   {
-    name = "ms-surface/0007-surface-sam";
-    patch = patchSrc + "/0007-surface-sam.patch";
+    name = "ms-surface/0007-surface-sam-over-hid";
+    patch = patchSrc + "/0007-surface-sam-over-hid.patch";
   }
   {
-    name = "ms-surface/0008-surface-sam-over-hid";
-    patch = patchSrc + "/0008-surface-sam-over-hid.patch";
+    name = "ms-surface/0008-surface-button";
+    patch = patchSrc + "/0008-surface-button.patch";
   }
   {
-    name = "ms-surface/0009-surface-button";
-    patch = patchSrc + "/0009-surface-button.patch";
+    name = "ms-surface/0009-surface-typecover";
+    patch = patchSrc + "/0009-surface-typecover.patch";
   }
   {
-    name = "ms-surface/0010-surface-typecover";
-    patch = patchSrc + "/0010-surface-typecover.patch";
+    name = "ms-surface/0010-surface-shutdown";
+    patch = patchSrc + "/0010-surface-shutdown.patch";
   }
   {
-    name = "ms-surface/0011-surface-shutdown";
-    patch = patchSrc + "/0011-surface-shutdown.patch";
+    name = "ms-surface/0011-surface-gpe";
+    patch = patchSrc + "/0011-surface-gpe.patch";
   }
   {
-    name = "ms-surface/0012-surface-gpe";
-    patch = patchSrc + "/0012-surface-gpe.patch";
+    name = "ms-surface/0012-cameras";
+    patch = patchSrc + "/0012-cameras.patch";
   }
   {
-    name = "ms-surface/0013-cameras";
-    patch = patchSrc + "/0013-cameras.patch";
+    name = "ms-surface/0013-amd-gpio";
+    patch = patchSrc + "/0013-amd-gpio.patch";
   }
   {
-    name = "ms-surface/0014-amd-gpio";
-    patch = patchSrc + "/0014-amd-gpio.patch";
-  }
-  {
-    name = "ms-surface/0015-rtc";
-    patch = patchSrc + "/0015-rtc.patch";
+    name = "ms-surface/0014-rtc";
+    patch = patchSrc + "/0014-rtc.patch";
   }
 ]

--- a/microsoft/surface/common/repos.nix
+++ b/microsoft/surface/common/repos.nix
@@ -4,8 +4,8 @@
   linux-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "linux-surface";
-    rev = "arch-6.11.4-1";
-    hash = "sha256-5rKfAIkGoD5Y4nMobr7wGvzZqN2yFElXqHdcQS2VL14=";
+    rev = "arch-6.12.4-1";
+    hash = "sha256-RAcM28eheOJeHU8liC2lh0zpt/SqwOsHlpWuLmncXVc=";
   };
 
   # This is the owner and repo for the pre-patched kernel from the "linux-surface" project:


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input


When using zfs this requires openZFS 2.2.7 or openZFS 2.3.0-rc4