### PR TITLE
framework/13-inch/intel-core-ultra-series1: add check for hardware.enableRedistributableFirmware

### DIFF
--- a/dell/e7240/default.nix
+++ b/dell/e7240/default.nix
@@ -1,6 +1,13 @@
 {
   imports = [
-    ../../common/cpu/intel
-    ../../common/pc/laptop
+    ../latitude/e7240/default.nix
+  ];
+
+  warnings = [
+    ''
+      DEPRECATED: Importing dell/e7240 is deprecated. Use dell/latitude/e7240 instead.
+
+      This module will be removed in a future release.
+    ''
   ];
 }

--- a/dell/e7240/default.nix
+++ b/dell/e7240/default.nix
@@ -1,13 +1,6 @@
 {
   imports = [
-    ../latitude/e7240/default.nix
-  ];
-
-  warnings = [
-    ''
-      DEPRECATED: Importing dell/e7240 is deprecated. Use dell/latitude/e7240 instead.
-
-      This module will be removed in a future release.
-    ''
+    ../../common/cpu/intel
+    ../../common/pc/laptop
   ];
 }

--- a/framework/13-inch/intel-core-ultra-series1/default.nix
+++ b/framework/13-inch/intel-core-ultra-series1/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   imports = [
@@ -12,7 +12,7 @@
 
   # Intel NPU Driver
   # https://discourse.nixos.org/t/new-installation-on-asus-zenbook-ux5406-intel-vpu-firmware-error-2/58732/2
-  hardware.firmware = [
+  hardware.firmware = lib.optionals (config.hardware.enableRedistributableFirmware) [
     (
       let
         model = "37xx";
@@ -29,4 +29,9 @@
       ''
     )
   ];
+
+  warnings = lib.mkIf (!config.hardware.enableRedistributableFirmware) [
+    ''For Intel NPU support, set the option: hardware.enableRedistributableFirmware = true;''
+ ];
+
 }


### PR DESCRIPTION
###### Description of changes

Add check for hardware.enableRedistributableFirmware as discussed in #1358

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

