### PR TITLE
Legion 16ach6h gpu power

### DIFF
--- a/lenovo/legion/16ach6h/README.md
+++ b/lenovo/legion/16ach6h/README.md
@@ -9,6 +9,12 @@ When using more than one drive, the value of `hardware.nvidia.prime.amdgpuBusId`
 
 Make sure you override this default in your personal configuration. For two drives, it should be `PCI:6:0:0`.
 
+## Using and troubleshooting power profiles (hybrid-only)
+
+Power profile support (cycled via Fn + Q) is provided by `nvidia-powerd`.
+Should you encounter issues with the `nvidia-powerd` daemon, 
+override the value of `hardware.nvidia.dynamicBoost.enable` to `false` in your personal configuration (and consider creating an issue if one does not exist).
+
 ## Setup at the time of testing
 ```
 $ nix-info -m

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -28,6 +28,7 @@
     nvidia = {
       modesetting.enable = lib.mkDefault true;
       powerManagement.enable = lib.mkDefault true;
+      dynamicBoost.enable = lib.mkDefault true;
 
       prime = {
         amdgpuBusId = lib.mkDefault "PCI:5:0:0";


### PR DESCRIPTION
###### Description of changes

Added and enabled `nvidia-powerd` (via [`dynamicBoost`](https://download.nvidia.com/XFree86/Linux-x86_64/550.142/README/dynamicboost.html)) to take advantage of the laptop's power profiles. Prior to this change, the performance profiles  (color-coded and cycled through via Fn + Q) have no effect on the dGPU `Current Power Limit` (CPL for short). This value can be observed via `sudo nvidia-smi -q -d POWER` or in `nvtop`.


###### Examples/observations

*Example on my RTX 3060-based laptop with a maximum (GPU) power limit of 130 W*:

For simplicity I used "maximum performance power profile" in KDE Plasma settings and ran Uniengine Heaven benchmark in the foreground.

* `dynamicBoost` **disabled** (or `nvidia-powerd` stopped): No matter the load, CPL == `Default Power Limit` (80 W).
* `dynamicBoost` **enabled** (`nvidia-powerd` running): 
  * Quiet (blue) mode: CPL is 80 W
  * Balanced (white) mode: CPL is 80 - 95 W depending on load
  * Performance (red) mode: CPL is 115 - 130 W depending on the load 

*Please, don't read too much into the wattage "measurements" below. I do not own an industry-grade calibrated measuring device, just a consumer one that I only "verified" by matching its readings to my electronics' specifications. I basically just looked at the readings for a few seconds and waited for their stabilization.*

I also "measured" wattage at the socket of the laptop charger and saw 
* an ~8% W difference (seems like too much to be noise) in Quiet mode (~125 W without `dynamicBoost`, ~115 W with `dynamicBoost` on Quiet mode)
*  apart from fans ramping up and temps rising, adequate spikes in power consumption when cycling power modes with `dynamicBoost` enabled (and no spikes or what I classify as noise - 1-3 W differences - without `dynamicBoost`) 

I haven't made time for testing the `ddg` specialization yet as I never really used that one. It should work the same way IMO.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

