### PR TITLE
Draft: NEEDS HELP surface: linux 6.12.19 -> 6.12.21

### DIFF
--- a/microsoft/surface/common/kernel/linux-surface/default.nix
+++ b/microsoft/surface/common/kernel/linux-surface/default.nix
@@ -7,14 +7,14 @@ let
 
   cfg = config.microsoft-surface;
 
-  version = "6.12.19";
+  version = "6.12.21";
   kernelPatches = surfacePatches {
     inherit version;
     patchFn = ./patches.nix;
   };
   kernelPackages = linuxPackage {
     inherit version kernelPatches;
-    sha256 = "sha256-1zvwV77ARDSxadG2FkGTb30Ml865I6KB8y413U3MZTE=";
+    sha256 = "sha256-nRrjmi6gJNmWRvZF/bu/pFRVdxMromQ+Ad914yJG1sc=";
     ignoreConfigErrors=true;
   };
 


### PR DESCRIPTION
###### Description of changes

Starting  with [linux 6.12.20](https://github.com/matthiasdotsh/nixos-hardware/tree/ms-surface/update-kernel-6.12.20) kernel bumps are failing.

```bash
# Sorry, my nixos config isn't public yet.
sudo nixos-rebuild switch --flake .#surface-pro9 
```

last lines from `nix log /nix/store/dvikj3jr164y07ffrz8j88d81c9f53mh-linux-6.12.21.drv` (nothing special before)

```bash
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/hdcp/hdcp_psp.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/hdcp/hdcp.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/hdcp/hdcp1_execution.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/hdcp/hdcp1_transition.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/hdcp/hdcp2_execution.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/modules/hdcp/hdcp2_transition.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/amdgpu_isp.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/isp_v4_1_0.o
  CC [M]  drivers/gpu/drm/amd/amdgpu/isp_v4_1_1.o
  LD [M]  drivers/gpu/drm/amd/amdgpu/amdgpu.o
  AR      drivers/gpu/built-in.a
make[2]: *** [../scripts/Makefile.build:478: drivers] Error 2
make[1]: *** [/build/linux-6.12.21/Makefile:1944: .] Error 2
make: *** [../Makefile:224: __sub-make] Error 2
```

Could someone who also has a surface please try if it works for him or does someone have an idea how to get more debug infos?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

