### PR TITLE
gmktec/nucbox/g3-plus: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ See code for all available configurations.
 | [Focus M2 Gen 1](focus/m2/gen1)                                                   | `<nixos-hardware/focus/m2/gen1>`                        |
 | [Gigabyte B550](gigabyte/b550)                                                    | `<nixos-hardware/gigabyte/b550>`                        |
 | [Gigabyte B650](gigabyte/b650)                                                    | `<nixos-hardware/gigabyte/b650>`                        |
+| [GMKtec NucBox G3 Plus](gmktec/nucbox/g3-plus)                                    | `<nixos-hardware/gmktec/nucbox/g3-plus>`                |
 | [GPD MicroPC](gpd/micropc)                                                        | `<nixos-hardware/gpd/micropc>`                          |
 | [GPD P2 Max](gpd/p2-max)                                                          | `<nixos-hardware/gpd/p2-max>`                           |
 | [GPD Pocket 3](gpd/pocket-3)                                                      | `<nixos-hardware/gpd/pocket-3>`                         |

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
         focus-m2-gen1 = import ./focus/m2/gen1;
         gigabyte-b550 = import ./gigabyte/b550;
         gigabyte-b650 = import ./gigabyte/b650;
+        gmktec-nucbox-g3-plus = import ./gmktec/nucbox/g3-plus;
         google-pixelbook = import ./google/pixelbook;
         gpd-micropc = import ./gpd/micropc;
         gpd-p2-max = import ./gpd/p2-max;

--- a/gmktec/nucbox/g3-plus/default.nix
+++ b/gmktec/nucbox/g3-plus/default.nix
@@ -1,0 +1,27 @@
+/*
+ * `gmktec-nucbox-g3-plus`:
+ *
+ * Product page:
+ * <https://www.gmktec.com/products/nucbox-g3-plus-enhanced-performance-mini-pc-with-intel-n150-processor>
+ *
+ * This profile just configures the Intel
+ * Twin Lake N150 CPU and integrated
+ * graphics for this mini-PC. fstrim is also
+ * enabled for the SSD. That's all this seemed
+ * to need to function properly. As is now
+ * expected from Intel NUC systems, it provides
+ * a solid "out-of-the-box" experience. No
+ * special quirks are apparent.
+ *
+ * We import the Alder Lake modules since Twin
+ * Lake is just a refreshed version of the
+ * Alder Lake-N series. Re-using those seems
+ * to be fine for this purpose.
+ */
+{
+  imports = [
+    ../../../common/cpu/intel/alder-lake
+    ../../../common/gpu/intel/alder-lake
+    ../../../common/pc/ssd
+  ];
+}


### PR DESCRIPTION
###### Description of changes

Product page:
<https://www.gmktec.com/products/nucbox-g3-plus-enhanced-performance-mini-pc-with-intel-n150-processor>

This profile just configures the Intel Twin Lake N150 CPU and integrated graphics for this mini-PC. fstrim is also enabled for the SSD. That's all this seemed to need to function properly. As is now expected from Intel NUC systems, it provides a solid "out-of-the-box" experience. No special quirks are apparent.

We import the Alder Lake modules since Twin Lake is just a refreshed version of the Alder Lake-N series. Re-using those seems to be fine for this purpose.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
