### PR TITLE
dell/xps/13-9315: fix screen flickering

### DIFF
--- a/dell/xps/13-9315/default.nix
+++ b/dell/xps/13-9315/default.nix
@@ -27,4 +27,7 @@
 
   # enable cooling management, see NixOS/nixos-hardware#127
   services.thermald.enable = lib.mkDefault true;
+
+  # fix laptop's screen flickering, see https://wiki.archlinux.org/title/Intel_graphics#Screen_flickering
+  boot.kernelParams = ["i915.enable_psr=0"];
 }


### PR DESCRIPTION
###### Description of changes

Since a ~recent update, the Dell XPS 13-9315 integrated screen started to flicker.
This is apparently due to the Panel Self Refresh (PSR) feature of the screen.
This PR adds a kernelParams to disable PSR, which fixes the flickering.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

