### PR TITLE
TUXEDO Infinitybook: Enable bluetooth by default

### DIFF
--- a/tuxedo/infinitybook/default.nix
+++ b/tuxedo/infinitybook/default.nix
@@ -5,8 +5,12 @@
     ../../common/pc/ssd
   ];
 
-  # Enable TUXEDO's kernel drivers if they are available
-  hardware = lib.optionalAttrs (options.hardware ? tuxedo-drivers) {
-    tuxedo-drivers.enable = lib.mkDefault true;
-  };
+  hardware =
+    lib.mkDefault {
+      bluetooth.enable = true;
+    }
+    # Enable TUXEDO's kernel drivers if they are available
+    // lib.optionalAttrs (options.hardware ? tuxedo-drivers) {
+      tuxedo-drivers.enable = true;
+    };
 }


### PR DESCRIPTION
###### Description of changes

As all Infinitybook models come equipped with Bluetooth, I think it's a good idea to enable it by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

