### PR TITLE
gpd/pocket-4: change minimum default kernel version to 6.12 to fix amdgpu error

### DIFF
--- a/gpd/pocket-4/default.nix
+++ b/gpd/pocket-4/default.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, ... }:
-let inherit (lib) mkDefault;
+let inherit (lib) mkIf mkDefault;
 in
 {
   imports = [
@@ -11,10 +11,15 @@ in
     ../../common/hidpi.nix
   ];
 
-  boot.kernelParams = [
-    # The GPD Pocket 4 uses a tablet LTPS display, that is mounted rotated 90° counter-clockwise
-    "fbcon=rotate:1" "video=eDP-1:panel_orientation=right_side_up"
-  ];
+  boot = {
+    # As of kernel version 6.6.72, amdgpu throws a fatal error during init, resulting in a barely-working display
+    kernelPackages = mkIf (lib.versionOlder pkgs.linux.version "6.12") pkgs.linuxPackages_latest;
+
+    kernelParams = [
+      # The GPD Pocket 4 uses a tablet LTPS display, that is mounted rotated 90° counter-clockwise
+      "fbcon=rotate:1" "video=eDP-1:panel_orientation=right_side_up"
+    ];
+  };
 
   fonts.fontconfig = {
     subpixel.rgba = "vbgr"; # Pixel order for rotated screen


### PR DESCRIPTION
###### Description of changes

The Pocket 4 (AI 9 HX 370 version tested) fails to init the amdgpu module when using kernel version 6.6, producing a mostly-broken display. This change defaults to at minimum kernel version 6.12 where the display is probed without issue and runs at native resolution as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

