### PR TITLE
gpd/pocket-4: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See code for all available configurations.
 | [GPD MicroPC](gpd/micropc)                                                        | `<nixos-hardware/gpd/micropc>`                          |
 | [GPD P2 Max](gpd/p2-max)                                                          | `<nixos-hardware/gpd/p2-max>`                           |
 | [GPD Pocket 3](gpd/pocket-3)                                                      | `<nixos-hardware/gpd/pocket-3>`                         |
+| [GPD Pocket 4](gpd/pocket-4)                                                      | `<nixos-hardware/gpd/pocket-4>`                         |
 | [GPD WIN 2](gpd/win-2)                                                            | `<nixos-hardware/gpd/win-2>`                            |
 | [GPD WIN Max 2 2023](gpd/win-max-2/2023)                                          | `<nixos-hardware/gpd/win-max-2/2023>`                   |
 | [GPD WIN Mini 2024](gpd/win-mini/2024)                                            | `<nixos-hardware/gpd/win-mini/2024>`                    |

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
         gpd-micropc = import ./gpd/micropc;
         gpd-p2-max = import ./gpd/p2-max;
         gpd-pocket-3 = import ./gpd/pocket-3;
+        gpd-pocket-4 = import ./gpd/pocket-4;
         gpd-win-2 = import ./gpd/win-2;
         gpd-win-max-2-2023 = import ./gpd/win-max-2/2023;
         gpd-win-mini-2024 = import ./gpd/win-mini/2024;

--- a/gpd/pocket-4/default.nix
+++ b/gpd/pocket-4/default.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, ... }:
+let inherit (lib) mkDefault;
+in
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+    ../../common/cpu/amd
+    ../../common/cpu/amd/pstate.nix
+    ../../common/gpu/amd
+    ../../common/hidpi.nix
+  ];
+
+  boot.kernelParams = [
+    # The GPD Pocket 4 uses a tablet LTPS display, that is mounted rotated 90° counter-clockwise
+    "fbcon=rotate:1" "video=eDP-1:panel_orientation=right_side_up"
+  ];
+
+  fonts.fontconfig = {
+    subpixel.rgba = "vbgr"; # Pixel order for rotated screen
+
+    # The display has √(2560² + 1600²) px / 8.8in ≃ 343 dpi
+    # Per the documentation, antialiasing, hinting, etc. have no visible effect at such high pixel densities anyhow.
+    hinting.enable = mkDefault false;
+  };
+
+  # More HiDPI settings
+  services.xserver.dpi = 343;
+}


### PR DESCRIPTION
###### Description of changes

Here's a Pocket 4 first pass based on the Pocket 3 setup.

I'm testing this on the [Pocket 4 with AI 9 HX 370](https://gpdstore.net/gpd-mini-laptop/gpd-pocket-4/#cgkit-tab-additional_information) using NixOS 24.11 and mainline kernel 6.12. Apart from the display rotation needed in kernel params and WM settings like the Pocket 3, basic desktop stuff seems to just work.

#### Verified so far:

- [x] Audio
- [x] Bluetooth
- [x] Camera: Works. Tested in OBS
- [x] Display: Built-in screen is on and oriented properly in stage-1 before LUKS passphrase. Sway requires WM-side rotation, not sure about other GUI envs.
- [x] DisplayPort over USB-C: Works
- [x] HDMI: Works. Auto-detects on hotplug and comes back after suspend. On in time for passphrase.
- [x] Internet via RJ45
- [x] MicroSD reader module: Works.
- [x] Mouse: Built-in touchpad and click buttons work fine.
- [x] P-States enabled, EPP settings available
- [x] Suspend and resume (systemctl suspend with default BIOS)
- [x] Touchscreen: Works
- [x] USB ports: All working
- [x] Video: Hardware decoding in mpv and chrome
- [x] Wifi

#### Not working:

❌ Fingerprint Reader: [HOLTEK FocalTech Fingerprint Device](https://linux-hardware.org/?id=usb:2808-0752). No driver support yet. Places to watch: [1](https://fprint.freedesktop.org/supported-devices.html), [2](https://github.com/ftfpteams/focaltech-linux-fingerprint-driver)

#### Untested:

❓ Optional hardware modules (KVM, serial, LTE). I don't have any of these to try out. YMMV.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

