### PR TITLE
hardkernel/odroid-h4: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ See code for all available configurations.
 | [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                                   | `<nixos-hardware/nxp/imx8mq-evk>`                       |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)                        | `<nixos-hardware/hardkernel/odroid-hc4>`                |
 | [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h3>`                 |
+| [Hardkernel Odroid H4](hardkernel/odroid-h4/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h4>`                 |
 | [Omen 14-fb0798ng](omen/14-fb0798ng)                                              | `<nixos-hardware/omen/14-fb0798ng>`                     |
 | [Omen 15-ce002ns](omen/15-ce002ns)                                                | `<nixos-hardware/omen/15-ce002ns>`                      |
 | [Omen 15-en0010ca](omen/15-en0010ca)                                              | `<nixos-hardware/omen/15-en0010ca>`                     |

--- a/flake.nix
+++ b/flake.nix
@@ -272,6 +272,7 @@
         nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
         hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
         hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;
+        hardkernel-odroid-h4 = import ./hardkernel/odroid-h4;
         omen-14-fb0798ng = import ./omen/14-fb0798ng;
         omen-15-ce002ns = import ./omen/15-ce002ns;
         omen-15-en0010ca = import ./omen/15-en0010ca;

--- a/hardkernel/odroid-h4/default.nix
+++ b/hardkernel/odroid-h4/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../../common/cpu/intel/alder-lake
+  ];
+}


### PR DESCRIPTION
###### Description of changes

- Add support for hardkernel ODROID H4
 
I decided to add only one module, it should work the same for the base, H4+ and H4 Ultra variants. There is precedent for this as the ODROID H3 module also does not differentiate between H3 and H3+.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

