### PR TITLE
Lenovo X1 2nd Gen: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad W520](lenovo/thinkpad/w520)                                      | `<nixos-hardware/lenovo/thinkpad/w520>`                 |
 | [Lenovo ThinkPad X1 Yoga](lenovo/thinkpad/x1/yoga)                                | `<nixos-hardware/lenovo/thinkpad/x1/yoga>`              |
 | [Lenovo ThinkPad X1 Yoga Gen 7](lenovo/thinkpad/x1/yoga/7th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/7th-gen>`      |
+| [Lenovo ThinkPad X1 (2nd Gen)](lenovo/thinkpad/x1/2nd-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/2nd-gen>`           |
 | [Lenovo ThinkPad X1 (6th Gen)](lenovo/thinkpad/x1/6th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`           |
 | [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`           |
 | [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`           |

--- a/flake.nix
+++ b/flake.nix
@@ -230,6 +230,7 @@
         lenovo-thinkpad-x1 = import ./lenovo/thinkpad/x1;
         lenovo-thinkpad-x1-yoga = import ./lenovo/thinkpad/x1/yoga;
         lenovo-thinkpad-x1-yoga-7th-gen = import ./lenovo/thinkpad/x1/yoga/7th-gen;
+        lenovo-thinkpad-x1-2nd-gen = import ./lenovo/thinkpad/x1/2nd-gen;
         lenovo-thinkpad-x1-6th-gen = import ./lenovo/thinkpad/x1/6th-gen;
         lenovo-thinkpad-x1-7th-gen = import ./lenovo/thinkpad/x1/7th-gen;
         lenovo-thinkpad-x1-9th-gen = import ./lenovo/thinkpad/x1/9th-gen;

--- a/lenovo/thinkpad/x1/2nd-gen/default.nix
+++ b/lenovo/thinkpad/x1/2nd-gen/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+{
+  imports = [
+    ../.
+    ../../../../common/cpu/intel/haswell
+    ../../../../common/pc/laptop/ssd
+  ];
+
+  services.throttled.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes
The 2nd Gen might be a bit aged, but mine runs still very well. So far I was using the 7th gen module, but thought it might potentially be helpfull to actually pull Haswell optimizations.

Until I can check those boxes below I'll leave this as draft.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

