### PR TITLE
Ensure WiFi works out-of-the-box on XPS13

### DIFF
--- a/dell/xps/13-9343/default.nix
+++ b/dell/xps/13-9343/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
   imports = [
@@ -7,6 +7,14 @@
     ../../../common/pc/ssd
   ];
 
-  # This will save you money and possibly your life!
-  services.thermald.enable = lib.mkDefault true;
+  services = {
+    fwupd.enable = lib.mkDefault true;
+    thermald.enable = lib.mkDefault true;
+  };
+
+  boot = {
+    # needs to be explicitly loaded or else bluetooth/wifi won't work
+    kernelModules = [ "wl" ];
+    extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
+  };
 }


### PR DESCRIPTION
###### Description of changes

Inspired by the [Dell Inspiron 3442](https://github.com/NixOS/nixos-hardware/blob/master/dell/inspiron/3442/default.nix) setup.

My XPS 13 setup looks like this (originally autogenerated from the graphical installer). Not sure whether `availableKernelModules` should be added to the setup in this repository and so.

```nix
boot = {
  initrd.availableKernelModules = [ "xhci_pci" "ehci_pci" "ahci" "usb_storage" "sd_mod" "rtsx_pci_sdmmc" ];
  initrd.kernelModules = [ ];
  kernelModules = [ "kvm-intel" "wl" ];
  extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
};

nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
services.fwupd.enable = true;
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input
