### PR TITLE
Add Lenovo Ideapad 5 Pro 14IMH9 / XiaoXin Pro 14IMH9 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ See code for all available configurations.
 | [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                                  | `<nixos-hardware/lenovo/ideapad/15alc6>`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)                         | `<nixos-hardware/lenovo/ideapad/15arh05>`               |
 | [Lenovo IdeaPad Gaming 3 15ach6](lenovo/ideapad/15ach6)                           | `<nixos-hardware/lenovo/ideapad/15ach6>`                |
+| [Lenovo IdeaPad 5 Pro 14imh9](lenovo/ideapad/14imh9)                              | `<nixos-hardware/lenovo/ideapad/14imh9>`                |
 | [Lenovo IdeaPad 5 Pro 16ach6](lenovo/ideapad/16ach6)                              | `<nixos-hardware/lenovo/ideapad/16ach6>`                |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                                        | `<nixos-hardware/lenovo/ideapad/z510>`                  |
 | [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                                    | `<nixos-hardware/lenovo/ideapad/slim-5>`                |
@@ -324,6 +325,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad Z Series](lenovo/thinkpad/z)                                     | `<nixos-hardware/lenovo/thinkpad/z>`                    |
 | [Lenovo ThinkPad Z13 Gen 1](lenovo/thinkpad/z/gen1/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/gen1/z13>`           |
 | [Lenovo ThinkPad Z13 Gen 2](lenovo/thinkpad/z/gen2/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/gen2/z13>`           |
+| [Lenovo XiaoXin Pro 14imh9 2024](lenovo/ideapad/14imh9)                           | `<nixos-hardware/lenovo/ideapad/14imh9>`                |
 | [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                                 | `<nixos-hardware/lenovo/yoga/6/13ALC6>`                 |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/amdgpu)               | `<nixos-hardware/lenovo/yoga/7/14ARH7/amdgpu>`          |
 | [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)               | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          |

--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,7 @@
         hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
         intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
         lenovo-ideacentre-k330 = import ./lenovo/ideacentre/k330;
+        lenovo-ideapad-14imh9 = import ./lenovo/ideapad/14imh9;
         lenovo-ideapad-15alc6 = import ./lenovo/ideapad/15alc6;
         lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;
         lenovo-ideapad-15ach6 = import ./lenovo/ideapad/15ach6;

--- a/lenovo/ideapad/14imh9/README.md
+++ b/lenovo/ideapad/14imh9/README.md
@@ -1,0 +1,16 @@
+# Lenovo Ideapad 5 Pro 14IMH9 / XiaoXin Pro 14IMH9 2024
+
+These devices support Conservation mode which charges the battery to 79/80%. See [TLP docs](https://linrunner.de/tlp/settings/bc-vendors.html#lenovo-non-thinkpad-series) and [auto-cpu freq](https://github.com/AdnanHodzic/auto-cpufreq?tab=readme-ov-file#battery-charging-thresholds) to enable it.
+
+`lspci`:
+```
+00:02.0 VGA compatible controller: Intel Corporation Meteor Lake-P [Intel Arc Graphics] (rev 08)
+```
+There is no dedicated graphics card. See specs [here](https://psref.lenovo.com/syspool/Sys/PDF/IdeaPad/IdeaPad_Pro_5_14IMH9/IdeaPad_Pro_5_14IMH9_Spec.pdf).
+
+## Extra Configuration
+### Bluetooth
+To enable bluetooth support, set `hardware.bluetooth.enable = true;`.
+
+### Sound
+This laptop need extra firmware for hi-quality sound. To enable that, set `hardware.firmware = [ pkgs.sof-firmware ];`.

--- a/lenovo/ideapad/14imh9/default.nix
+++ b/lenovo/ideapad/14imh9/default.nix
@@ -1,0 +1,110 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel/meteor-lake
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  boot = {
+    # Workaround: Out of the box, resuming from hibernation will break sounds.
+    #             See https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/766
+    extraModprobeConfig = ''
+      options snd-hda-intel model=generic
+      options snd-hda-intel snd-intel-dspcfg.dsp_driver=1
+      blacklist snd_soc_skl
+    '';
+
+    kernelParams = [
+      # Workaround: i915 0000:00:02.0: [drm] *ERROR* Atomic update failure on pipe A
+      #             See https://www.dedoimedo.com/computers/intel-microcode-atomic-update.html
+      "i915.enable_psr=0"
+
+      # Workaround: Seems like guc on VT-d is faulty and may also cause GUC: TLB invalidation response timed out.
+      #             It will cause random gpu resets under hw video decoding.
+      #             See https://wiki.archlinux.org/title/Dell_XPS_16_(9640)#Random_freezes
+      "iommu.strict=1"
+      "iommu.passthrough=1"
+    ];
+  };
+
+  environment.variables = {
+    # Workaround: GPU HANG: ecode 12:1:85dffdfb, in CanvasRenderer [4408]
+    #             See https://gitlab.freedesktop.org/mesa/mesa/-/issues/7755
+    INTEL_DEBUG = "no32";
+  };
+
+  systemd = {
+    # Workaround: Sometimes xhci driver will become malfunctional after resuming from hibernate / suspend.
+    #             This will cause (almost) all external devices stop working.
+    #             A simple reset is enough to bring external devices alive :)
+    #
+    #             Note: to avoid unnecessary resets, we firstly check if integrated camera is presented
+    #                   (Should always be there as it was built into machine!).
+    #                   If not, just do the reset.
+    services.workaround-reset-xhci-driver-after-resume-if-needed = {
+      script = ''
+        result=$(${pkgs.usbutils}/bin/lsusb | ${pkgs.gnugrep}/bin/grep Chicony)
+        if [[ -z $result ]]; then
+          ${pkgs.kmod}/bin/rmmod xhci_pci xhci_hcd
+          ${pkgs.kmod}/bin/modprobe xhci_pci xhci_hcd
+        fi
+      '';
+      after = [
+        "suspend.target"
+        "hibernate.target"
+        "hybrid-sleep.target"
+      ];
+      wantedBy = [
+        "suspend.target"
+        "hibernate.target"
+        "hybrid-sleep.target"
+        "multi-user.target"
+      ];
+    };
+
+    # Workaround: Lenovo seems write bad acpi power management firmware. Without this config,
+    #             suspend (to ram / disk) will simply reboot instead of power off. :(
+    sleep.extraConfig = ''
+      HibernateMode=shutdown
+    '';
+  };
+
+  # TPM2 module
+  security.tpm2.enable = lib.mkDefault true;
+
+  hardware = {
+    enableRedistributableFirmware = lib.mkDefault true; # WiFi
+
+    # Workaround: Lenovo wrote bad screen edid firmware that will cause system
+    #             not able to use 120Hz screen fresh rate.
+    #             Manually patch it with correct value fixes this problem.
+    #
+    #             TODO: This laptop actually support VRR (Variable refresh rate).
+    #                   But I do not have any interests in supporting this.
+    #                   PR is welecomed :)
+    display = {
+      edid.packages = [
+        (pkgs.runCommand "edid-14imh9" { } ''
+          mkdir -p "$out/lib/firmware/edid"
+          base64 -d > "$out/lib/firmware/edid/14imh9.bin" <<'EOF'
+          AP///////wAObxYUAAAAAAAgAQS1HhN4AyEVqFNJnCUPUFQAAAABAQEBAQEBAQEBAQEBAQEBzodAoLAIanAwIDYALbwQAAAYAAAA/QAoeOXlRgEKICAgICAgAAAA/gBDU09UIFQzCiAgICAgAAAA/gBNTkUwMDdaQTEtNQogAa9wE3kAAAMBFJoPAQU/C58ALwAfAAcHaQACAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4kA==
+          EOF
+        '')
+      ];
+
+      outputs = {
+        "eDP-1".edid = "14imh9.bin";
+      };
+    };
+
+    i2c.enable = lib.mkDefault true; # Touchpad
+  };
+
+  services = {
+    fwupd.enable = lib.mkDefault true; # Firmware Upgrades. Partially supported.
+    hardware.bolt.enable = lib.mkDefault true; # Thunderbolt
+    thermald.enable = lib.mkDefault true; # This will save you money and possibly your life!
+  };
+}


### PR DESCRIPTION
###### Description of changes
Added the definition for `Lenovo Ideapad 5 Pro 14IMH9 / XiaoXin Pro 14IMH9 2024`. They are basically the same product but rebranded and sold in different regions.

As there were a lot of vendor specific changes, `README.md` does not document all of them. Comments in `default.nix` should be self-explanatory, though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

