### PR TITLE
include Dell Latitude 549 in flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ See code for all available configurations.
 | [Dell Inspiron 7460](dell/inspiron/7460)                                          | `<nixos-hardware/dell/inspiron/7460>`                   |
 | [Dell Latitude 3340](dell/latitude/3340)                                          | `<nixos-hardware/dell/latitude/3340>`                   |
 | [Dell Latitude 3480](dell/latitude/3480)                                          | `<nixos-hardware/dell/latitude/3480>`                   |
+| [Dell Latitude 5490](dell/latitude/5490)                                          | `<nixos-hardware/dell/latitude/5490>`                   |
 | [Dell Latitude 5520](dell/latitude/5520)                                          | `<nixos-hardware/dell/latitude/5520>`                   |
 | [Dell Latitude 7280](dell/latitude/7280)                                          | `<nixos-hardware/dell/latitude/7280>`                   |
 | [Dell Latitude 7390](dell/latitude/7390)                                          | `<nixos-hardware/dell/latitude/7390>`                   |

--- a/dell/latitude/5490/default.nix
+++ b/dell/latitude/5490/default.nix
@@ -12,7 +12,7 @@
   
   boot = {
     # Kernel Panic on suspend fix, taken from ArchLinux wiki.
-    kernelParams = "acpi_enforce_resources=lax i915.enable_dc=0";
+    kernelParams = [ "acpi_enforce_resources=lax" "i915.enable_dc=0" ];
     # Audio Mute LED
     extraModprobeConfig = ''
        options snd-hda-intel model=mute-led-gpio

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
         dell-inspiron-7460 = import ./dell/inspiron/7460;
         dell-latitude-3340 = import ./dell/latitude/3340;
         dell-latitude-3480 = import ./dell/latitude/3480;
+        dell-latitude-5490 = import ./dell/latitude/5490;
         dell-latitude-5520 = import ./dell/latitude/5520;
         dell-latitude-7280 = import ./dell/latitude/7280;
         dell-latitude-7390 = import ./dell/latitude/7390;


### PR DESCRIPTION
###### Description of changes

`./dell/latitude/5490` exists, but is not included in `flake.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

