### PR TITLE
feat: lenovo legion 15ach6h hardware.nvidia.open

### DIFF
--- a/lenovo/legion/15ach6h/default.nix
+++ b/lenovo/legion/15ach6h/default.nix
@@ -3,6 +3,9 @@
 {
   imports = [ ./hybrid ];
 
+  # Use the open source kernel module drivers recommended by NVidia (>= Turing architecture)
+  hardware.nvidia.open = true;
+
   specialisation.ddg.configuration = {
     # This specialisation is for the case where "DDG" (Dual-Direct GFX, A hardware feature that can enable in bios) is enabled, since the amd igpu is blocked at hardware level and the built-in display is directly connected to the dgpu, we no longer need the amdgpu and prime configuration.
     system.nixos.tags = [ "Dual-Direct-GFX-Mode" ];


### PR DESCRIPTION
###### Description of changes

Added `hardware.nvidia.open = true;` since all lenovo legion 15ach6h ship with >= Turing architecture NVidia GPUs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input