### PR TITLE
raspberry-pi.4.leds: enable overlays-dtmerge + fix target names

### DIFF
--- a/raspberry-pi/4/leds.nix
+++ b/raspberry-pi/4/leds.nix
@@ -20,6 +20,10 @@ in
 
   # Adapted from: https://gist.github.com/SFrijters/206d2c09656affb04284f076c75a1969
   config = lib.mkMerge [
+    (lib.mkIf (cfg.eth.disable || cfg.act.disable || cfg.pwr.disable) {
+      hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
+      hardware.deviceTree.filter = "*-rpi-4-*.dtb";
+    })
     (lib.mkIf cfg.eth.disable {
       hardware.deviceTree = {
         overlays = [

--- a/raspberry-pi/4/leds.nix
+++ b/raspberry-pi/4/leds.nix
@@ -71,13 +71,16 @@ in
           {
             name = "disable-act-led";
             filter = "*rpi-4-b*";
-            dtsText = ''
+            dtsText = let
+              kernelVersion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.2";
+              target = if kernelVersion then "<&led_act>" else "<&act_led>";
+            in ''
               /dts-v1/;
               /plugin/;
               /{
                   compatible = "raspberrypi,4-model-b";
                   fragment@0 {
-                      target = <&act_led>;
+                      target = ${target};
                       __overlay__ {
                           gpios = <&gpio 42 0>; /* first two values copied from bcm2711-rpi-4-b.dts */
                           linux,default-trigger = "none";
@@ -98,13 +101,16 @@ in
           {
             name = "disable-pwr-led";
             filter = "*rpi-4-b*";
-            dtsText = ''
+            dtsText = let
+              kernelVersion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.2";
+              target = if kernelVersion then "<&led_pwr>" else "<&pwr_led>";
+            in ''
               /dts-v1/;
               /plugin/;
               /{
                   compatible = "raspberrypi,4-model-b";
                   fragment@0 {
-                      target = <&pwr_led>;
+                      target = ${target};
                       __overlay__ {
                           gpios = <&expgpio 2 0>; /* first two values copied from bcm2711-rpi-4-b.dts */
                           linux,default-trigger = "default-on";


### PR DESCRIPTION
###### Description of changes

currently the overlays are not applied.

and somehow it got renamed... compare kernel:
- 6.1: https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/act-led-overlay.dts
- 6.2+: https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/act-led-overlay.dts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

