### PR TITLE
Lenovo ideacentre k330

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ See code for all available configurations.
 | [Huawei Matebook X Pro (2020)](huawei/machc-wa)                                   | `<nixos-hardware/huawei/machc-wa>`                      |
 | [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)                       | `<nixos-hardware/nxp/imx8qm-mek>`                       |
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                                             | `<nixos-hardware/intel/nuc/8i7beh>`                     |
+| [Lenovo IdeaCentre K330](lenovo/ideacentre/k330)                                  | `<nixos-hardware/lenovo/ideacentre/k330>`               |
 | [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                                  | `<nixos-hardware/lenovo/ideapad/15alc6>`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)                         | `<nixos-hardware/lenovo/ideapad/15arh05>`               |
 | [Lenovo IdeaPad Gaming 3 15ach6](lenovo/ideapad/15ach6)                           | `<nixos-hardware/lenovo/ideapad/15ach6>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,7 @@
         huawei-machc-wa = import ./huawei/machc-wa;
         hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
         intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
+        lenovo-ideacentre-k330 = import ./lenovo/ideacentre/k330;
         lenovo-ideapad-15alc6 = import ./lenovo/ideapad/15alc6;
         lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;
         lenovo-ideapad-15ach6 = import ./lenovo/ideapad/15ach6;

--- a/lenovo/ideacentre/k330/README.md
+++ b/lenovo/ideacentre/k330/README.md
@@ -1,0 +1,17 @@
+# Lenovo IdeaCentre K330
+
+The specific system I took for reference has the following hardware configuration:
+
+- Intel Core i7 2600
+- NVIDIA GeForce GT 545 [Latest supported (proprietary) driver (390.xx)](https://www.nvidia.com/en-us/drivers/details/196213/)
+- Some SSD (originally had a Seagate Barracuda hard drive)
+
+This hardware configuration was motivated by #1297
+
+I recommend enabling xserver instead of trying to use Wayland. As documented in the above linked issue, using Wayland with this rather old hardware lead to the system freezing after a short time of operation.
+
+```nix
+{
+    services.xserver.enable = true;
+}
+```

--- a/lenovo/ideacentre/k330/default.nix
+++ b/lenovo/ideacentre/k330/default.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+{
+    imports = [
+        ../../../common/cpu/intel
+        ../../../common/gpu/nvidia # Is it possible/advisable to pin this to the 390.xx driver family in case the user wants to use non-free drivers?
+        ../../../common/gpu/amd # The K330 could be bought with AMD GPUs but I don't have that configuration
+        ../../../common/pc
+    ];
+
+    # On my machine Wayland causes the desktop to freeze after a short time of operation
+    services.displayManager.sddm.wayland.enable = false;
+
+    # Should this be a conditional default in case plasma is activated?
+    # What if somebody installs both plasma AND another DE?
+    # The goal is to prefer x11 over wayland due to compatibility issues with the old hardware
+
+    
+    services.displayManager.defaultSession = lib.mkIf config.services.xserver.desktopManager.plasma6.enable (lib.mkDefault "plasmax11");
+}


### PR DESCRIPTION
###### Description of changes

This will add a default configuration for the Lenovo IdeaCentre K330

Since I don't really know what I am doing here, I'll need some input from more experienced Nix users. The main goal was to help out with an instability that came from wayland being a default even on old systems (for plasma desktops). #1297 

The contributing guidelines recommend to import
- CPU (Intel)
- GPU (NVIDIA)
- PC (in this case) | Laptop
- HDD | SSD

I imported CPU, GPU and PC but am unsure about the storage component since presumably most old systmes that somebody wants to revive will use a cheap SSD, including mine while the original hardware was almost certainly a HDD (in my case a Seagate Barracuda)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration (somewhat as in I tested if disabling wayland and running on x11 fixes the issue, which it did)
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Best,
Gab