### PR TITLE
lenovo/yoga/7/14IAH7: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ See code for all available configurations.
 | [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                      | `<nixos-hardware/lenovo/yoga/6/13ALC6>`                 |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/amdgpu)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/amdgpu>`          |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)    | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          |
+| [Lenovo Yoga Slim 7i Pro X 14IAH7 (Integrated)](lenovo/yoga/7/14IAH7/integrated) |`<nixos-hardware/lenovo/yoga/7/14IAH7/integrated>` |
+| [Lenovo Yoga Slim 7i Pro X 14IAH7 (Hybrid)](lenovo/yoga/7/14IAH7/hybrid) |`<nixos-hardware/lenovo/yoga/7/14IAH7/hybrid>` |
 | [LENOVO Yoga 7 Slim Gen8](lenovo/yoga/7/slim/gen8)                     | `<nixos-hardware/lenovo/yoga/7/slim/gen8>`              |
 | [MSI B550-A PRO](msi/b550-a-pro)                                       | `<nixos-hardware/msi/b550-a-pro>`                       |
 | [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                 | `<nixos-hardware/msi/b350-tomahawk>`                    |

--- a/flake.nix
+++ b/flake.nix
@@ -238,6 +238,8 @@
         lenovo-yoga-7-14ARH7 = import ./lenovo/yoga/7/14ARH7;
         lenovo-yoga-7-14ARH7-amdgpu = import ./lenovo/yoga/7/14ARH7/amdgpu;
         lenovo-yoga-7-14ARH7-nvidia = import ./lenovo/yoga/7/14ARH7/nvidia;
+        lenovo-yoga-7-14IAH7-integrated = import ./lenovo/yoga/7/14IAH7/integrated;
+        lenovo-yoga-7-14IAH7-hybrid = import ./lenovo/yoga/7/14IAH7/hybrid;
         lenovo-yoga-7-slim-gen8 = import ./lenovo/yoga/7/slim/gen8;
         letsnote-cf-lx4 = import ./panasonic/letsnote/cf-lx4;
         malibal-aon-s1-intel = import ./malibal/aon/s1;

--- a/lenovo/yoga/7/14IAH7/hybrid/default.nix
+++ b/lenovo/yoga/7/14IAH7/hybrid/default.nix
@@ -1,0 +1,39 @@
+/*
+ * `lenovo-yoga-7-14IAH7-hybrid`:
+ *
+ * This is a hybrid profile that enables the NVIDIA
+ * driver and PRIME offload mode for making use of both
+ * integrated and dedicated graphics. Use this profile if
+ * you want to use the NVIDIA GeForce RTX 3050 Mobile.
+ * Read about PRIME offload mode here:
+ * <https://wiki.nixos.org/wiki/NVIDIA#Offload_mode>
+ *
+ * The `lenovo-yoga-7-14IAH7-integrated` profile only
+ * has the integrated Intel GPU enabled. The dedicated
+ * NVIDIA GPU is disabled entirely. Use that profile
+ * instead if you want to only use integrated graphics.
+ *
+ * `nouveau` wasn't added to any profiles since it
+ * is known to cause freezes for this device.
+ * `nouveau` is blacklisted by default when enabling this:
+ * <https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/hardware/video/nvidia.nix>
+ */
+{ lib, ... }:
+{
+  imports = [
+    ../shared.nix
+    ../../../../../common/gpu/nvidia/ampere
+    ../../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  hardware.nvidia = {
+    # Info: <https://wiki.nixos.org/wiki/NVIDIA#Common_setup>
+    prime = {
+      intelBusId = "PCI:0:2:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+
+    # Info: <https://download.nvidia.com/XFree86/Linux-x86_64/460.73.01/README/dynamicpowermanagement.html>
+    powerManagement.enable = lib.mkDefault true;
+  };
+}

--- a/lenovo/yoga/7/14IAH7/integrated/default.nix
+++ b/lenovo/yoga/7/14IAH7/integrated/default.nix
@@ -1,0 +1,28 @@
+/*
+ * `lenovo-yoga-7-14IAH7-integrated`:
+ *
+ * This profile only has the integrated Intel GPU
+ * enabled. The dedicated NVIDIA GPU is disabled
+ * entirely. Use this profile if you want to only
+ * use the integrated GPU.
+ *
+ * It is recommended to use this profile to disable
+ * dedicated graphics, rather than doing it through
+ * the BIOS, since that method causes issues with
+ * the integrated graphics drivers. Doing it
+ * through blacklisting achieves the same result
+ * with no side-effects.
+ *
+ * The `lenovo-yoga-7-14IAH7-hybrid` hybrid profile
+ * enables the NVIDIA driver and PRIME offload mode
+ * for making use of both GPUs. Use that profile
+ * instead if you want to use the NVIDIA GPU.
+ * Read about PRIME offload mode here:
+ * <https://wiki.nixos.org/wiki/NVIDIA#Offload_mode>
+ */
+{
+  imports = [
+    ../shared.nix
+    ../../../../../common/gpu/nvidia/disable.nix
+  ];
+}

--- a/lenovo/yoga/7/14IAH7/shared.nix
+++ b/lenovo/yoga/7/14IAH7/shared.nix
@@ -1,0 +1,19 @@
+/*
+ * Here are configurations for the
+ * Intel Core i7-12700H CPU, along
+ * with a few others.
+ */
+{
+  imports = [
+    ../../../../common/cpu/intel/alder-lake
+    ../../../../common/gpu/intel/alder-lake
+    ../../../../common/pc/laptop
+    ../../../../common/pc/ssd
+  ];
+
+  boot = {
+    kernelModules = [ "kvm-intel" ];
+    # Info: <https://wiki.archlinux.org/title/Power_management#Active_State_Power_Management>
+    kernelParams = [ "pcie_aspm.policy=powersupersave" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

There is already a profile for the AMD version of this device, being the Lenovo
`14ARH7` (Lenovo Yoga Slim 7 Pro X) under `lenovo/yoga/7/14IAH7`.

I opted to make an entirely separate profile, rather than sharing with it, since
I don't have that device to confirm that unintended changes aren't introduced.

- Add profile for `14IAH7`
- Update `README.md`
- Update `flake.nix`

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
