### PR TITLE
raspberry-pi-4: poe-hat: add PWM polarity value

### DIFF
--- a/raspberry-pi/4/poe-hat.nix
+++ b/raspberry-pi/4/poe-hat.nix
@@ -18,7 +18,7 @@ in {
 
     hardware.deviceTree = {
       overlays = [
-        # Equivalent to: https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+        # Equivalent to: https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
         {
           name = "rpi-poe-overlay";
           dtsText = ''
@@ -38,7 +38,7 @@ in {
                     compatible = "pwm-fan";
                     cooling-levels = <0 1 10 100 255>;
                     #cooling-cells = <2>;
-                    pwms = <&fwpwm 0 80000>;
+                    pwms = <&fwpwm 0 80000  0>;
                   };
                 };
               };

--- a/raspberry-pi/4/poe-plus-hat.nix
+++ b/raspberry-pi/4/poe-plus-hat.nix
@@ -19,8 +19,8 @@ in {
     hardware.deviceTree = {
       overlays = [
         # Combined equivalent to:
-        # * https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
-        # * https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
+        # * https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+        # * https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
         {
           name = "rpi-poe-plus-overlay";
           dtsText = ''
@@ -40,7 +40,7 @@ in {
                     compatible = "pwm-fan";
                     cooling-levels = <0 1 10 100 255>;
                     #cooling-cells = <2>;
-                    pwms = <&fwpwm 0 80000>;
+                    pwms = <&fwpwm 0 80000 0>;
                   };
                 };
               };


### PR DESCRIPTION
###### Description of changes

Updating poe-hat and poe-plus-hat overlays to include PWM polarity value ([ref](https://github.com/raspberrypi/linux/commit/e951bdb8b1b93e288c0147a722a22017d63e3f17))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

