### PR TITLE
Add support for TUXEDO InfinityBook Pro Intel Gen9

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ See code for all available configurations.
 | [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                                  | `<nixos-hardware/tuxedo/infinitybook/v4>`               |
 | [TUXEDO Aura 15 - Gen1](tuxedo/aura/15/gen1)                                      | `<nixos-hardware/tuxedo/aura/15/gen1>`                  |
 | [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)               | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       |
+| [TUXEDO InfinityBook Pro 14 - Gen9 - INTEL](tuxedo/infinitybook/pro14/gen9-intel) | `<nixos-hardware/tuxedo/infinitybook/pro14/gen9-intel>` |
 | [TUXEDO Pulse 14 - Gen3](tuxedo/pulse/14/gen3)                                    | `<nixos-hardware/tuxedo/pulse/14/gen3>`                 |
 | [TUXEDO Pulse 15 - Gen2](tuxedo/pulse/15/gen2)                                    | `<nixos-hardware/tuxedo/pulse/15/gen2>`                 |
 | [Xiaomi Redmibook 16 Pro 2024](xiaomi/redmibook/16-pro-2024)                      | `<nixos-hardware/xiaomi/redmibook/16-pro-2024>`         |

--- a/flake.nix
+++ b/flake.nix
@@ -317,6 +317,7 @@
         tuxedo-aura-15-gen1 = import ./tuxedo/aura/15/gen1;
         tuxedo-infinitybook-v4 = import ./tuxedo/infinitybook/v4;
         tuxedo-infinitybook-pro14-gen7 = import ./tuxedo/infinitybook/pro14/gen7;
+        tuxedo-infinitybook-pro14-gen9-intel = import ./tuxedo/infinitybook/pro14/gen9-intel;
         tuxedo-pulse-14-gen3 = import ./tuxedo/pulse/14/gen3;
         tuxedo-pulse-15-gen2 = import ./tuxedo/pulse/15/gen2;
         xiaomi-redmibook-16-pro-2024 = import ./xiaomi/redmibook/16-pro-2024;

--- a/tuxedo/infinitybook/default.nix
+++ b/tuxedo/infinitybook/default.nix
@@ -1,0 +1,12 @@
+{ lib, options, ... }:
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+  ];
+
+  # Enable TUXEDO's kernel drivers if they are available
+  hardware = lib.optionalAttrs (options.hardware ? tuxedo-drivers) {
+    tuxedo-drivers.enable = lib.mkDefault true;
+  };
+}

--- a/tuxedo/infinitybook/pro14/gen7/default.nix
+++ b/tuxedo/infinitybook/pro14/gen7/default.nix
@@ -2,9 +2,8 @@
 
 {
   imports = [
+    ../../.
     ../../../../common/cpu/intel
-    ../../../../common/pc/laptop
-    ../../../../common/pc/ssd
   ];
 
   # Cooling management

--- a/tuxedo/infinitybook/pro14/gen9-intel/README.md
+++ b/tuxedo/infinitybook/pro14/gen9-intel/README.md
@@ -1,0 +1,1 @@
+# [TUXEDO InfinityBook Pro 14 - Gen9 - INTEL](https://www.tuxedocomputers.com/en/TUXEDO-InfinityBook-Pro-14-Gen9-INTEL)

--- a/tuxedo/infinitybook/pro14/gen9-intel/default.nix
+++ b/tuxedo/infinitybook/pro14/gen9-intel/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../../.
+    ../../../../common/cpu/intel
+  ];
+}


### PR DESCRIPTION
###### Description of changes
Commonized the existing TUXEDO InfinityBook configurations and add one for my new laptop :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

