### PR TITLE
Add Lenovo ThinkPad X1 Yoga Gen 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad W520](lenovo/thinkpad/w520)                                      | `<nixos-hardware/lenovo/thinkpad/w520>`                 |
 | [Lenovo ThinkPad X1 Yoga](lenovo/thinkpad/x1/yoga)                                | `<nixos-hardware/lenovo/thinkpad/x1/yoga>`              |
 | [Lenovo ThinkPad X1 Yoga Gen 7](lenovo/thinkpad/x1/yoga/7th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/7th-gen>`      |
+| [Lenovo ThinkPad X1 Yoga Gen 8](lenovo/thinkpad/x1/yoga/8th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/8th-gen>`      |
 | [Lenovo ThinkPad X1 (2nd Gen)](lenovo/thinkpad/x1/2nd-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/2nd-gen>`           |
 | [Lenovo ThinkPad X1 (6th Gen)](lenovo/thinkpad/x1/6th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`           |
 | [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`           |

--- a/flake.nix
+++ b/flake.nix
@@ -234,6 +234,7 @@
         lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
         lenovo-thinkpad-x1-yoga = import ./lenovo/thinkpad/x1/yoga;
         lenovo-thinkpad-x1-yoga-7th-gen = import ./lenovo/thinkpad/x1/yoga/7th-gen;
+        lenovo-thinkpad-x1-yoga-8th-gen = import ./lenovo/thinkpad/x1/yoga/8th-gen;
         lenovo-thinkpad-x1-2nd-gen = import ./lenovo/thinkpad/x1/2nd-gen;
         lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
         lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;

--- a/lenovo/thinkpad/x1/yoga/8th-gen/default.nix
+++ b/lenovo/thinkpad/x1/yoga/8th-gen/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../.
+    ../../../../../common/pc/laptop/ssd
+  ];
+}


### PR DESCRIPTION
Convertible laptop equipped with e.g. 13th Gen Intel Core i7-1365U × 12, 32 GiB RAM, and 512 MiB or 1 TiB SSD HDD.

###### Description of changes

Adds a configuration, which is practically identical to the [7th-gen model](https://github.com/NixOS/nixos-hardware/blob/master/lenovo/thinkpad/x1/yoga/7th-gen/default.nix).

@MayNiklas, would you mind to review?

###### Additional Context

1.) The model has a fingerprint reader integrated in the power button. I'm not sure whether this is already covered or I should to add [the related configuration](https://github.com/NixOS/nixos-hardware/blob/master/lenovo/thinkpad/default.nix#L10C5-L10C35) to this PR.

2.) My `hardware-configuration.nix`, which is derived from the one generated by the GUI installer, looks like this:

```nix
{ config, lib, modulesPath, ... }:
{
  imports = [
    (modulesPath + "/installer/scan/not-detected.nix")
  ];

  boot = {
    initrd.availableKernelModules = [ "xhci_pci" "thunderbolt" "nvme" "usb_storage" "sd_mod" ];
    initrd.kernelModules = [ ];
    kernelModules = [ "kvm-intel" ];
    extraModulePackages = [ ];
  };

  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
  services.fwupd.enable = true;
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
