### PR TITLE
fix: remove intel from services.xserver.videoDrivers due to deprecation in 24.11

### DIFF
--- a/dell/latitude/3480/default.nix
+++ b/dell/latitude/3480/default.nix
@@ -9,6 +9,4 @@
 
   # touchpad goes over i2c
   boot.blacklistedKernelModules = [ "psmouse" ];
-
-  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
 }

--- a/dell/latitude/7430/default.nix
+++ b/dell/latitude/7430/default.nix
@@ -16,6 +16,4 @@
     "i8042.dumbkbd=1" 
     "i8042.nopnp=1" 
   ];
-
-  services.xserver.videoDrivers = lib.mkDefault [ "intel" ];
 }

--- a/gpd/pocket-3/default.nix
+++ b/gpd/pocket-3/default.nix
@@ -14,7 +14,6 @@ in
 
 	# GPU is an Intel Iris Xe, on a “TigerLake” mobile CPU
 	boot.initrd.kernelModules = [ "i915" ];  # Early loading so the passphrase prompt appears on external displays
-	services.xserver.videoDrivers = [ "intel" ];
 	hardware.graphics.extraPackages = with pkgs; [
 		intel-media-driver
 		(if (lib.versionOlder (lib.versions.majorMinor lib.version) "23.11") then vaapiIntel else intel-vaapi-driver)


### PR DESCRIPTION
Closes #1300

###### Description of changes

Removed `services.xserver.videoDrivers = [ "intel" ];` from: 
- `gpd/pocket-3` (tested on my device)
- `dell/latitude/3480` (not tested)
- `dell/latitude/7430` (not tested)

Since "modesetting" is the default first item nothing additional needs to be added.

From https://github.com/NixOS/nixpkgs/blob/cbd8ec4de4469333c82ff40d057350c30e9f7d36/pkgs/servers/x11/xorg/overrides.nix#L1024 :
```nix
  xf86videointel = throw ''
    xf86videointel has been removed as the package is unmaintained and the driver is no longer functional.
    Please remove "intel" from `services.xserver.videoDrivers` and switch to the "modesetting" driver.
  ''; # Added 2024-12-16;
```

Further documented here: https://github.com/NixOS/nixpkgs/pull/365448/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input (https://codeberg.org/tetov/nix/commit/3dcdafd5543e47bb9636138c885e92b1638a7f4a)

