### PR TITLE
dell/xps/13-9350: use lunar-lake cpu config

### DIFF
--- a/dell/xps/13-9350/default.nix
+++ b/dell/xps/13-9350/default.nix
@@ -2,7 +2,7 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
+    ../../../common/cpu/intel/lunar-lake
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];


### PR DESCRIPTION
###### Description of changes

I don't have the Laptop yet but looking at the specs it's a Lunar Lake CPU. I don't see any harm in adding this.

<https://www.notebookcheck.net/Dell-XPS-13-9350-laptop-review-Intel-Lunar-Lake-is-the-perfect-fit.911314.0.html>
> Dell XPS 13 9350 laptop review: Intel Lunar Lake is the perfect fit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

