### PR TITLE
lenovo/thinkpad/x13s: source kernel through `config` instead of `pkgs`

### DIFF
--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -1,10 +1,12 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 let
+  inherit (config.boot.kernelPackages) kernel;
+
   dtbName = "sc8280xp-lenovo-thinkpad-x13s.dtb";
-  dtb = "${pkgs.linux}/dtbs/qcom/${dtbName}";
+  dtb = "${kernel}/dtbs/qcom/${dtbName}";
   # Version the dtb based on the kernel
-  dtbEfiPath = "dtbs/x13s-${pkgs.linux.version}.dtb";
+  dtbEfiPath = "dtbs/x13s-${kernel.version}.dtb";
   cfg = {
    wifiMac = "e4:65:38:52:22:a9";
    bluetoothMac = "E4:25:18:22:44:AA";


### PR DESCRIPTION
###### Description of changes

The previous implementation was sourcing the kernel through `pkgs.linux`,
which is only representative of the final system if `boot.kernelPackages`
is left as the default value of `pkgs.linuxPackages`.

You can of course change this to other package sets, such as
`pkgs.linuxPackages_latest`. Instead, we now reference the kernel
through `config.boot.kernelPackages.kernel`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
- [x] Tested evaluation of modules with `nix run ./tests#run .` to succeed.
