### PR TITLE
dell-precision-5530: remove unnecessary default nvidia options

### DIFF
--- a/dell/precision/5530/default.nix
+++ b/dell/precision/5530/default.nix
@@ -1,4 +1,4 @@
-{ lib, config, ... }:
+{ lib, ... }:
 
 {
   imports = [
@@ -29,19 +29,17 @@
 
   hardware = {
     nvidia = {
-      open = lib.mkDefault false;
       nvidiaSettings = lib.mkDefault true;
       modesetting.enable = lib.mkDefault true;
-      package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.stable;
       prime = {
         intelBusId = lib.mkDefault "PCI:0:2:0";
         nvidiaBusId = lib.mkDefault "PCI:1:0:0";
       };
     };
   };
-  # This will save you money and possibly your life!
   services = {
     fwupd.enable = lib.mkDefault true;
+     # This will save you money and possibly your life!
     thermald.enable = lib.mkDefault true;
   };
 }


### PR DESCRIPTION
In the nvidia module, we already disable the open source driver and we default to the stable nvidia package.

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

