### PR TITLE
surface: linux 6.12.9 -> 6.12.10

### DIFF
--- a/microsoft/surface/common/kernel/linux-surface/default.nix
+++ b/microsoft/surface/common/kernel/linux-surface/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.12.9";
+  version = "6.12.10";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "sha256-h74DYN8JMbNA0rrDUWGlSAcPvDqMNSxJ4h6WZmwmrrQ=";
+    sha256 = "sha256-SlFuXtdIU3pzy0LsR/u+tt+LEpjoiSwpwOkd55CVspc=";
     ignoreConfigErrors=true;
   };
 


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

My Surface Pro9 is not booting with the new 6.12.10 kernel.

It's failing with: 
```bash
loading module 8250_dw...
[      11.047154] surface_serial_hub serial0-0: error -ETIMEDOUT: failed to get firmware version
[      11.049053] surface_serial_hub serial0-0: probe with driver surface_serial_hub failed with error -110
```
And the keyboard cover is not working for DiskEncryption.

I think the relevant part from my `configuration.nix` is:

```nix
  # Add the kernel modules such that we have a working keyboard for the
  # LUKS full disk encryption.
  # https://github.com/linux-surface/linux-surface/wiki/Disk-Encryption
  boot.initrd.kernelModules = [
    "surface_aggregator"
    "surface_aggregator_registry"
    "surface_aggregator_hub"
    "surface_hid_core"
    "surface_hid"
    "pinctrl_tigerlake"
    "intel_lpss"
    "intel_lpss_pci"
    "8250_dw"
  ];
```

Any idea how to fix this?