### PR TITLE
Fix doc build by adding missing defaultText

### DIFF
--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -9,6 +9,7 @@ in {
     default = lib.and
       (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05")
       kernel_version_compatible;
+    defaultText = "enabled by default on NixOS >= 24.05 and kernel >= 6.10";
   };
 
 


### PR DESCRIPTION
###### Description of changes

see build failure at https://github.com/NuschtOS/search.nuschtos.de/actions/runs/12948513311/job/36117329099?pr=40

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

