### PR TITLE
fix typo in framework audio.nix

### DIFF
--- a/framework/13-inch/common/audio.nix
+++ b/framework/13-inch/common/audio.nix
@@ -14,7 +14,7 @@ in
           This option requires PipeWire and WirePlumber.
 
           The filter chain includes the following:
-            - Pyschoacoustic bass enhancement
+            - Psychoacoustic bass enhancement
             - Loudness compensation
             - Equalizer
             - Slight compression


### PR DESCRIPTION
###### Description of changes
Just a fix to a typo in the description of the hardware.framework.laptop13.audioEnhancement option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

