### PR TITLE
lenovo/thinkpad/x13-yoga: add thunderbolt support

### DIFF
--- a/lenovo/thinkpad/x13/yoga/default.nix
+++ b/lenovo/thinkpad/x13/yoga/default.nix
@@ -5,4 +5,6 @@
   ];
 
   services.xserver.wacom.enable = lib.mkDefault config.services.xserver.enable;
+  
+  services.hardware.bolt.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
###### Description of changes

During setting up my Lenovo Thinkpad X13 Yoga with a Thinkpad Thunderbolt Dock, I discovered that my device failed to communicate with the dock, especially for the ethernet connection. By adding the ``services.hardware.bolt.enable = true`` configuration, my laptop now successfully connects to the ethernet connected to the Thunderbolt dock.

Happy to discuss this suggested change in more detail.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

