### PR TITLE
Make comment less intimidating (Lenovo X1 Yoga Gen 7)

### DIFF
--- a/lenovo/thinkpad/x1/yoga/7th-gen/default.nix
+++ b/lenovo/thinkpad/x1/yoga/7th-gen/default.nix
@@ -4,10 +4,7 @@
     ../../../../../common/pc/laptop/ssd
   ];
 
-  # This laptop is too new for the kernel currently in nixos-unstable.
-  # On Kernel 5.15.x, dmesg shows the `hardware is newer than drivers` message.
-  # When starting the system with 5.15.x, only a tty is being displayed.
-  # After our tests, at least version 5.19 is required for the system to work properly.
+  # At least kernel 5.19 is required for the system to work properly.
   boot.kernelPackages = lib.mkIf
     (lib.versionOlder pkgs.linux.version "5.19")
     (lib.mkDefault pkgs.linuxPackages_latest);


### PR DESCRIPTION
###### Description of changes

The comment above the kernel version check is not relevant for the current nixos-unstable. We leave the check in place but make at least the comment less scary.

Fixes #1370. As discussed with @MayNiklas.