### PR TITLE
xiaomi/redmibook/16-pro-2024: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,3 +357,4 @@ See code for all available configurations.
 | [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)               | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       |
 | [TUXEDO Pulse 14 - Gen3](tuxedo/pulse/14/gen3)                                    | `<nixos-hardware/tuxedo/pulse/14/gen3>`                 |
 | [TUXEDO Pulse 15 - Gen2](tuxedo/pulse/15/gen2)                                    | `<nixos-hardware/tuxedo/pulse/15/gen2>`                 |
+| [Xiaomi Redmibook 16 Pro 2024](xiaomi/redmibook/16-pro-2024)                      | `<nixos-hardware/xiaomi/redmibook/16-pro-2024>`         |

--- a/flake.nix
+++ b/flake.nix
@@ -308,6 +308,7 @@
         tuxedo-infinitybook-pro14-gen7 = import ./tuxedo/infinitybook/pro14/gen7;
         tuxedo-pulse-14-gen3 = import ./tuxedo/pulse/14/gen3;
         tuxedo-pulse-15-gen2 = import ./tuxedo/pulse/15/gen2;
+        xiaomi-redmibook-16-pro-2024 = import ./xiaomi/redmibook/16-pro-2024;
 
         common-cpu-amd = import ./common/cpu/amd;
         common-cpu-amd-pstate = import ./common/cpu/amd/pstate.nix;

--- a/xiaomi/fix-boot-quirk.nix
+++ b/xiaomi/fix-boot-quirk.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+{
+  # Required fix to allow booting NixOS on certain Xiaomi laptops
+  # https://discourse.nixos.org/t/system-wont-boot-path-efi-stub/29212/12
+  boot.kernelPatches = lib.singleton {
+    name = "Fix boot";
+    patch = null;
+    extraStructuredConfig = with lib.kernel; {
+      ACPI_DEBUG = yes;
+    };
+  };
+}

--- a/xiaomi/redmibook/16-pro-2024/README.md
+++ b/xiaomi/redmibook/16-pro-2024/README.md
@@ -1,0 +1,39 @@
+# Xiaomi Redmibook 16 Pro (2024)
+
+Note that the boot fix requires building the kernel. As such, you might run out
+of space during nixos-rebuild if you mount tmpfs on `/tmp`.
+
+## Tested Hardware
+
+```shellsession
+$ lspci -nn
+00:00.0 Host bridge [0600]: Intel Corporation Device [8086:7d14] (rev 04)
+00:01.0 PCI bridge [0604]: Intel Corporation Device [8086:7ecc] (rev 10)
+00:02.0 VGA compatible controller [0300]: Intel Corporation Meteor Lake-P [Intel Arc Graphics] [8086:7d55] (rev 08)
+00:04.0 Signal processing controller [1180]: Intel Corporation Meteor Lake-P Dynamic Tuning Technology [8086:7d03] (rev 04)
+00:06.0 PCI bridge [0604]: Intel Corporation Device [8086:7e4d] (rev 20)
+00:07.0 PCI bridge [0604]: Intel Corporation Meteor Lake-P Thunderbolt 4 PCI Express Root Port #1 [8086:7ec5] (rev 10)
+00:08.0 System peripheral [0880]: Intel Corporation Meteor Lake-P Gaussian & Neural-Network Accelerator [8086:7e4c] (rev 20)
+00:0a.0 Signal processing controller [1180]: Intel Corporation Meteor Lake-P Platform Monitoring Technology [8086:7d0d] (rev 01)
+00:0b.0 Processing accelerators [1200]: Intel Corporation Meteor Lake NPU [8086:7d1d] (rev 04)
+00:0d.0 USB controller [0c03]: Intel Corporation Meteor Lake-P Thunderbolt 4 USB Controller [8086:7ec0] (rev 10)
+00:0d.2 USB controller [0c03]: Intel Corporation Meteor Lake-P Thunderbolt 4 NHI #0 [8086:7ec2] (rev 10)
+00:12.0 Serial controller [0700]: Intel Corporation Meteor Lake-P Integrated Sensor Hub [8086:7e45] (rev 20)
+00:14.0 USB controller [0c03]: Intel Corporation Meteor Lake-P USB 3.2 Gen 2x1 xHCI Host Controller [8086:7e7d] (rev 20)
+00:14.2 RAM memory [0500]: Intel Corporation Device [8086:7e7f] (rev 20)
+00:14.3 Network controller [0280]: Intel Corporation Meteor Lake PCH CNVi WiFi [8086:7e40] (rev 20)
+00:15.0 Serial bus controller [0c80]: Intel Corporation Meteor Lake-P Serial IO I2C Controller #0 [8086:7e78] (rev 20)
+00:16.0 Communication controller [0780]: Intel Corporation Meteor Lake-P CSME HECI #1 [8086:7e70] (rev 20)
+00:1f.0 ISA bridge [0601]: Intel Corporation Device [8086:7e02] (rev 20)
+00:1f.3 Multimedia audio controller [0401]: Intel Corporation Meteor Lake-P HD Audio Controller [8086:7e28] (rev 20)
+00:1f.4 SMBus [0c05]: Intel Corporation Meteor Lake-P SMBus Controller [8086:7e22] (rev 20)
+00:1f.5 Serial bus controller [0c80]: Intel Corporation Meteor Lake-P SPI Controller [8086:7e23] (rev 20)
+01:00.0 Non-Volatile memory controller [0108]: SK hynix BC511 NVMe SSD [1c5c:1339]
+02:00.0 Non-Volatile memory controller [0108]: Yangtze Memory Technologies Co.,Ltd PC300 NVMe SSD (DRAM-less) [1e49:1033] (rev 03)
+```
+
+## Extra Configuration
+
+### Bluetooth
+
+To enable bluetooth support, set `hardware.bluetooth.enable = true;`.

--- a/xiaomi/redmibook/16-pro-2024/default.nix
+++ b/xiaomi/redmibook/16-pro-2024/default.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+{
+  imports = [
+    ../../fix-boot-quirk.nix
+    ../../../common/cpu/intel
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  services.thermald.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes

~~Also exposed the boot fix as a module since other models might be affected as well~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

