### PR TITLE
framework: fix TRRS headphones modprobe

### DIFF
--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -1,4 +1,5 @@
-{ lib, pkgs, ... }: {
+{ lib, config, ... }:
+{
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
@@ -10,7 +11,7 @@
 
   # Fix TRRS headphones missing a mic
   # https://community.frame.work/t/headset-microphone-on-linux/12387/3
-  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder pkgs.linux.version "6.6.8") ''
+  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.6.8") ''
     options snd-hda-intel model=dell-headset-multi
   '';
 

--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -1,4 +1,5 @@
-{ lib, pkgs, ... }: {
+{ lib, config, ... }:
+{
   imports = [
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
@@ -9,7 +10,7 @@
 
   # Fix TRRS headphones missing a mic
   # https://community.frame.work/t/headset-microphone-on-linux/12387/3
-  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder pkgs.linux.version "6.6.8") ''
+  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.6.8") ''
     options snd-hda-intel model=dell-headset-multi
   '';
 


### PR DESCRIPTION
###### Description of changes
It seems like the modprobe configuration is not guareded with the right condition -- matching with `pkgs.linux.version` doesn't reflect the kernel the user might have opted into.

With this change, `boot.kernelPackages = pkgs.linuxPackages_6_1;` will correctly set the modprobe configuration no matter what the default kernel nixpkgs ships.

Note: I have changed this option for both 13 and 16 inch models, however I have only tested it for the 13 inch model. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

