### PR TITLE
codeowners: remove tomfitzhenry from pinebook-pro

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,6 @@ dell/xps/15-9560 @Lyndeno
 lenovo/thinkpad/x230 @makefu @yegortimoshenko
 lenovo/thinkpad/x250 @Mic92
 pcengines/apu @yegortimoshenko
-pine64/pinebook-pro @tomfitzhenry
 pine64/rockpro64 @tomfitzhenry
 pine64/star64 @fgaz
 purism/librem/13v3 @yegortimoshenko


### PR DESCRIPTION
I no longer use this.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

