### PR TITLE
Added profile for Dell G3 3579 laptop

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ See code for all available configurations.
 | [Chuwi MiniBook X](chuwi/minibook-x)                                              | `<nixos-hardware/chuwi/minibook-x>`                     |
 | [Deciso DEC series](deciso/dec)                                                   | `<nixos-hardware/deciso/dec>`                           |
 | [Dell G3 3779](dell/g3/3779)                                                      | `<nixos-hardware/dell/g3/3779>`                         |
+| [Dell G3 3579](dell/g3/3579)                                                      | `<nixos-hardware/dell/g3/3579>`                         |
 | [Dell Inspiron 3442](dell/inspiron/3442)                                       | `<nixos-hardawre/dell/inspiron/3442>`                |
 | [Dell Inspiron 14 5420](dell/inspiron/14-5420)                                    | `<nixos-hardawre/dell/inspiron/14-5420>`                |
 | [Dell Inspiron 5509](dell/inspiron/5509)                                          | `<nixos-hardware/dell/inspiron/5509>`                   |

--- a/dell/g3/3579/default.nix
+++ b/dell/g3/3579/default.nix
@@ -1,0 +1,32 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel/coffee-lake
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/pascal
+    ../../../common/pc/laptop
+    ../../../common/pc/laptop/ssd
+  ];
+
+  # Specify bus id of Nvidia and Intel graphics
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+
+  # Cooling management
+  services.thermald.enable = lib.mkDefault true;
+
+  boot = {
+    # Use same ACPI identifier as Dell Ubuntu
+    kernelParams = [ "acpi_osi=Linux-Dell-Video" ];
+
+    # Enable fan sensors.
+    kernelModules = [ "dell-smm-hwmon" ];
+
+    # Forces the driver to load on unknown hardware
+    extraModprobeConfig = "options dell-smm-hwmon	ignore_dmi=1";
+    # NOTE: PWM fan control compatibility needs explicit whitelisting in the kernel driver's code.
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
         deciso-dec = import ./deciso/dec;
         dell-e7240 = import ./dell/e7240;
         dell-g3-3779 = import ./dell/g3/3779;
+        dell-g3-3579 = import ./dell/g3/3579;
         dell-inspiron-14-5420 = import ./dell/inspiron/14-5420;
         dell-inspiron-5509 = import ./dell/inspiron/5509;
         dell-inspiron-5515 = import ./dell/inspiron/5515;


### PR DESCRIPTION
###### Description of changes

Added profile for Dell G3 3579 laptop that enables fan sensors kernel drivers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

