### PR TITLE
Add Framework AMD AI 300 Series

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See code for all available configurations.
 | [Framework 13th Gen Intel Core](framework/13-inch/13th-gen-intel)                 | `<nixos-hardware/framework/13-inch/13th-gen-intel>`     |
 | [Framework Intel Core Ultra Series 1](framework/13-inch/intel-core-ultra-series1) | `<nixos-hardware/framework/13-inch/intel-core-ultra-series1>`     |
 | [Framework 13 AMD Ryzen 7040 Series](framework/13-inch/7040-amd)                  | `<nixos-hardware/framework/13-inch/7040-amd>`           |
+| [Framework 13 AMD AI 300 Series](framework/13-inch/amd-ai-300-series)             | `<nixos-hardware/framework/13-inch/amd-ai-300-series>`  |
 | [Framework 16 AMD Ryzen 7040 Series](framework/16-inch/7040-amd)                  | `<nixos-hardware/framework/16-inch/7040-amd>`           |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                                    | `<nixos-hardware/friendlyarm/nanopc-t4>`                |
 | [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                                  | `<nixos-hardware/friendlyarm/nanopi-r5s>`               |

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,7 @@
         framework-13th-gen-intel = import ./framework/13-inch/13th-gen-intel;
         framework-intel-core-ultra-series1 = import ./framework/13-inch/intel-core-ultra-series1;
         framework-13-7040-amd = import ./framework/13-inch/7040-amd;
+        framework-amd-ai-300-series = import ./framework/13-inch/amd-ai-300-series;
         framework-16-7040-amd = import ./framework/16-inch/7040-amd;
         friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
         friendlyarm-nanopi-r5s = import ./friendlyarm/nanopi-r5s;

--- a/framework/13-inch/amd-ai-300-series/README.md
+++ b/framework/13-inch/amd-ai-300-series/README.md
@@ -1,0 +1,15 @@
+# [Framework Laptop 13](https://frame.work/)
+
+## Updating Firmware
+
+First put enable `fwupd`
+
+```nix
+services.fwupd.enable = true;
+```
+
+Then run
+
+```sh
+ $ fwupdmgr update
+```

--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../common
+    ../common/amd.nix
+  ];
+  config.hardware.framework.laptop13.audioEnhancement.rawDeviceName = lib.mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
+}


### PR DESCRIPTION
###### Description of changes

Add a module for the new Framework AMD AI 300 Series.  Largely this is a clone of the 7040 AMD series module.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

