### PR TITLE
gpd-win-max-2-2023/bmi260: 1.0.0 -> 1.1.0

### DIFF
--- a/gpd/win-max-2/2023/bmi260/package.nix
+++ b/gpd/win-max-2/2023/bmi260/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttr: {
   pname = "bmi260";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "hhd-dev";
     repo = finalAttr.pname;
     rev = "v${finalAttr.version}";
-    hash = "sha256-EFous0pPpCuVoCsFz6/4NryQRSH9Jw9Qng+RY1hiX1c=";
+    hash = "sha256-So8rWDTXYsMUgLBU9WrJp47txA8dI98tcxXNy92AYgg=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -38,6 +38,6 @@ stdenv.mkDerivation (finalAttr: {
       gpl2Only
     ];
     maintainers = with maintainers; [ Cryolitia ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 })


### PR DESCRIPTION
fix: https://github.com/NixOS/nixos-hardware/issues/1352

###### Description of changes

https://github.com/hhd-dev/bmi260/commit/2d764db2bd69f2922d7fad6cb162136e32f357a2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

