### PR TITLE
Set Alder Lake support for the Aoostar R1 N100

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See code for all available configurations.
 | [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                                  | `<nixos-hardware/apple/macbook-pro/14-1>`               |
 | [Apple MacMini (2010, Intel, Nvidia)](apple/macmini/4)                            | `<nixos-hardware/apple/macmini/4>`                      |
 | [Apple Macs with a T2 Chip](apple/t2)                                             | `<nixos-hardware/apple/t2>`                             |
+| [Aoostar R1 N100](aoostar/r1/n100)                                                | `<nixos-hardware/aoostar/r1/n100>`                      |
 | [Asus Pro WS X570-ACE](asus/pro-ws-x570-ace)                                      | `<nixos-hardware/asus/pro-ws-x570-ace>`                 |
 | [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                                     | `<nixos-hardware/asus/ally/rc71l>`                      |
 | [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/amdgpu)                      | `<nixos-hardware/asus/flow/gv302x/amdgpu>`              |

--- a/aoostar/r1/n100/default.nix
+++ b/aoostar/r1/n100/default.nix
@@ -1,0 +1,12 @@
+{
+  imports = [
+    ../../../common/cpu/intel/alder-lake
+  ];
+
+  # lopter@(2025-02-06): according to sensors-detect this comes with an ITE
+  # IT8613E super io chip, which is not officialy supported yet. See also:
+  #
+  # - unofficial driver: https://github.com/frankcrawford/it87
+  # - reddit thread on with useful information to configure pwm from the bios:
+  #   https://www.reddit.com/r/MiniPCs/comments/1bnkg1u/aoostar_r1r7_question_does_the_fan_header_support/
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
       {
         acer-aspire-4810t = import ./acer/aspire/4810t;
         airis-n990 = import ./airis/n990;
+        aoostar-r1-n100 = import ./aoostar/r1/n100;
         apple-imac-14-2 = import ./apple/imac/14-2;
         apple-imac-18-2 = import ./apple/imac/18-2;
         apple-macbook-air-3 = import ./apple/macbook-air/3;


### PR DESCRIPTION
###### Description of changes

Add definition for the Aoostar R1 NAS.

In order to get micro-code updates, to select the right driver for hardware transcoding on the integrated GPU, and serve as a place for further customization in the future. I left a note about the "super io" chip used in that computer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

