### PR TITLE
Revert "framework/13-inch/12th-gen-intel: add hdmi audio fix"

### DIFF
--- a/framework/13-inch/12th-gen-intel/default.nix
+++ b/framework/13-inch/12th-gen-intel/default.nix
@@ -11,13 +11,6 @@
       # same as 13th gen framework 13-inch
       hardware.framework.laptop13.audioEnhancement.rawDeviceName = lib.mkDefault "alsa_output.pci-0000_00_1f.3.analog-stereo";
     }
-    {
-      # fix hdmi audio
-      # src https://community.frame.work/t/hdmi-audio-output/9523/23
-      boot.extraModprobeConfig = ''
-        options snd-intel-dspcfg dsp_driver=3
-      '';
-    }
     # https://community.frame.work/t/tracking-hard-freezing-on-fedora-36-with-the-new-12th-gen-system/20675/391
     (lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.2") {
       boot.kernelParams = [


### PR DESCRIPTION
This reverts commit 8b5ef47338c924c827c00dec69cf7108744fe199.

fixes https://github.com/NixOS/nixos-hardware/issues/1362

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

