### PR TITLE
raspberry-pi-4: add tv-hat overlay

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -17,6 +17,7 @@
     ./pwm0.nix
     ./tc358743.nix
     ./touch-ft5406.nix
+    ./tv-hat.nix
     ./xhci.nix
   ];
 

--- a/raspberry-pi/4/tv-hat.nix
+++ b/raspberry-pi/4/tv-hat.nix
@@ -1,0 +1,109 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi."4".tv-hat;
+in {
+  options.hardware = {
+    raspberry-pi."4".tv-hat = {
+      enable = lib.mkEnableOption ''
+        support for the Raspberry Pi TV Hat.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
+    hardware.deviceTree.overlays = [
+      # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/spi0-0cs-overlay.dts
+      # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-tv-overlay.dts
+      {
+        name = "spi0-0cs.dtbo";
+        dtsText = "
+        /dts-v1/;
+        /plugin/;
+    
+        /{
+          compatible = \"brcm,bcm2711\";
+          fragment@0 {
+            target-path = \"/soc/gpio@7e200000\";
+            __overlay__ {
+              spi0_pins: spi0_pins {
+                brcm,pins = <0x09 0x0a 0x0b>;
+                brcm,function = <0x04>;
+                phandle = <0x0d>;
+              };
+
+              spi0_cs_pins: spi0_cs_pins {
+                brcm,pins = <0x08 0x07>;
+                brcm,function = <0x01>;
+                phandle = <0x0e>;
+              };
+            };
+          };
+          fragment@1 {
+            target-path = \"/soc/spi@7e204000\";
+            __overlay__ {
+              pinctrl-names = \"default\";
+              pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+              cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+              status = \"okay\";
+
+              spidev0: spidev@0{
+                compatible = \"lwn,bk4\";
+                reg = <0>;      /* CE0 */
+                #address-cells = <1>;
+                #size-cells = <0>;
+                spi-max-frequency = <125000000>;
+              };
+
+              spidev1: spidev@1{
+                compatible = \"lwn,bk4\";
+                reg = <1>;      /* CE1 */
+                #address-cells = <1>;
+                #size-cells = <0>;
+                spi-max-frequency = <125000000>;
+              };
+            };
+          };
+      };";
+      }
+      {
+        name = "rpi-tv-overlay";
+        dtsText = ''
+          // rpi-tv HAT
+
+          /dts-v1/;
+          /plugin/;
+
+          / {
+            compatible = "brcm,bcm2711";
+
+            fragment@0 {
+              target = <&spidev0>;
+              __overlay__ {
+                status = "disabled";
+              };
+            };
+
+            fragment@1 {
+              target = <&spi0>;
+              __overlay__ {
+                /* needed to avoid dtc warning */
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                status = "okay";
+
+                cxd2880@0 {
+                  compatible = "sony,cxd2880";
+                  reg = <0>; /* CE0 */
+                  spi-max-frequency = <50000000>;
+                  status = "okay";
+                };
+              };
+            };
+          };
+        '';
+      }
+    ];
+  };
+}

--- a/raspberry-pi/4/tv-hat.nix
+++ b/raspberry-pi/4/tv-hat.nix
@@ -12,6 +12,7 @@ in {
   };
   config = lib.mkIf cfg.enable {
     hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
+    hardware.deviceTree.filter = "*-rpi-4-*.dtb";
     hardware.deviceTree.overlays = [
       # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/spi0-0cs-overlay.dts
       # https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-tv-overlay.dts


### PR DESCRIPTION
###### Description of changes
This PR adds support to the [Raspberry Pi TV HAT](https://www.raspberrypi.com/products/raspberry-pi-tv-hat/). I needed to add two overlays one for the tv-hat and another one to enable SPI. I wasn't sure if merging them on the same file or not, at the end I put them together.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input


