### PR TITLE
purism/librem/5r4: kernel: 6.6.29 -> 6.6.74, update pulseaudio options

### DIFF
--- a/purism/librem/5r4/audio.nix
+++ b/purism/librem/5r4/audio.nix
@@ -1,18 +1,41 @@
-{ config, lib, pkgs, ... }:
-{
-  config = lib.mkIf config.hardware.librem5.audio {
-    assertions = [{
-      assertion = config.hardware.pulseaudio.enable;
-      message = "Call audio on Librem5 requires pulse audio to be enabled through `hardware.pulseaudio.enable`.";
-    }];
-    hardware.pulseaudio = {
-      enable = true;
-      # this is required to correctly configure the modem as PA source/sink
-      extraConfig = ''
-        .include ${config.hardware.librem5.package}/etc/pulse/librem5.pa
-      '';
-    };
-
-    services.dbus.packages = [ pkgs.callaudiod ];
-  };
+{ config
+, lib
+, pkgs
+, ...
+}: {
+  config =
+    lib.mkIf config.hardware.librem5.audio
+      {
+        services.dbus.packages = [ pkgs.callaudiod ];
+      }
+    // (
+      let
+        paConfig = {
+          enable = true;
+          # this is required to correctly configure the modem as PA source/sink
+          extraConfig = ''
+            .include ${config.hardware.librem5.package}/etc/pulse/librem5.pa
+          '';
+        };
+      in
+      if lib.versionOlder (lib.versions.majorMinor lib.version) "25.05"
+      then {
+        assertions = [
+          {
+            assertion = config.hardware.pulseaudio.enable;
+            message = "Call audio on Librem5 requires pulse audio to be enabled through `hardware.pulseaudio.enable`.";
+          }
+        ];
+        hardware.pulseaudio = paConfig;
+      }
+      else {
+        assertions = [
+          {
+            assertion = config.services.pulseaudio.enable;
+            message = "Call audio on Librem5 requires pulse audio to be enabled through `services.pulseaudio.enable`.";
+          }
+        ];
+        services.pulseaudio = paConfig;
+      }
+    );
 }

--- a/purism/librem/5r4/kernel.nix
+++ b/purism/librem/5r4/kernel.nix
@@ -6,16 +6,19 @@
 buildLinux (args
   // rec {
   defconfig = "librem5_defconfig";
-  version = "6.6.29-librem5";
+  version = "6.6.74-librem5";
   modDirVersion = version;
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "linux";
-    rev = "pureos/6.6.29pureos1";
-    hash = "sha256-i8HSAJ1/Z2Ux2s3Srse+L0S1Zd/70ldpGBhIgEZ6nBw=";
+    rev = "pureos/6.6.74pureos1";
+    hash = "sha256-qUPY+2fHVu7SFc+Uf8U7QtkQJJsE/4I1SavpLqJ/34c=";
   };
   kernelPatches = [ ];
+  # see https://github.com/NixOS/nixpkgs/pull/366004
+  ignoreConfigErrors = true;
+
   structuredExtraConfig = with lib.kernel; {
     # buildLinux overrides this and defaults to 32, so go back to the value defined librem5_defconfig
     # this is required for millipixels to take photos, otherwise the VIDIOC_REQ_BUFS ioctl returns ENOMEM


### PR DESCRIPTION
###### Description of changes

the audio changes are a bit annoying but hopefully that can be removed once 25.05 is released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

