### PR TITLE
pine64/rockpro64: HDMI output and Network in initrd

### DIFF
--- a/pine64/rockpro64/README.md
+++ b/pine64/rockpro64/README.md
@@ -12,3 +12,11 @@ firmware.
 
 Alternatively, starting from the _Tow-Boot_ disk image on eMMC is easier to
 deal with and understand than having to deal with _U-Boot_ manually.
+
+## Console
+
+To configure default console I/O to use serial instead of HDMI (default):
+
+```nix
+hardware.rockpro64.console = "serial";
+```

--- a/pine64/rockpro64/console.nix
+++ b/pine64/rockpro64/console.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+{
+  options.hardware.rockpro64.console = lib.mkOption {
+    default = "hdmi";
+    description = "Default console to use at boot.";
+    type = lib.types.enum [
+      "hdmi"
+      "serial"
+    ];
+  };
+  config = lib.mkIf (config.hardware.rockpro64.console == "hdmi") {
+    boot.kernelParams = [
+      "console=ttyS0"
+      "console=tty0"
+    ];
+  };
+}

--- a/pine64/rockpro64/default.nix
+++ b/pine64/rockpro64/default.nix
@@ -1,10 +1,17 @@
 { lib, ... }:
 {
+  imports = [
+    ./console.nix
+  ];
   boot.initrd.kernelModules = [
     # PCIe/NVMe
     "nvme"
     "pcie_rockchip_host"
     "phy_rockchip_pcie"
+    # Network
+    "dwmac_rk"
+    # HDMI
+    "rockchipdrm"
   ];
   # control the fan on the rockpro64 (like the one in the NAS case)
   hardware.fancontrol = {


### PR DESCRIPTION
###### Description of changes

- Added HDMI output configuration by enabling the console=tty0 kernel parameter to direct output to HDMI instead of serial.
- Included necessary kernel modules in the initial RAM disk (initrd):
    - Added dwmac_rk module for network support.
    - Added rockchipdrm for HDMI support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

