### PR TITLE
starfive visionfive2: allow uboot and opensbi source overrides

### DIFF
--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -5,6 +5,10 @@
   ...
 }:
 {
+  imports = [
+    ./firmware.nix
+  ];
+
   boot = {
     consoleLogLevel = lib.mkDefault 7;
     # Switch to default as soon they reach >= 6.11

--- a/starfive/visionfive/v2/firmware.nix
+++ b/starfive/visionfive/v2/firmware.nix
@@ -1,26 +1,50 @@
-{ callPackage
-, writeShellApplication
-, stdenv
-, mtdutils
-}:
-
-rec {
-  opensbi = callPackage ./opensbi.nix { };
-  uboot = callPackage ./uboot.nix { inherit opensbi; };
-  updater-flash = writeShellApplication {
-    name = "visionfive2-firmware-update-flash";
-    runtimeInputs = [ mtdutils ];
-    text = ''
-      flashcp -v ${uboot}/u-boot-spl.bin.normal.out /dev/mtd0
-      flashcp -v ${uboot}/u-boot.itb /dev/mtd2
-    '';
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.hardware.visionfive2;
+in
+{
+  options = {
+    hardware.visionfive2 = {
+      opensbi.src = lib.mkOption {
+        description = "VisionFive2 OpenSBI source";
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+      };
+      uboot.src = lib.mkOption {
+        description = "VisionFive2 U-boot source";
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+      };
+    };
   };
-  updater-sd = writeShellApplication {
-    name = "visionfive2-firmware-update-sd";
-    runtimeInputs = [ ];
-    text = ''
-      dd if=${uboot}/u-boot-spl.bin.normal.out of=/dev/mmcblk0p1 conv=fsync
-      dd if=${uboot}/u-boot.itb of=/dev/mmcblk0p2 conv=fsync
-    '';
+
+  config = {
+    system.build = {
+      opensbi = (pkgs.callPackage ./opensbi.nix {}).overrideAttrs (f: p: {
+        src = if cfg.opensbi.src != null then cfg.opensbi.src else p.src;
+      });
+
+      uboot = (pkgs.callPackage ./uboot.nix { inherit (config.system.build) opensbi; }).overrideAttrs (f: p: {
+        src = if cfg.uboot.src != null then cfg.uboot.src else p.src;
+      });
+
+      updater-flash = pkgs.writeShellApplication {
+        name = "visionfive2-firmware-update-flash";
+        runtimeInputs = [ pkgs.mtdutils ];
+        text = ''
+          flashcp -v ${config.system.build.uboot}/u-boot-spl.bin.normal.out /dev/mtd0
+          flashcp -v ${config.system.build.uboot}/u-boot.itb /dev/mtd2
+        '';
+      };
+
+      updater-sd = pkgs.writeShellApplication {
+        name = "visionfive2-firmware-update-sd";
+        runtimeInputs = [ ];
+        text = ''
+          dd if=${config.system.build.uboot}/u-boot-spl.bin.normal.out of=/dev/mmcblk0p1 conv=fsync
+          dd if=${config.system.build.uboot}/u-boot.itb of=/dev/mmcblk0p2 conv=fsync
+        '';
+      };
+    };
   };
 }

--- a/starfive/visionfive/v2/firmware.nix
+++ b/starfive/visionfive/v2/firmware.nix
@@ -5,15 +5,29 @@ in
 {
   options = {
     hardware.visionfive2 = {
-      opensbi.src = lib.mkOption {
-        description = "VisionFive2 OpenSBI source";
-        type = lib.types.nullOr lib.types.package;
-        default = null;
+      opensbi = {
+        src = lib.mkOption {
+          description = "VisionFive2 OpenSBI source";
+          type = lib.types.nullOr lib.types.package;
+          default = null;
+        };
+        patches = lib.mkOption {
+          description = "List of patches to apply to the VisionFive2 OpenSBI source";
+          type = lib.types.nullOr (lib.types.listOf lib.types.package);
+          default = null;
+        };
       };
-      uboot.src = lib.mkOption {
-        description = "VisionFive2 U-boot source";
-        type = lib.types.nullOr lib.types.package;
-        default = null;
+      uboot = {
+        src = lib.mkOption {
+          description = "VisionFive2 U-boot source";
+          type = lib.types.nullOr lib.types.package;
+          default = null;
+        };
+        patches = lib.mkOption {
+          description = "List of patches to apply to the VisionFive2 U-boot source";
+          type = lib.types.nullOr (lib.types.listOf lib.types.package);
+          default = null;
+        };
       };
     };
   };
@@ -22,10 +36,12 @@ in
     system.build = {
       opensbi = (pkgs.callPackage ./opensbi.nix {}).overrideAttrs (f: p: {
         src = if cfg.opensbi.src != null then cfg.opensbi.src else p.src;
+        patches = if cfg.opensbi.patches != null then cfg.opensbi.patches else (p.patches or []);
       });
 
       uboot = (pkgs.callPackage ./uboot.nix { inherit (config.system.build) opensbi; }).overrideAttrs (f: p: {
         src = if cfg.uboot.src != null then cfg.uboot.src else p.src;
+        patches = if cfg.uboot.patches != null then cfg.uboot.patches else (p.patches or []);
       });
 
       updater-flash = pkgs.writeShellApplication {

--- a/starfive/visionfive/v2/sd-image.nix
+++ b/starfive/visionfive/v2/sd-image.nix
@@ -1,7 +1,5 @@
 { config, pkgs, modulesPath, ... }:
-
-let firmware = pkgs.callPackage ./firmware.nix { };
-in {
+{
   imports = [
     "${modulesPath}/profiles/base.nix"
     "${modulesPath}/installer/sd-card/sd-image.nix"
@@ -36,10 +34,10 @@ in {
       EOF
 
       eval $(partx $img -o START,SECTORS --nr 1 --pairs)
-      dd conv=notrunc if=${firmware.uboot}/u-boot-spl.bin.normal.out of=$img seek=$START count=$SECTORS
+      dd conv=notrunc if=${config.system.build.uboot}/u-boot-spl.bin.normal.out of=$img seek=$START count=$SECTORS
 
       eval $(partx $img -o START,SECTORS --nr 2 --pairs)
-      dd conv=notrunc if=${firmware.uboot}/u-boot.itb of=$img seek=$START count=$SECTORS
+      dd conv=notrunc if=${config.system.build.uboot}/u-boot.itb of=$img seek=$START count=$SECTORS
     '';
 
     populateRootCommands = ''
@@ -48,5 +46,5 @@ in {
     '';
   };
 
-  environment.systemPackages = [ firmware.updater-flash ];
+  environment.systemPackages = [ config.system.build.updater-flash ];
 }

--- a/starfive/visionfive/v2/spl-tool.nix
+++ b/starfive/visionfive/v2/spl-tool.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation (finalAttrs: {
   pname = "spi_tool";
   version = "0x01010101";
   src = fetchFromGitHub {
@@ -15,4 +15,4 @@ stdenv.mkDerivation rec{
     mkdir -p $out/bin
     cp spl_tool $out/bin
   '';
-}
+})


### PR DESCRIPTION
###### Description of changes

Adds an easy way to override the sources for uboot and OpenSBI, this makes it easier for someone to switch to a the vendor's u-boot and OpenSBI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

