### PR TITLE
dell/latitude/7420: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ See code for all available configurations.
 | [Dell Latitude 5520](dell/latitude/5520)                                          | `<nixos-hardware/dell/latitude/5520>`                   |
 | [Dell Latitude 7280](dell/latitude/7280)                                          | `<nixos-hardware/dell/latitude/7280>`                   |
 | [Dell Latitude 7390](dell/latitude/7390)                                          | `<nixos-hardware/dell/latitude/7390>`                   |
+| [Dell Latitude 7420](dell/latitude/7420)                                          | `<nixos-hardware/dell/latitude/7420>`                   |
 | [Dell Latitude 7430](dell/latitude/7430)                                          | `<nixos-hardware/dell/latitude/7430>`                   |
 | [Dell Latitude 7490](dell/latitude/7490)                                          | `<nixos-hardware/dell/latitude/7490>`                   |
 | [Dell Latitude 9430](dell/latitude/9430)                                          | `<nixos-hardware/dell/latitude/9430>`                   |

--- a/dell/latitude/7420/default.nix
+++ b/dell/latitude/7420/default.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel/tiger-lake
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
         dell-latitude-5520 = import ./dell/latitude/5520;
         dell-latitude-7280 = import ./dell/latitude/7280;
         dell-latitude-7390 = import ./dell/latitude/7390;
+        dell-latitude-7420 = import ./dell/latitude/7420;
         dell-latitude-7430 = import ./dell/latitude/7430;
         dell-latitude-7490 = import ./dell/latitude/7490;
         dell-latitude-9430 = import ./dell/latitude/9430;


### PR DESCRIPTION
This adds an entry for `dell-latitude-7420`. Before using this change with my 7420, VA-API wasn't working, so I had no hardware accelerated video decoding; now VA-API is working.

I'm not specially setting any kernel parameters like some other entries do, because I don't think it's necessary in this case. Our Tiger Lake module already sets `i915.enable_guc=3`, and other i915 settings can be left at the default (e.g. upstream Linux defaults `i915.enable_fbc` to `-1`, meaning that FBC should be enabled for chips for which that is supported). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I did not run `nix run ./tests#run .` as requested by `CONTRIBUTING.md`, because when I tried, my load average went to 60 until my OOM killer was activated. Nonetheless, this is a pretty straightforward change, so it should be fine.