### PR TITLE
framework: Add framework12

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ See code for all available configurations.
 | [Framework Intel Core Ultra Series 1](framework/13-inch/intel-core-ultra-series1) | `<nixos-hardware/framework/13-inch/intel-core-ultra-series1>`     |
 | [Framework 13 AMD Ryzen 7040 Series](framework/13-inch/7040-amd)                  | `<nixos-hardware/framework/13-inch/7040-amd>`           |
 | [Framework 13 AMD AI 300 Series](framework/13-inch/amd-ai-300-series)             | `<nixos-hardware/framework/13-inch/amd-ai-300-series>`  |
+| [Framework 12 13th Gen Intel Core](framework/12-inch/13th-gen-intel)              | `<nixos-hardware/framework/12-inch/13th-gen-intel>`     |
 | [Framework 16 AMD Ryzen 7040 Series](framework/16-inch/7040-amd)                  | `<nixos-hardware/framework/16-inch/7040-amd>`           |
 | [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                                    | `<nixos-hardware/friendlyarm/nanopc-t4>`                |
 | [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                                  | `<nixos-hardware/friendlyarm/nanopi-r5s>`               |

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,7 @@
         framework-11th-gen-intel = import ./framework/13-inch/11th-gen-intel;
         framework-12th-gen-intel = import ./framework/13-inch/12th-gen-intel;
         framework-13th-gen-intel = import ./framework/13-inch/13th-gen-intel;
+        framework-12-13th-gen-intel = import ./framework/12-inch/13th-gen-intel;
         framework-intel-core-ultra-series1 = import ./framework/13-inch/intel-core-ultra-series1;
         framework-13-7040-amd = import ./framework/13-inch/7040-amd;
         framework-amd-ai-300-series = import ./framework/13-inch/amd-ai-300-series;

--- a/framework/12-inch/13th-gen-intel/README.md
+++ b/framework/12-inch/13th-gen-intel/README.md
@@ -1,0 +1,17 @@
+# [Framework Laptop 12](https://frame.work/laptop12)
+
+## Updating Firmware
+
+First put enable `fwupd`
+
+```nix
+services.fwupd.enable = true;
+```
+
+Then run
+
+```sh
+ $ fwupdmgr update
+```
+
+- [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop12.RPL.BIOS.firmware)

--- a/framework/12-inch/13th-gen-intel/default.nix
+++ b/framework/12-inch/13th-gen-intel/default.nix
@@ -1,0 +1,7 @@
+{ config, lib, ... }:
+{
+  imports = [
+    ../common
+    ../../../common/cpu/intel
+  ];
+}

--- a/framework/12-inch/common/default.nix
+++ b/framework/12-inch/common/default.nix
@@ -1,0 +1,19 @@
+{ lib, config, ... }:
+{
+  imports = [
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../bluetooth.nix
+    ../../kmod.nix
+    ../../framework-tool.nix
+  ];
+
+  # Fix TRRS headphones missing a mic
+  # https://github.com/torvalds/linux/commit/7b509910b3ad6d7aacead24c8744de10daf8715d
+  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.13.0") ''
+    options snd-hda-intel model=dell-headset-multi
+  '';
+
+  # Needed for desktop environments to detect display orientation
+  hardware.sensor.iio.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes

Add support for the new [Framework Laptop 12](https://frame.work/laptop12).
Pre-orders have opened but devices haven't started shipping yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input