### PR TITLE
Add rest of Radxa devices that alredy have U-Boot package in nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ See code for all available configurations.
 | [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   |
 | [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        |
 | [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      |
+| [Radxa ROCK Pi E](radxa/rock-pi-e)                                                | `<nixos-hardware/radxa/rock-pi-e>`                      |
 | [Raspberry Pi 2](raspberry-pi/2)                                                  | `<nixos-hardware/raspberry-pi/2>`                       |
 | [Raspberry Pi 3](raspberry-pi/3)                                                  | `<nixos-hardware/raspberry-pi/3>`                       |
 | [Raspberry Pi 4](raspberry-pi/4)                                                  | `<nixos-hardware/raspberry-pi/4>`                       |

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ See code for all available configurations.
 | [Purism Librem 15v3](purism/librem/13v3)                                          | `<nixos-hardware/purism/librem/15v3>`                   |
 | [Purism Librem 5r4](purism/librem/5r4)                                            | `<nixos-hardware/purism/librem/5r4>`                    |
 | [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   |
+| [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        |
 | [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      |
 | [Raspberry Pi 2](raspberry-pi/2)                                                  | `<nixos-hardware/raspberry-pi/2>`                       |
 | [Raspberry Pi 3](raspberry-pi/3)                                                  | `<nixos-hardware/raspberry-pi/3>`                       |

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ See code for all available configurations.
 | [Purism Librem 15v3](purism/librem/13v3)                                          | `<nixos-hardware/purism/librem/15v3>`                   |
 | [Purism Librem 5r4](purism/librem/5r4)                                            | `<nixos-hardware/purism/librem/5r4>`                    |
 | [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   |
+| [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      |
 | [Raspberry Pi 2](raspberry-pi/2)                                                  | `<nixos-hardware/raspberry-pi/2>`                       |
 | [Raspberry Pi 3](raspberry-pi/3)                                                  | `<nixos-hardware/raspberry-pi/3>`                       |
 | [Raspberry Pi 4](raspberry-pi/4)                                                  | `<nixos-hardware/raspberry-pi/4>`                       |

--- a/flake.nix
+++ b/flake.nix
@@ -296,6 +296,7 @@
         raspberry-pi-4 = import ./raspberry-pi/4;
         raspberry-pi-5 = import ./raspberry-pi/5;
         rock-4c-plus = import ./radxa/rock-4c-plus;
+        rock-pi-4 = import ./radxa/rock-pi-4;
         kobol-helios4 = import ./kobol/helios4;
         samsung-np900x3c = import ./samsung/np900x3c;
         slimbook-hero-rpl-rtx = import ./slimbook/hero/rpl-rtx;

--- a/flake.nix
+++ b/flake.nix
@@ -296,6 +296,7 @@
         raspberry-pi-4 = import ./raspberry-pi/4;
         raspberry-pi-5 = import ./raspberry-pi/5;
         rock-4c-plus = import ./radxa/rock-4c-plus;
+        rock-5b = import ./radxa/rock-5b;
         rock-pi-4 = import ./radxa/rock-pi-4;
         kobol-helios4 = import ./kobol/helios4;
         samsung-np900x3c = import ./samsung/np900x3c;

--- a/flake.nix
+++ b/flake.nix
@@ -298,6 +298,7 @@
         rock-4c-plus = import ./radxa/rock-4c-plus;
         rock-5b = import ./radxa/rock-5b;
         rock-pi-4 = import ./radxa/rock-pi-4;
+        rock-pi-e = import ./radxa/rock-pi-e;
         kobol-helios4 = import ./kobol/helios4;
         samsung-np900x3c = import ./samsung/np900x3c;
         slimbook-hero-rpl-rtx = import ./slimbook/hero/rpl-rtx;

--- a/radxa/README.md
+++ b/radxa/README.md
@@ -58,7 +58,7 @@ Below is an annoated flake example to create the initial boot image.
         modules = [
           nixos-hardware.nixosModules.rock-4c-plus  # Update the system according to your device.
           disko.nixosModules.disko                  # disko usage is optional in the running system, but we need it to generate the initial boot image.
-          "${nixos-hardware}/radxa/disko.nix"       # Common Radxa Disko profile. it is system-agnostic.
+          "${nixos-hardware}/radxa/disko.nix"       # Common Radxa Disko profile. It is system-agnostic.
           {
             disko = {
               imageBuilder = {
@@ -92,3 +92,13 @@ Below is an annoated flake example to create the initial boot image.
   };
 }
 ```
+
+For most of the supported products, you only need to change the device module (
+i.e. `nixos-hardware.nixosModules.rock-4c-plus`) to match the one you are using.
+
+## Known issues
+
+* Currently, the `hardware.radxa` module and Radxa-maintained SoC vendor modules
+(eg. `hardware.rockchip`) are tightly coupled and not intended for end-user to
+use. Those options are currently used internally for hardware enablement, and
+end-user should not need to modify them. Consider those interfaces **unstable**.

--- a/radxa/README.md
+++ b/radxa/README.md
@@ -74,8 +74,8 @@ Below is an annoated flake example to create the initial boot image.
             # Override the default bootloader with a cross built one.
             # Use this if you do not have binfmt configured on your system.
             # For NixOS, please add `boot.binfmt.emulatedSystems = [ "aarch64-linux" ];` to your system configuration.
-            # Update the system and the firmware package according to your device.
-            # hardware.radxa.rock-4c-plus.platformFirmware = nixpkgs-unfree.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.ubootRock4CPlus;
+            # Read the device module to see how it was configured.
+            # hardware.rockchip.platformFirmware = nixpkgs-unfree.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.ubootRock4CPlus;
 
             users.users.radxa = {
               isNormalUser = true;

--- a/radxa/README.md
+++ b/radxa/README.md
@@ -57,6 +57,14 @@ Below is an annoated flake example to create the initial boot image.
         system = "aarch64-linux";
         modules = [
           nixos-hardware.nixosModules.rock-4c-plus  # Update the system according to your device.
+
+          # Or, if the default platform firmware is not available in the NixOS version you are using:
+          # (import nixos-hardware.nixosModules.rock-pi-e {
+          #   lib = nixpkgs-unfree.lib;
+          #   config = nixpkgs-unfree.config;
+          #   pkgs = nixpkgs-unfree.legacyPackages.aarch64-linux;
+          # })
+
           disko.nixosModules.disko                  # disko usage is optional in the running system, but we need it to generate the initial boot image.
           "${nixos-hardware}/radxa/disko.nix"       # Common Radxa Disko profile. It is system-agnostic.
           {

--- a/radxa/rock-4c-plus/default.nix
+++ b/radxa/rock-4c-plus/default.nix
@@ -9,7 +9,7 @@ let
 in {
   imports = [
     ../.
-    ../../rockchip/rk3399
+    ../../rockchip
   ];
 
   options.hardware.radxa.rock-4c-plus = {

--- a/radxa/rock-4c-plus/default.nix
+++ b/radxa/rock-4c-plus/default.nix
@@ -13,7 +13,7 @@
       radxa.enable = true;
       rockchip = {
         rk3399.enable = true;
-        platformFirmware = pkgs.ubootRock4CPlus;
+        platformFirmware = lib.mkDefault pkgs.ubootRock4CPlus;
       };
     };
   };

--- a/radxa/rock-4c-plus/default.nix
+++ b/radxa/rock-4c-plus/default.nix
@@ -2,29 +2,18 @@
 , pkgs
 , config
 , ...
-}:
-let
-  cfg = config.hardware.radxa.rock-4c-plus;
-  rkCfg = config.hardware.rockchip;
-in {
+}: {
   imports = [
     ../.
     ../../rockchip
   ];
-
-  options.hardware.radxa.rock-4c-plus = {
-    platformFirmware = lib.mkPackageOption pkgs "ubootRock4CPlus" { };
-  };
 
   config = {
     hardware = {
       radxa.enable = true;
       rockchip = {
         rk3399.enable = true;
-        diskoExtraPostVM = ''
-          dd conv=notrunc,fsync if=${cfg.platformFirmware}/idbloader.img of=$out/${rkCfg.diskoImageName} bs=512 seek=64
-          dd conv=notrunc,fsync if=${cfg.platformFirmware}/u-boot.itb of=$out/${rkCfg.diskoImageName} bs=512 seek=16384
-        '';
+        platformFirmware = pkgs.ubootRock4CPlus;
       };
     };
   };

--- a/radxa/rock-5b/default.nix
+++ b/radxa/rock-5b/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, pkgs
+, config
+, ...
+}:
+let
+  cfg = config.hardware.radxa.rock-5b;
+  rkCfg = config.hardware.rockchip;
+in {
+  imports = [
+    ../.
+    ../../rockchip
+  ];
+
+  options.hardware.radxa.rock-5b = {
+    platformFirmware = lib.mkPackageOption pkgs "ubootRock5ModelB" { };
+  };
+
+  config = {
+    hardware = {
+      radxa.enable = true;
+      rockchip = {
+        rk3588.enable = true;
+        diskoExtraPostVM = ''
+          dd conv=notrunc,fsync if=${cfg.platformFirmware}/idbloader.img of=$out/${rkCfg.diskoImageName} bs=512 seek=64
+          dd conv=notrunc,fsync if=${cfg.platformFirmware}/u-boot.itb of=$out/${rkCfg.diskoImageName} bs=512 seek=16384
+        '';
+      };
+    };
+  };
+}

--- a/radxa/rock-5b/default.nix
+++ b/radxa/rock-5b/default.nix
@@ -13,7 +13,7 @@
       radxa.enable = true;
       rockchip = {
         rk3588.enable = true;
-        platformFirmware = pkgs.ubootRock5ModelB;
+        platformFirmware = lib.mkDefault pkgs.ubootRock5ModelB;
       };
     };
   };

--- a/radxa/rock-5b/default.nix
+++ b/radxa/rock-5b/default.nix
@@ -2,29 +2,18 @@
 , pkgs
 , config
 , ...
-}:
-let
-  cfg = config.hardware.radxa.rock-5b;
-  rkCfg = config.hardware.rockchip;
-in {
+}: {
   imports = [
     ../.
     ../../rockchip
   ];
-
-  options.hardware.radxa.rock-5b = {
-    platformFirmware = lib.mkPackageOption pkgs "ubootRock5ModelB" { };
-  };
 
   config = {
     hardware = {
       radxa.enable = true;
       rockchip = {
         rk3588.enable = true;
-        diskoExtraPostVM = ''
-          dd conv=notrunc,fsync if=${cfg.platformFirmware}/idbloader.img of=$out/${rkCfg.diskoImageName} bs=512 seek=64
-          dd conv=notrunc,fsync if=${cfg.platformFirmware}/u-boot.itb of=$out/${rkCfg.diskoImageName} bs=512 seek=16384
-        '';
+        platformFirmware = pkgs.ubootRock5ModelB;
       };
     };
   };

--- a/radxa/rock-pi-4/default.nix
+++ b/radxa/rock-pi-4/default.nix
@@ -13,7 +13,7 @@
       radxa.enable = true;
       rockchip = {
         rk3399.enable = true;
-        platformFirmware = pkgs.ubootRockPi4;
+        platformFirmware = lib.mkDefault pkgs.ubootRockPi4;
       };
     };
   };

--- a/radxa/rock-pi-4/default.nix
+++ b/radxa/rock-pi-4/default.nix
@@ -2,29 +2,18 @@
 , pkgs
 , config
 , ...
-}:
-let
-  cfg = config.hardware.radxa.rock-pi-4;
-  rkCfg = config.hardware.rockchip;
-in {
+}: {
   imports = [
     ../.
     ../../rockchip
   ];
-
-  options.hardware.radxa.rock-pi-4 = {
-    platformFirmware = lib.mkPackageOption pkgs "ubootRockPi4" { };
-  };
 
   config = {
     hardware = {
       radxa.enable = true;
       rockchip = {
         rk3399.enable = true;
-        diskoExtraPostVM = ''
-          dd conv=notrunc,fsync if=${cfg.platformFirmware}/idbloader.img of=$out/${rkCfg.diskoImageName} bs=512 seek=64
-          dd conv=notrunc,fsync if=${cfg.platformFirmware}/u-boot.itb of=$out/${rkCfg.diskoImageName} bs=512 seek=16384
-        '';
+        platformFirmware = pkgs.ubootRockPi4;
       };
     };
   };

--- a/radxa/rock-pi-4/default.nix
+++ b/radxa/rock-pi-4/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, pkgs
+, config
+, ...
+}:
+let
+  cfg = config.hardware.radxa.rock-pi-4;
+  rkCfg = config.hardware.rockchip;
+in {
+  imports = [
+    ../.
+    ../../rockchip
+  ];
+
+  options.hardware.radxa.rock-pi-4 = {
+    platformFirmware = lib.mkPackageOption pkgs "ubootRockPi4" { };
+  };
+
+  config = {
+    hardware = {
+      radxa.enable = true;
+      rockchip = {
+        rk3399.enable = true;
+        diskoExtraPostVM = ''
+          dd conv=notrunc,fsync if=${cfg.platformFirmware}/idbloader.img of=$out/${rkCfg.diskoImageName} bs=512 seek=64
+          dd conv=notrunc,fsync if=${cfg.platformFirmware}/u-boot.itb of=$out/${rkCfg.diskoImageName} bs=512 seek=16384
+        '';
+      };
+    };
+  };
+}

--- a/radxa/rock-pi-e/default.nix
+++ b/radxa/rock-pi-e/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, pkgs
+, config
+, ...
+}: {
+  imports = [
+    ../.
+    ../../rockchip
+  ];
+
+  config = {
+    hardware = {
+      radxa.enable = true;
+      rockchip = {
+        rk3328.enable = true;
+        platformFirmware = pkgs.ubootRockPiE;
+      };
+    };
+  };
+}

--- a/radxa/rock-pi-e/default.nix
+++ b/radxa/rock-pi-e/default.nix
@@ -13,7 +13,7 @@
       radxa.enable = true;
       rockchip = {
         rk3328.enable = true;
-        platformFirmware = pkgs.ubootRockPiE;
+        platformFirmware = lib.mkDefault pkgs.ubootRockPiE;
       };
     };
   };

--- a/rockchip/default.nix
+++ b/rockchip/default.nix
@@ -8,6 +8,7 @@ let
 in {
   imports = [
     ./rk3399
+    ./rk3588
   ];
 
   options.hardware.rockchip = {

--- a/rockchip/default.nix
+++ b/rockchip/default.nix
@@ -7,6 +7,7 @@ let
   cfg = config.hardware.rockchip;
 in {
   imports = [
+    ./rk3328
     ./rk3399
     ./rk3588
   ];

--- a/rockchip/default.nix
+++ b/rockchip/default.nix
@@ -6,6 +6,10 @@
 let
   cfg = config.hardware.rockchip;
 in {
+  imports = [
+    ./rk3399
+  ];
+
   options.hardware.rockchip = {
     enable = lib.mkEnableOption "Rockchip SoC support";
     diskoImageName = lib.mkOption {

--- a/rockchip/default.nix
+++ b/rockchip/default.nix
@@ -17,12 +17,26 @@ in {
       type = lib.types.str;
       default = "main.raw";
       description = ''
-        The output image name for Disko.
-        Can be used by diskoExtraPostVM.
+        The output image name of Disko.
+        You need to match this value with the real image name. Setting it alone
+        won't change the output image name, as it is controlled by Disko module.
+
+        Can be used in diskoExtraPostVM.
       '';
+    };
+    platformFirmware = lib.mkPackageOption pkgs "platform firmware" {
+      default = null;
     };
     diskoExtraPostVM = lib.mkOption {
       type = lib.types.str;
+      default = ''
+        ${lib.getExe' pkgs.coreutils "dd"} conv=notrunc,fsync if=${config.hardware.rockchip.platformFirmware}/idbloader.img of=$out/${config.hardware.rockchip.diskoImageName} bs=512 seek=64
+        ${lib.getExe' pkgs.coreutils "dd"} conv=notrunc,fsync if=${config.hardware.rockchip.platformFirmware}/u-boot.itb of=$out/${config.hardware.rockchip.diskoImageName} bs=512 seek=16384
+      '';
+      defaultText = lib.literalExpression ''
+        ${lib.getExe' pkgs.coreutils "dd"} conv=notrunc,fsync if=${config.hardware.rockchip.platformFirmware}/idbloader.img of=$out/${config.hardware.rockchip.diskoImageName} bs=512 seek=64
+        ${lib.getExe' pkgs.coreutils "dd"} conv=notrunc,fsync if=${config.hardware.rockchip.platformFirmware}/u-boot.itb of=$out/${config.hardware.rockchip.diskoImageName} bs=512 seek=16384
+      '';
       description = ''
         The post VM hook for Disko's Image Builder.
         Can be used to install platform firmware like U-Boot.

--- a/rockchip/rk3328/default.nix
+++ b/rockchip/rk3328/default.nix
@@ -1,0 +1,16 @@
+{ lib
+, pkgs
+, config
+, ...
+}:
+let
+  cfg = config.hardware.rockchip.rk3328;
+in {
+  options.hardware.rockchip.rk3328 = {
+    enable = lib.mkEnableOption "Rockchip RK3328 support";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.rockchip.enable = true;
+  };
+}

--- a/rockchip/rk3399/default.nix
+++ b/rockchip/rk3399/default.nix
@@ -6,12 +6,8 @@
 let
   cfg = config.hardware.rockchip.rk3399;
 in {
-  imports = [
-    ../.
-  ];
-
   options.hardware.rockchip.rk3399 = {
-      enable = lib.mkEnableOption "Rockchip RK3399 support";
+    enable = lib.mkEnableOption "Rockchip RK3399 support";
   };
 
   config = lib.mkIf cfg.enable {

--- a/rockchip/rk3588/default.nix
+++ b/rockchip/rk3588/default.nix
@@ -1,0 +1,16 @@
+{ lib
+, pkgs
+, config
+, ...
+}:
+let
+  cfg = config.hardware.rockchip.rk3588;
+in {
+  options.hardware.rockchip.rk3588 = {
+    enable = lib.mkEnableOption "Rockchip RK3588 support";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.rockchip.enable = true;
+  };
+}


### PR DESCRIPTION
###### Description of changes

* Add ROCK 5B, ROCK Pi E, and ROCK Pi 4 (U-Boot reports as ROCK Pi 4A) support
* Refactor Rockchip devices bootloader installation. All Rockchip U-Boot packages contain `u-boot.itb` and `idbloader.img`, and so far the installation offsets are the same across 3 different SoCs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

All 3 new devices and the existing ROCK 4C+ are tested.