### PR TITLE
Pr  imx8 atf build issues

### DIFF
--- a/nxp/imx8mp-evk/bsp/imx8mp-atf.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-atf.nix
@@ -1,40 +1,57 @@
-{
-  lib,
-  pkgs,
-  buildArmTrustedFirmware,
-  fetchgit,
-  enable-tee,
-}:
-with pkgs; let
-  opteedflag =
-    if enable-tee
-    then "SPD=opteed"
-    else "";
+{ lib, fetchgit, enable-tee, stdenv, buildPackages, pkgsCross, openssl, }:
+let
+  opteedflag = if enable-tee then "SPD=opteed" else "";
   target-board = "imx8mp";
-in
-  buildArmTrustedFirmware rec {
-    pname = "imx8mp-atf";
-    platform = target-board;
-    enableParallelBuilding = true;
-    extraMeta.platforms = ["aarch64-linux"];
+in stdenv.mkDerivation rec {
+  pname = "imx8mp-atf";
+  version = "lf6.1.55_2.2.0";
+  platform = target-board;
+  enableParallelBuilding = true;
 
-    src = fetchgit {
-      url = "https://github.com/nxp-imx/imx-atf.git";
-      #lf6.1.55_2.2.0
-      rev = "08e9d4eef2262c0dd072b4325e8919e06d349e02";
-      sha256 = "sha256-96EddJXlFEkP/LIGVgNBvUP4IDI3BbDE/c9Yub22gnc=";
-    };
+  src = fetchgit {
+    url = "https://github.com/nxp-imx/imx-atf.git";
+    rev = "08e9d4eef2262c0dd072b4325e8919e06d349e02";
+    sha256 = "sha256-96EddJXlFEkP/LIGVgNBvUP4IDI3BbDE/c9Yub22gnc=";
+  };
 
-    makeFlags = [ 
-      "HOSTCC=$(CC_FOR_BUILD)"
-      "M0_CROSS_COMPILE=arm-none-eabi-"
-      "CROSS_COMPILE=aarch64-unknown-linux-gnu-"
-      # binutils 2.39 regression
-      # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`
-      # See also: https://developer.trustedfirmware.org/T996
-      "LDFLAGS=-no-warn-rwx-segments"
-      "PLAT=${platform}" "bl31" "${opteedflag}"
-    ];  
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-    filesToInstall = ["build/${target-board}/release/bl31.bin"];
-  }
+  # For Cortex-M0 firmware in RK3399
+  nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
+
+  buildInputs = [ openssl ];
+
+  makeFlags = [
+    "HOSTCC=$(CC_FOR_BUILD)"
+    "M0_CROSS_COMPILE=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    # binutils 2.39 regression
+    # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`
+    # See also: https://developer.trustedfirmware.org/T996
+    "LDFLAGS=-no-warn-rwx-segments"
+    "PLAT=${platform}"
+    "bl31"
+    "${opteedflag}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp build/${target-board}/release/bl31.bin $out
+
+    runHook postInstall
+  '';
+
+  hardeningDisable = [ "all" ];
+  dontStrip = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/nxp-imx/imx-atf";
+    description =
+      "Reference implementation of secure world software for ARMv8-A";
+    license = [ licenses.bsd3 ];
+    maintainers = with maintainers; [ gngram ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
@@ -10,7 +10,6 @@ with pkgs; let
     else "";
 
   imx8mp-atf = pkgs.callPackage ./imx8mp-atf.nix {
-    inherit (pkgs) buildArmTrustedFirmware;
     inherit enable-tee;
   };
   imx8mp-firmware = pkgs.callPackage ./imx8mp-firmware.nix {};

--- a/nxp/imx8mq-evk/bsp/imx8mq-atf.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-atf.nix
@@ -1,34 +1,57 @@
-{
-  lib,
-  pkgs,
-  buildArmTrustedFirmware,
-  fetchgit,
-  enable-tee,
-}:
-with pkgs; let
-  opteedflag =
-    if enable-tee
-    then "SPD=opteed"
-    else "";
+{ lib, fetchgit, enable-tee, stdenv, buildPackages, pkgsCross, openssl, }:
+let
+  opteedflag = if enable-tee then "SPD=opteed" else "";
   target-board = "imx8mq";
-in
-  buildArmTrustedFirmware rec {
-    pname = "imx8mq-atf";
-    platform = target-board;
-    enableParallelBuilding = true;
-    extraMeta.platforms = ["aarch64-linux"];
+in stdenv.mkDerivation rec {
+  pname = "imx8mq-atf";
+  version = "lf6.1.55_2.2.0";
+  platform = target-board;
+  enableParallelBuilding = true;
 
-    src = fetchgit {
-      url = "https://github.com/nxp-imx/imx-atf.git";
-      #lf6.1.55_2.2.0
-      rev = "08e9d4eef2262c0dd072b4325e8919e06d349e02";
-      sha256 = "sha256-96EddJXlFEkP/LIGVgNBvUP4IDI3BbDE/c9Yub22gnc=";
-    };
+  src = fetchgit {
+    url = "https://github.com/nxp-imx/imx-atf.git";
+    rev = "08e9d4eef2262c0dd072b4325e8919e06d349e02";
+    sha256 = "sha256-96EddJXlFEkP/LIGVgNBvUP4IDI3BbDE/c9Yub22gnc=";
+  };
 
-    extraMakeFlags = lib.concatLists [
-      (lib.optional (lib.versionAtLeast pkgs.binutils.version "2.39") "LDFLAGS=--no-warn-rwx-segments")
-      ["PLAT=${platform}" "bl31" "${opteedflag}"]
-    ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-    filesToInstall = ["build/${target-board}/release/bl31.bin"];
-  }
+  # For Cortex-M0 firmware in RK3399
+  nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
+
+  buildInputs = [ openssl ];
+
+  makeFlags = [
+    "HOSTCC=$(CC_FOR_BUILD)"
+    "M0_CROSS_COMPILE=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    # binutils 2.39 regression
+    # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`
+    # See also: https://developer.trustedfirmware.org/T996
+    "LDFLAGS=-no-warn-rwx-segments"
+    "PLAT=${platform}"
+    "bl31"
+    "${opteedflag}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp build/${target-board}/release/bl31.bin $out
+
+    runHook postInstall
+  '';
+
+  hardeningDisable = [ "all" ];
+  dontStrip = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/nxp-imx/imx-atf";
+    description =
+      "Reference implementation of secure world software for ARMv8-A";
+    license = [ licenses.bsd3 ];
+    maintainers = with maintainers; [ gngram ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
@@ -9,7 +9,6 @@ with pkgs; let
     else "";
 
   imx8mq-atf = pkgs.callPackage ./imx8mq-atf.nix {
-    inherit (pkgs) buildArmTrustedFirmware;
     inherit enable-tee;
   };
   imx8mq-firmware = pkgs.callPackage ./imx8mq-firmware.nix {};


### PR DESCRIPTION
###### Description of changes
Fixes native build issue for iMX8MP-evk
Fixes cross and native build issue for iMX8MQ-evk

###### Things done
- Using package specific derivation instead of buildArmTrustedFirmware
 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

