### PR TITLE
lenovo/thinkpad/p14s: check kernel version through `config` instead of `pkgs`

### DIFF
--- a/lenovo/thinkpad/p14s/default.nix
+++ b/lenovo/thinkpad/p14s/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   # P14s is a rebadged T14 with slight internal differences.
@@ -14,7 +14,7 @@
   # "vendor" setting, in this case the thinkpad_acpi driver.
   # See https://hansdegoede.livejournal.com/27130.html
   # See https://lore.kernel.org/linux-acpi/20221105145258.12700-1-hdegoede@redhat.com/
-  boot.kernelParams = lib.mkIf (lib.versionOlder pkgs.linux.version "6.2") [ "acpi_backlight=native" ];
+  boot.kernelParams = lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.2") [ "acpi_backlight=native" ];
 
   # see https://github.com/NixOS/nixpkgs/issues/69289
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "5.2") pkgs.linuxPackages_latest;


### PR DESCRIPTION
###### Description of changes

The previous implementation was checking the kernel version through
`pkgs.linux`, which is only representative of the final system if
`boot.kernelPackages` is left as the default value of
`pkgs.linuxPackages`.

You can of course change this to other package sets, such as
`pkgs.linuxPackages_latest`. Instead, we now reference the kernel
through `config.boot.kernelPackages.kernel`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
- [x] Tested evaluation of modules with `nix run ./tests#run .` to succeed.
