### PR TITLE
imx8: fix the unused module error accross all imx8

### DIFF
--- a/nxp/common/bsp/linux-imx8.nix
+++ b/nxp/common/bsp/linux-imx8.nix
@@ -1,56 +1,57 @@
-{ pkgs, ... } @ args:
+{ pkgs, ... }@args:
 
 with pkgs;
 
-buildLinux (args // rec {
-  version = "5.15.71";
+buildLinux (
+  args
+  // rec {
+    version = "5.15.71";
 
-  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = version;
+    # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+    modDirVersion = version;
 
-  defconfig = "imx_v8_defconfig";
+    defconfig = "imx_v8_defconfig";
 
-  # https://github.com/NixOS/nixpkgs/pull/366004
-  # introduced a breaking change that if a module is declared but it is not being used it will fail
-  # if you try to suppress each of he errors e.g.
-  # REISERFS_FS_SECURITY = lib.mkForce unset; within structuredExtraConfig
-  # that list runs to a long 100+ modules so we go back to the previous default and ignore them
-  ignoreConfigErrors = true;
+    # https://github.com/NixOS/nixpkgs/pull/366004
+    # introduced a breaking change that if a module is declared but it is not being used it will fail.
+    ignoreConfigErrors = true;
 
-  kernelPatches = [
-  ];
+    kernelPatches = [
+    ];
 
-  autoModules = false;
+    autoModules = false;
 
-  extraConfig = ''
-    CRYPTO_TLS m
-    TLS y
-    MD_RAID0 m
-    MD_RAID1 m
-    MD_RAID10 m
-    MD_RAID456 m
-    DM_VERITY m
-    LOGO y
-    FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
-    FB_EFI n
-    EFI_STUB y
-    EFI y
-    VIRTIO y
-    VIRTIO_PCI y
-    VIRTIO_BLK y
-    DRM_VIRTIO_GPU y
-    EXT4_FS y
-    USBIP_CORE m
-    USBIP_VHCI_HCD m
-    USBIP_HOST m
-    USBIP_VUDC m
-  '';
+    extraConfig = ''
+      CRYPTO_TLS m
+      TLS y
+      MD_RAID0 m
+      MD_RAID1 m
+      MD_RAID10 m
+      MD_RAID456 m
+      DM_VERITY m
+      LOGO y
+      FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+      FB_EFI n
+      EFI_STUB y
+      EFI y
+      VIRTIO y
+      VIRTIO_PCI y
+      VIRTIO_BLK y
+      DRM_VIRTIO_GPU y
+      EXT4_FS y
+      USBIP_CORE m
+      USBIP_VHCI_HCD m
+      USBIP_HOST m
+      USBIP_VUDC m
+    '';
 
-  src = fetchFromGitHub {
-    owner = "nxp-imx";
-    repo = "linux-imx";
-    # tag: refs/tags/lf-5.15.71-2.2.0
-    rev = "3313732e9984cb8a6b10a9085c7e18d58e770d56";
-    sha256 = "sha256-PBRiSgjPOq4keiwPOfNOswf1Zzdbn6YOjpOgv4/Oscc=";
-  };
-} // (args.argsOverride or { }))
+    src = fetchFromGitHub {
+      owner = "nxp-imx";
+      repo = "linux-imx";
+      # tag: refs/tags/lf-5.15.71-2.2.0
+      rev = "3313732e9984cb8a6b10a9085c7e18d58e770d56";
+      sha256 = "sha256-PBRiSgjPOq4keiwPOfNOswf1Zzdbn6YOjpOgv4/Oscc=";
+    };
+  }
+  // (args.argsOverride or { })
+)

--- a/nxp/imx8mp-evk/bsp/imx8mp-linux.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-linux.nix
@@ -1,50 +1,56 @@
-{pkgs, ...} @ args:
+{ pkgs, ... }@args:
 with pkgs;
-  buildLinux (args
-    // rec {
-      version = "6.1.55";
-      name = "imx8mp-linux";
+buildLinux (
+  args
+  // rec {
+    version = "6.1.55";
+    name = "imx8mp-linux";
 
-      # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-      modDirVersion = version;
+    # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+    modDirVersion = version;
 
-      defconfig = "imx_v8_defconfig";
+    defconfig = "imx_v8_defconfig";
 
-      kernelPatches = [
-      ];
+    # https://github.com/NixOS/nixpkgs/pull/366004
+    # introduced a breaking change that if a module is declared but it is not being used it will faill.
+    ignoreConfigErrors = true;
 
-      autoModules = false;
+    kernelPatches = [
+    ];
 
-      extraConfig = ''
-        CRYPTO_TLS m
-        TLS y
-        MD_RAID0 m
-        MD_RAID1 m
-        MD_RAID10 m
-        MD_RAID456 m
-        DM_VERITY m
-        LOGO y
-        FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
-        FB_EFI n
-        EFI_STUB y
-        EFI y
-        VIRTIO y
-        VIRTIO_PCI y
-        VIRTIO_BLK y
-        DRM_VIRTIO_GPU y
-        EXT4_FS y
-        USBIP_CORE m
-        USBIP_VHCI_HCD m
-        USBIP_HOST m
-        USBIP_VUDC m
-      '';
+    autoModules = false;
 
-      src = fetchFromGitHub {
-        owner = "nxp-imx";
-        repo = "linux-imx";
-        # tag: lf-6.1.55-2.2.0
-        rev = "770c5fe2c1d1529fae21b7043911cd50c6cf087e";
-        sha256 = "sha256-tIWt75RUrjB6KmUuAYBVyAC1dmVGSUAgqV5ROJh3xU0=";
-      };
-    }
-    // (args.argsOverride or {}))
+    extraConfig = ''
+      CRYPTO_TLS m
+      TLS y
+      MD_RAID0 m
+      MD_RAID1 m
+      MD_RAID10 m
+      MD_RAID456 m
+      DM_VERITY m
+      LOGO y
+      FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER n
+      FB_EFI n
+      EFI_STUB y
+      EFI y
+      VIRTIO y
+      VIRTIO_PCI y
+      VIRTIO_BLK y
+      DRM_VIRTIO_GPU y
+      EXT4_FS y
+      USBIP_CORE m
+      USBIP_VHCI_HCD m
+      USBIP_HOST m
+      USBIP_VUDC m
+    '';
+
+    src = fetchFromGitHub {
+      owner = "nxp-imx";
+      repo = "linux-imx";
+      # tag: lf-6.1.55-2.2.0
+      rev = "770c5fe2c1d1529fae21b7043911cd50c6cf087e";
+      sha256 = "sha256-tIWt75RUrjB6KmUuAYBVyAC1dmVGSUAgqV5ROJh3xU0=";
+    };
+  }
+  // (args.argsOverride or { })
+)

--- a/nxp/imx8mq-evk/bsp/imx8mq-linux.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-linux.nix
@@ -10,6 +10,10 @@ with pkgs;
 
       defconfig = "imx_v8_defconfig";
 
+      # https://github.com/NixOS/nixpkgs/pull/366004
+      # introduced a breaking change that if a module is declared but it is not being used it will faill.
+      ignoreConfigErrors = true;
+
       kernelPatches = [
       ];
 


### PR DESCRIPTION

###### Description of changes
this fixes the unused modules error that was introduced by https://github.com/NixOS/nixpkgs/pull/366004

for all the imx8 targets

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

