### PR TITLE
mkimage hash update for imx8mp and imx8mq eval platforms

### DIFF
--- a/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
@@ -22,7 +22,7 @@ in {
     src = pkgs.fetchgit {
       url = "https://github.com/nxp-imx/imx-mkimage.git";
       rev = "c4365450fb115d87f245df2864fee1604d97c06a";
-      sha256 = "sha256-xycEaWKVM63BlDyBKNN0OefyK6iX/fQOTvv4fRVM55U=";
+      sha256 = "sha256-sCih7KWjCfGPZKX3ZHp7XsaLzRo7GsMdLr8Vk/5mYKQ=";
       leaveDotGit = true;
     };
 

--- a/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
@@ -21,7 +21,7 @@ in {
     src = pkgs.fetchgit {
       url = "https://github.com/nxp-imx/imx-mkimage.git";
       rev = "c4365450fb115d87f245df2864fee1604d97c06a";
-      sha256 = "sha256-xycEaWKVM63BlDyBKNN0OefyK6iX/fQOTvv4fRVM55U=";
+      sha256 = "sha256-sCih7KWjCfGPZKX3ZHp7XsaLzRo7GsMdLr8Vk/5mYKQ=";
       leaveDotGit = true;
     };
 


### PR DESCRIPTION
###### Description of changes
Updated correct hash for mkimage utility for imx8mp and imx8mq eval platforms

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

