### PR TITLE
feat(nvidia-prime): automatic battery-saver specialisation

### DIFF
--- a/common/gpu/nvidia/prime.nix
+++ b/common/gpu/nvidia/prime.nix
@@ -3,11 +3,35 @@
 {
   imports = [ ./. ];
 
-  hardware.nvidia.prime = {
-    offload = {
-      enable = lib.mkOverride 990 true;
-      enableOffloadCmd = lib.mkIf config.hardware.nvidia.prime.offload.enable true; # Provides `nvidia-offload` command.
+  options = {
+    hardware.nvidia.primeBatterySaverSpecialisation = lib.mkEnableOption "configure a specialisation which turns on NVIDIA Prime battery saver";
+  };
+
+  config = {
+
+    hardware.nvidia.prime = {
+      offload = {
+        enable = lib.mkOverride 990 true;
+        enableOffloadCmd = lib.mkIf config.hardware.nvidia.prime.offload.enable true; # Provides `nvidia-offload` command.
+      };
+      # Hardware should specify the bus ID for intel/nvidia devices
     };
-    # Hardware should specify the bus ID for intel/nvidia devices
+
+    specialisation = lib.mkIf config.hardware.nvidia.primeBatterySaverSpecialisation {
+      battery-saver.configuration = {
+        system.nixos.tags = ["battery-saver"];
+        imports = [
+          # Leave only the integrated GPU enabled
+          ./disable.nix
+        ];
+        hardware.nvidia = {
+          prime.offload.enable = lib.mkForce false;
+          powerManagement = {
+            enable = lib.mkForce false;
+          	finegrained = lib.mkForce false;
+          };
+        };
+      };
+    };
   };
 }


### PR DESCRIPTION
This enables a boot option that switches off NVIDIA GPU. Allows for battery saving.

@moduon MT-9339

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

