### PR TITLE
asus: init fa506ic

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                              | `<nixos-hardware/asus/zephyrus/gu603h>`                 |
 | [Asus TUF FX504GD](asus/fx504gd)                                                  | `<nixos-hardware/asus/fx504gd>`                         |
 | [Asus TUF FX506HM](asus/fx506hm)                                                  | `<nixos-hardware/asus/fx506hm>`                         |
+| [Asus TUF FA506IC](asus/fa506ic)                                                  | `<nixos-hardware/asus/fa506ic>`                         |
 | [Asus TUF FA507RM](asus/fa507rm)                                                  | `<nixos-hardware/asus/fa507rm>`                         |
 | [Asus TUF FA507NV](asus/fa507nv)                                                  | `<nixos-hardware/asus/fa507nv>`                         |
 | [Asus Zenbook Flip S13 UX371](asus/zenbook/ux371/)                                | `<nixos-hardware/asus/zenbook/ux371>`                   |

--- a/asus/fa506ic/default.nix
+++ b/asus/fa506ic/default.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
+    ../../common/gpu/amd
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/gpu/nvidia/ampere
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+  ];
+
+  hardware.nvidia = {
+    modesetting.enable = lib.mkDefault true;
+    open = lib.mkDefault false;
+    nvidiaSettings = lib.mkDefault true;
+    dynamicBoost.enable = lib.mkDefault true;
+
+    prime = {
+      amdgpuBusId = "PCI:0:6:0";
+      nvidiaBusId = "PCI:0:1:0";
+    };
+  };
+
+  services = {
+    asusd = {
+      enable = lib.mkDefault true;
+      enableUserService = lib.mkDefault true;
+    };
+    supergfxd.enable = lib.mkDefault true;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         asus-ally-rc71l = import ./asus/ally/rc71l;
         asus-fx504gd = import ./asus/fx504gd;
         asus-fx506hm = import ./asus/fx506hm;
+        asus-fa506ic = import ./asus/fa506ic;
         asus-fa507nv = import ./asus/fa507nv;
         asus-fa507rm = import ./asus/fa507rm;
         asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;


### PR DESCRIPTION
###### Description of changes
Add Asus tuf a15(2021) fa506ic hardware config

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

