### PR TITLE
dell-precision-5560: remove redundant config and enable fwupd

### DIFF
--- a/dell/precision/5560/README.md
+++ b/dell/precision/5560/README.md
@@ -15,6 +15,3 @@ boot.extraModprobeConfig = ''
 And you should decide what you want to do with the NVIDIA GPU, either sync or offload.
 
 Fwupd works, you can update the BIOS and DBX.
-```nix
-services.fwupd.enable = true;
-```

--- a/dell/precision/5560/default.nix
+++ b/dell/precision/5560/default.nix
@@ -9,10 +9,6 @@
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;
 
-  boot = {
-    kernelParams = [ "i915.modeset=1" ];
-  };
-
   hardware.nvidia.prime = {
     intelBusId = "PCI:0:2:0";
     nvidiaBusId = "PCI:1:0:0";

--- a/dell/precision/5560/default.nix
+++ b/dell/precision/5560/default.nix
@@ -9,6 +9,8 @@
 
   hardware.enableRedistributableFirmware = lib.mkDefault true;
 
+  services.fwupd.enable = true;
+
   hardware.nvidia.prime = {
     intelBusId = "PCI:0:2:0";
     nvidiaBusId = "PCI:1:0:0";


### PR DESCRIPTION
###### Description of changes

- removed redundant `i915.modeset=1`
- enabled `services.fwupd`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

