### PR TITLE
framework/13-inch/intel-core-ultra-series1: fix intel_vpu firmware error -2

### DIFF
--- a/framework/13-inch/intel-core-ultra-series1/default.nix
+++ b/framework/13-inch/intel-core-ultra-series1/default.nix
@@ -9,4 +9,24 @@
   # Need at least 6.9 to make suspend properly
   # Specifically this patch: https://github.com/torvalds/linux/commit/073237281a508ac80ec025872ad7de50cfb5a28a
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.9") (lib.mkDefault pkgs.linuxPackages_latest);
+
+  # Intel NPU Driver
+  # https://discourse.nixos.org/t/new-installation-on-asus-zenbook-ux5406-intel-vpu-firmware-error-2/58732/2
+  hardware.firmware = [
+    (
+      let
+        model = "37xx";
+        version = "0.0";
+
+        firmware = pkgs.fetchurl {
+          url = "https://github.com/intel/linux-npu-driver/raw/v1.13.0/firmware/bin/vpu_${model}_v${version}.bin";
+          hash = "sha256-Mpoeq8HrwChjtHALsss/7QsFtDYAoFNsnhllU0xp3os=";
+        };
+      in
+      pkgs.runCommand "intel-vpu-firmware-${model}-${version}" { } ''
+        mkdir -p "$out/lib/firmware/intel/vpu"
+        cp '${firmware}' "$out/lib/firmware/intel/vpu/vpu_${model}_v${version}.bin"
+      ''
+    )
+  ];
 }


### PR DESCRIPTION
###### Description of changes

Boot error message before patch:

```
$ journalctl | grep vpu
Feb 03 03:10:51 nixos kernel: intel_vpu 0000:00:0b.0: [drm] *ERROR* ivpu_fw_request(): Failed to request firmware: -2
Feb 03 03:10:51 nixos kernel: intel_vpu 0000:00:0b.0: [drm] ivpu_hw_power_down(): NPU not idle during power down
Feb 03 03:10:51 nixos kernel: intel_vpu 0000:00:0b.0: probe with driver intel_vpu failed with error -2
```

Fixed after patch:

```
$ journalctl | grep vpu
Feb 03 03:13:30 nixos kernel: intel_vpu 0000:00:0b.0: [drm] Firmware: intel/vpu/vpu_37xx_v0.0.bin, version: 20240221*MTL_CLIENT_SILICON-release*2101*ci_tag_ud202408_vpu_rc_20240221_2101*845c105994a
Feb 03 03:13:30 nixos kernel: [drm] Initialized intel_vpu 1.0.0 for 0000:00:0b.0 on minor 0
```

Source: https://discourse.nixos.org/t/new-installation-on-asus-zenbook-ux5406-intel-vpu-firmware-error-2/58732/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

