### PR TITLE
gpd/pocket-4: add firmware blobs for GPU, wifi, bluetooth

### DIFF
--- a/gpd/pocket-4/default.nix
+++ b/gpd/pocket-4/default.nix
@@ -11,6 +11,11 @@ in
     ../../common/hidpi.nix
   ];
 
+  # Add firmware blobs for GPU, wifi, bluetooth.
+  # Non-required amdgpu/isp_4_1_0.bin still fails with no impact on usage.
+  # Kernel fix coming in https://github.com/torvalds/linux/commit/ea5d49349894a7a74ce8dba242e3a487d24b6c0e
+  hardware.firmware = [(import ./firmware.nix { inherit pkgs; })];
+
   boot = {
     # As of kernel version 6.6.72, amdgpu throws a fatal error during init, resulting in a barely-working display
     kernelPackages = mkIf (lib.versionOlder pkgs.linux.version "6.12") pkgs.linuxPackages_latest;

--- a/gpd/pocket-4/firmware.nix
+++ b/gpd/pocket-4/firmware.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+let
+  lfw = "${pkgs.linux-firmware}/lib/firmware";
+in
+pkgs.stdenv.mkDerivation {
+  name = "gpd-pocket-4-firmware";
+  phases = [ "installPhase" ];
+  # Wide net for amdgpu/amdtee to support non-370 CPU models I can't test.
+  installPhase = ''
+    mkdir -p $out/lib/firmware/intel $out/lib/firmware/rtl_nic
+    cp -r \
+      ${lfw}/amdgpu \
+      ${lfw}/amdtee \
+      ${lfw}/iwlwifi-ty-a0-gf-a0* \
+      $out/lib/firmware/
+    cp ${lfw}/intel/ibt-0041-0041.sfi $out/lib/firmware/intel/
+    cp ${lfw}/rtl_nic/rtl8125b-2.fw $out/lib/firmware/rtl_nic/
+  '';
+}


### PR DESCRIPTION
Fixes wifi and other dmesg firmware errors for people running without nixos-generate-config.

###### Description of changes

* `amdgpu`
* `amdtee`
* `iwlwifi-ty-a0-gf-a0*`
* `intel/ibt-0041-0041.sfi`
* `rtl_nic/rtl8125b-2.fw`

Tested for a few days.

Known issue: Non-required `amdgpu/isp_4_1_0.bin` logs failure with no impact on usage. Upstream log fix coming in https://github.com/torvalds/linux/commit/ea5d49349894a7a74ce8dba242e3a487d24b6c0e

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

