### PR TITLE
Modify apple/t2/default.nix to use configured efiSysMountPoint

### DIFF
--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -23,6 +23,7 @@ let
     });
 
   pipewirePackage = overrideAudioFiles pkgs.pipewire "spa/plugins/";
+  esmp = config.boot.loader.efi.efiSysMountPoint;
 
   apple-set-os-loader-installer = pkgs.stdenv.mkDerivation {
     name = "apple-set-os-loader-installer-1.0";
@@ -85,19 +86,19 @@ in
     (lib.mkIf t2Cfg.enableAppleSetOsLoader {
       # Activation script to install apple-set-os-loader in order to unlock the iGPU
       system.activationScripts.appleSetOsLoader = ''
-        if [[ -e /boot/efi/efi/boot/bootx64_original.efi ]]; then
+        if [[ -e ${esmp}/efi/boot/bootx64_original.efi ]]; then
           true # It's already installed, no action required
-        elif [[ -e /boot/efi/efi/boot/bootx64.efi ]]; then
+        elif [[ -e ${esmp}/efi/boot/bootx64.efi ]]; then
           # Copy the new bootloader to a temporary location
-          cp ${apple-set-os-loader-installer}/bootx64.efi /boot/efi/efi/boot/bootx64_temp.efi
+          cp ${apple-set-os-loader-installer}/bootx64.efi ${esmp}/efi/boot/bootx64_temp.efi
 
           # Rename the original bootloader
-          mv /boot/efi/efi/boot/bootx64.efi /boot/efi/efi/boot/bootx64_original.efi
+          mv ${esmp}/efi/boot/bootx64.efi ${esmp}/efi/boot/bootx64_original.efi
 
           # Move the new bootloader to the final destination
-          mv /boot/efi/efi/boot/bootx64_temp.efi /boot/efi/efi/boot/bootx64.efi
+          mv ${esmp}/efi/boot/bootx64_temp.efi ${esmp}/efi/boot/bootx64.efi
         else
-          echo "Error: /boot/efi/efi/boot/bootx64.efi is missing" >&2
+          echo "Error: ${esmp}/efi/boot/bootx64.efi is missing" >&2
         fi
       '';
 


### PR DESCRIPTION
###### Description of changes
The configured option to use a custom bootx64.efi has a hard-coded path, which doesn't work for users (like myself) who have mounted their ESP in a different place. This PR uses the configured `config.boot.loader.efi.efiSysMountPoint` as the root dir to look for the EFI file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input <- will do once I make this pr :p

