### PR TITLE
lenovo-z13-gen2: networking.networkmanager.fccUnlockScripts → networking.modemmanager.fccUnlockScripts

### DIFF
--- a/lenovo/thinkpad/z/gen2/z13/default.nix
+++ b/lenovo/thinkpad/z/gen2/z13/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ...}:
+{ pkgs, lib, ... }:
 
 {
   imports = [
@@ -7,10 +7,15 @@
 
   environment.etc."asound.conf".source = ./asound.conf;
 
-  networking.networkmanager.fccUnlockScripts = [
-    {
-      id = "2c7c:030a";
-      path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/2c7c:030a";
-    }
-  ];
+  networking =
+    let
+      fcc_unlock_script = rec {
+        id = "2c7c:030a";
+        path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/${id}";
+      };
+    in
+    if lib.versionOlder lib.version "25.05pre" then
+      { networkmanager.fccUnlockScripts = [ fcc_unlock_script ]; }
+    else
+      { modemmanager.fccUnlockScripts = [ fcc_unlock_script ]; };
 }


### PR DESCRIPTION

Fixes evaluation warning

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.