### PR TITLE
hp/elitebook/830/g6: check kernel version through `config` instead of `pkgs`

### DIFF
--- a/hp/elitebook/830/g6/default.nix
+++ b/hp/elitebook/830/g6/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ config, lib, ... }:
 {
   imports = [
     ../../../../common/cpu/intel
@@ -16,7 +16,7 @@
   services.fwupd.enable = lib.mkDefault true;
 
   # Enables ACPI platform profiles
-  boot = lib.mkIf (lib.versionAtLeast pkgs.linux.version "6.1") {
+  boot = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.1") {
     kernelModules = [ "hp-wmi" ];
   };
 


### PR DESCRIPTION
###### Description of changes

The previous implementation was checking the kernel version through
`pkgs.linux`, which is only representative of the final system if
`boot.kernelPackages` is left as the default value of
`pkgs.linuxPackages`.

You can of course change this to other package sets, such as
`pkgs.linuxPackages_latest`. Instead, we now reference the kernel
through `config.boot.kernelPackages.kernel`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

- [x] Tested evaluation of modules with `nix run ./tests#run .` to succeed.
