### PR TITLE
apple t2: rename hardware.pulseaudio -> services.pulseaudio

### DIFF
--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -72,7 +72,7 @@ in
       # For audio
       boot.kernelParams = [ "pcie_ports=compat" "intel_iommu=on" "iommu=pt" ];
 
-      hardware.pulseaudio.package = overrideAudioFiles pkgs.pulseaudio "src/modules/";
+      services.pulseaudio.package = overrideAudioFiles pkgs.pulseaudio "src/modules/";
 
       services.pipewire.package = pipewirePackage;
       services.pipewire.wireplumber.package = pkgs.wireplumber.override {


### PR DESCRIPTION
###### Description of changes
`hardware.pulseaudio` was renamed to `services.pulseaudio`, so currently it shows a warning, it should be renamed here, right?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

