### PR TITLE
Add Lenovo Legion 5 Pro 16arh7h

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ See code for all available configurations.
 | [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                              | `<nixos-hardware/lenovo/legion/16ach6h>`                |
 | [Lenovo Legion 5 Pro 16ach6h (Hybrid)](lenovo/legion/16ach6h/hybrid)              | `<nixos-hardware/lenovo/legion/16ach6h/hybrid>`         |
 | [Lenovo Legion 5 Pro 16ach6h (Nvidia)](lenovo/legion/16ach6h/nvidia)              | `<nixos-hardware/lenovo/legion/16ach6h/nvidia>`         |
+| [Lenovo Legion 5 Pro 16arh7h (IGPU Only)](lenovo/legion/16arh7h/igpu-only)        | `<nixos-hardware/lenovo/legion/16arh7h/igpu-only>`      |
+| [Lenovo Legion 5 Pro 16arh7h (Hybrid)](lenovo/legion/16arh7h/hybrid)              | `<nixos-hardware/lenovo/legion/16arh7h/hybrid>`         |
 | [Lenovo Legion 7 16achg6 (Hybrid)](lenovo/legion/16achg6/hybrid)                  | `<nixos-hardware/lenovo/legion/16achg6/hybrid>`         |
 | [Lenovo Legion 7 16achg6 (Nvidia)](lenovo/legion/16achg6/nvidia)                  | `<nixos-hardware/lenovo/legion/16achg6/nvidia>`         |
 | [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)                     | `<nixos-hardware/lenovo/legion/16irx8h>`                |

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,8 @@
         lenovo-legion-16ach6h = import ./lenovo/legion/16ach6h;
         lenovo-legion-16ach6h-hybrid = import ./lenovo/legion/16ach6h/hybrid;
         lenovo-legion-16ach6h-nvidia = import ./lenovo/legion/16ach6h/nvidia;
+        lenovo-legion-16arh7h-igpu-only = import ./lenovo/legion/16arh7h/igpu-only;
+        lenovo-legion-16arh7h-hybrid = import ./lenovo/legion/16arh7h/hybrid;
         lenovo-legion-16achg6-hybrid = import ./lenovo/legion/16achg6/hybrid;
         lenovo-legion-16achg6-nvidia = import ./lenovo/legion/16achg6/nvidia;
         lenovo-legion-16aph8 = import ./lenovo/legion/16aph8;

--- a/lenovo/legion/16arh7h/README.md
+++ b/lenovo/legion/16arh7h/README.md
@@ -1,0 +1,4 @@
+# Useful Links
+
+[NixOS Wiki - Nvidia](https://wiki.nixos.org/wiki/NVIDIA)
+

--- a/lenovo/legion/16arh7h/hybrid/default.nix
+++ b/lenovo/legion/16arh7h/hybrid/default.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  lib,
+  ...
+}: {
+  imports = [
+    ../../../../common/cpu/amd
+    ../../../../common/cpu/amd/pstate.nix
+    ../../../../common/gpu/nvidia/prime.nix # prime offload
+    ../../../../common/gpu/nvidia/ampere # use open drivers
+    ../../../../common/pc/laptop
+    ../../../../common/pc/laptop/ssd
+  ];
+
+  boot.kernelModules = ["amdgpu"];
+  services.xserver.videoDrivers = ["nvidia"];
+
+  hardware = {
+    amdgpu.initrd.enable = false;
+
+    nvidia = {
+      package = config.boot.kernelPackages.nvidiaPackages.latest;
+      modesetting.enable = lib.mkDefault true;
+      powerManagement.enable = lib.mkDefault true;
+      powerManagement.finegrained = lib.mkDefault true;
+      prime = {
+        amdgpuBusId = lib.mkDefault "PCI:52:0:0"; # Hexadecimal 34:00.0
+        nvidiaBusId = lib.mkDefault "PCI:1:0:0"; # Hexadecimal 01:00.0
+      };
+    };
+  };
+}

--- a/lenovo/legion/16arh7h/igpu-only/default.nix
+++ b/lenovo/legion/16arh7h/igpu-only/default.nix
@@ -1,0 +1,11 @@
+# This will enable only the integrated AMD GPU, while disabling the dedicated Nvidia GPU
+{...}: {
+  imports = [
+    ../../../../common/cpu/amd
+    ../../../../common/cpu/amd/pstate.nix
+    ../../../../common/gpu/amd
+    ../../../../common/gpu/nvidia/disable.nix
+    ../../../../common/pc/laptop
+    ../../../../common/pc/laptop/ssd
+  ];
+}


### PR DESCRIPTION
###### Description of changes
Added profiles for Lenovo Legion 5 Pro 16ARH7H.
Includes configuration for igpu only as well as nvidia hybrid (offload mode) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

