### PR TITLE
Enable fingerprint reader and FW update for Lenovo X1 Yoga models

### DIFF
--- a/lenovo/thinkpad/x1/yoga/default.nix
+++ b/lenovo/thinkpad/x1/yoga/default.nix
@@ -4,5 +4,9 @@
     ../../yoga.nix
   ];
 
-  services.xserver.wacom.enable = lib.mkDefault config.services.xserver.enable;
+  services = {
+    fprintd.enable = lib.mkDefault true;
+    fwupd.enable = lib.mkDefault true;
+    xserver.wacom.enable = lib.mkDefault config.services.xserver.enable;
+  };
 }


### PR DESCRIPTION
###### Description of changes

Assuming that all (recent) Lenovo X1 Yoga models have an integrated fingerprint reader and allow updating the firmware, we can enable the two related services by default.

Ping for review @Mic92, @MayNiklas, @mschneiderwng

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input
