### PR TITLE
Fix Gigabyte B650 suspend issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ See code for all available configurations.
 | [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                                  | `<nixos-hardware/friendlyarm/nanopi-r5s>`               |
 | [Focus M2 Gen 1](focus/m2/gen1)                                                   | `<nixos-hardware/focus/m2/gen1>`                        |
 | [Gigabyte B550](gigabyte/b550)                                                    | `<nixos-hardware/gigabyte/b550>`                        |
+| [Gigabyte B650](gigabyte/b650)                                                    | `<nixos-hardware/gigabyte/b650>`                        |
 | [GPD MicroPC](gpd/micropc)                                                        | `<nixos-hardware/gpd/micropc>`                          |
 | [GPD P2 Max](gpd/p2-max)                                                          | `<nixos-hardware/gpd/p2-max>`                           |
 | [GPD Pocket 3](gpd/pocket-3)                                                      | `<nixos-hardware/gpd/pocket-3>`                         |

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,7 @@
         friendlyarm-nanopi-r5s = import ./friendlyarm/nanopi-r5s;
         focus-m2-gen1 = import ./focus/m2/gen1;
         gigabyte-b550 = import ./gigabyte/b550;
+        gigabyte-b650 = import ./gigabyte/b650;
         google-pixelbook = import ./google/pixelbook;
         gpd-micropc = import ./gpd/micropc;
         gpd-p2-max = import ./gpd/p2-max;

--- a/gigabyte/b650/README.md
+++ b/gigabyte/b650/README.md
@@ -6,8 +6,3 @@ bug where the PC will wakeup immediately after going into suspend.
 ## Affects at least
 
 - Gigabyte B650M Aorus Elite AX (Rev. 1.3) (BIOS Version F32b)
-  - Can not be fixed by modifying enabled entries in /proc/acpi/wakeup.
-    Computer wakes up even if all enabled entries are disabled. Therefore, no
-    fix exist currently.
-
-

--- a/gigabyte/b650/b650-fix-suspend.nix
+++ b/gigabyte/b650/b650-fix-suspend.nix
@@ -1,0 +1,6 @@
+{
+  # see https://bbs.archlinux.org/viewtopic.php?pid=2227023
+  boot.kernelParams = [
+    "acpi_osi=\"!Windows 2015\""
+  ];
+}

--- a/gigabyte/b650/default.nix
+++ b/gigabyte/b650/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./b650-fix-suspend.nix
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Fixing the long-unsolved issue with Gigabyte B650 series mainboards where the system is unable to suspend properly. The solution is adapted from https://bbs.archlinux.org/viewtopic.php?pid=2227023.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

