### PR TITLE
lenovo/legion/15ich: Use Coffee Lake CPU

### DIFF
--- a/lenovo/legion/15ich/default.nix
+++ b/lenovo/legion/15ich/default.nix
@@ -2,7 +2,7 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
+    ../../../common/cpu/intel/coffee-lake
     ../../../common/gpu/nvidia/prime.nix
     ../../../common/gpu/nvidia/pascal
     ../../../common/pc/laptop


### PR DESCRIPTION
###### Description of changes

Updated CPU import for the Lenovo Legion Y530-15ICH to use the generation specific CPU rather than the generic import. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

