### PR TITLE
Simplify implementation of B550 suspend fix

### DIFF
--- a/gigabyte/b550/README.md
+++ b/gigabyte/b550/README.md
@@ -9,9 +9,10 @@ Symptoms:
 - It goes into suspend, then seems to boot and hang.  Sometimes it suspends successfully, but waking it from suspend puts it in the "zombie" state.
 - By playing chicken with volatile storage and flicking the power switch on the back of power supply, you can sometimes get it to wake from suspend as the card un-powers before volatile storage does.
 
-Fix: disable GPP0 and GPP8 (And, for some cards, potentially PTXH, I can't test) in /proc/acpi/wakeup
-    - To do this permanently, a systemd service is provided
+This can be fixed by disabling GPP0 and GPP8 (And, for some cards, potentially PTXH, I can't test) in /proc/acpi/wakeup.
 
+But because /proc/acpi/wakeup only supports toggling (not disabling) wakeups, we use a udev rule to disable wakeups for
+the same device by PCI device ID instead.
 
 ## This affects at least:
 - Gigabyte b550m-d3sh (my machine)

--- a/gigabyte/b550/b550-fix-suspend.nix
+++ b/gigabyte/b550/b550-fix-suspend.nix
@@ -1,35 +1,13 @@
-{ pkgs, lib, ... } :
-
 {
-  systemd.services.bugfixSuspend-GPP0 = {
-    enable            = lib.mkDefault true;
-    description       = "Fix crash on wakeup from suspend/hibernate (b550 bugfix)";
-    unitConfig = {
-      Type            = "oneshot";
-    };
-    serviceConfig = {
-      User            = "root"; # root may not be necessary
-      # check for gppN, disable if enabled
-      # lifted from  https://www.reddit.com/r/gigabyte/comments/p5ewjn/comment/ksbm0mb/ /u/Demotay
-      ExecStart       = "-${pkgs.bash}/bin/bash -c 'if grep 'GPP0' /proc/acpi/wakeup | grep -q 'enabled'; then echo 'GPP0' > /proc/acpi/wakeup; fi'"; 
-      RemainAfterExit = "yes";  # required to not toggle when `nixos-rebuild switch` is ran
-      
-    };
-    wantedBy = ["multi-user.target"];
-  };
-
-  systemd.services.bugfixSuspend-GPP8 = {
-    enable            = lib.mkDefault true;
-    description       = "Fix crash on wakeup from suspend/hibernate (b550 bugfix)";
-    unitConfig = {
-      Type            = "oneshot";
-    };
-    serviceConfig = {
-      User            = "root";
-      ExecStart       = "-${pkgs.bash}/bin/bash -c 'if grep 'GPP8' /proc/acpi/wakeup | grep -q 'enabled'; then echo 'GPP8' > /proc/acpi/wakeup; fi'";
-      RemainAfterExit = "yes";
-    };
-    wantedBy = ["multi-user.target"];
-  };
-
+  # Work around an issue causing the system to unsuspend immediately after suspend
+  # and/or hang after suspend.
+  #
+  # See https://www.reddit.com/r/gigabyte/comments/p5ewjn/comment/ksbm0mb/ /u/Demotay
+  #
+  # Most suggestions elsewhere are to disable GPP0 and/or GPP8 using /proc/acpi/wakeup, but that is
+  # inconvenient because it toggles. This does essentially the same thing using udev, which can set
+  # the wakeup attribute to a specific value.
+  services.udev.extraRules = ''
+    ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x1022", ATTR{device}=="0x1483", ATTR{power/wakeup}="disabled"
+  '';
 }


### PR DESCRIPTION
@NireBryce (contributor of the original change): any chance you can test this on your B550, or at least compare the IDs in lspci and /proc/acpi/wakeup)? It *should* do the same thing (you should see GPP0 and GPP8 "disabled" in /proc/acpi/wakeup after rebooting with this applied, and suspend/wakeup should work) but in a way not prone to accidentally togging rather than disabling wakeups.

I've had it in my local config for a while (didn't realize nixos-hardware carried motherboard-specific fixes like this one), and I'm pretty sure I'm working around the same bug, but I can't be 100% sure the device IDs on your system match mine (would surprise me if they didn't, but given the BIOS seems to be buggy to begin with I'd prefer to verify that assumption...)

###### Description of changes

Instead of using systemd oneshot services that have to be careful to not toggle wakeups back on, use a udev rule to disable wakeups by device ID.

On a B550 Vision D Rev 1.0 with BIOS F17, these do almost the same thing:

````
$ lspci -n | grep 1022:1483
00:01.1 0604: 1022:1483
00:01.2 0604: 1022:1483
00:03.1 0604: 1022:1483

$ cat /proc/acpi/wakeup
Device  S-state   Status   Sysfs node
...
GPP0      S4    *disabled  pci:0000:00:01.1
GPP8      S4    *disabled  pci:0000:00:03.1
````

Two of the three devices with the PCI vendor/device ID specified by the
udev rule correspond to devices previously disabled via ACPI (if I
understand correctly disabling these via either /proc/acpi/wakeup or
udev device attribute has the same effect).

The third device is (like the other two) using the "pcieport" driver.
Using a device connected via that port as a wakeup device still works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

