### PR TITLE
add asus-rog-strix-g533zw

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See code for all available configurations.
 | [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/amdgpu)                      | `<nixos-hardware/asus/flow/gv302x/amdgpu>`              |
 | [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/nvidia)                      | `<nixos-hardware/asus/flow/gv302x/nvidia>`              |
 | [Asus ROG Strix G513IM](asus/rog-strix/g513im)                                    | `<nixos-hardware/asus/rog-strix/g513im>`                |
+| [Asus ROG Strix G533ZW](asus/rog-strix/g533zw)                                    | `<nixos-hardware/asus/rog-strix/g533zw>`                |
 | [Asus ROG Strix G713IE](asus/rog-strix/g713ie)                                    | `<nixos-hardware/asus/rog-strix/g713ie>`                |
 | [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                                    | `<nixos-hardware/asus/rog-strix/g733qs>`                |
 | [Asus ROG Strix X570-E GAMING](asus/rog-strix/x570e)                              | `<nixos-hardware/asus/rog-strix/x570e>`                 |

--- a/asus/rog-strix/g533zw/default.nix
+++ b/asus/rog-strix/g533zw/default.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ampere
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../battery.nix
+  ];
+
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  }; 
+}

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
         asus-flow-gv302x-nvidia = import ./asus/flow/gv302x/nvidia;
         asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;
         asus-rog-strix-g513im = import ./asus/rog-strix/g513im;
+        asus-rog-strix-g533zw = import ./asus/rog-strix/g533zw;
         asus-rog-strix-g713ie = import ./asus/rog-strix/g713ie;
         asus-rog-strix-g733qs = import ./asus/rog-strix/g733qs;
         asus-rog-strix-x570e = import ./asus/rog-strix/x570e;


### PR DESCRIPTION
###### Description of changes
Add support for Asus ROG Strix G533zw. The configuration is based on the asus-zephyrus-gu603h since they have essentially the same hardware. I also included asus/battery.nix support though this may not be necessary.

###### Things done

I ran the tests pointing the nixos-hardware URL to my fork, am currently using my nixos-hardware fork as an input and including the asus-rog-strix-g533zw package. Everything is working!

I also added the import to the flake.nix file and included an entry in the README.md!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ :heavy_check_mark:  ] Tested the changes in your own NixOS Configuration
- [ :heavy_check_mark:  ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

