### PR TITLE
gpu/intel/tiger-lake: don't try to use Xe by default

### DIFF
--- a/common/gpu/intel/tiger-lake/default.nix
+++ b/common/gpu/intel/tiger-lake/default.nix
@@ -2,7 +2,6 @@
 {
   imports = [ ../. ];
   config = {
-    hardware.intelgpu.driver = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.8") "xe";
     boot.kernelParams = lib.mkIf (config.hardware.intelgpu.driver == "i915") [ "i915.enable_guc=3" ];
     hardware.intelgpu.vaapiDriver = "intel-media-driver";
   };


### PR DESCRIPTION
fixes https://github.com/NixOS/nixos-hardware/issues/1278

###### Description of changes

Don't try to use `Xe` on Tiger Lake, since the module won't load unless you use `force_probe`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

