### PR TITLE
Update correct hash for imx mkimage utility

### DIFF
--- a/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
@@ -15,18 +15,21 @@ with pkgs; let
   imx8mp-firmware = pkgs.callPackage ./imx8mp-firmware.nix {};
   imx8mp-uboot = pkgs.callPackage ./imx8mp-uboot.nix {};
   imx8mp-optee-os = pkgs.callPackage ./imx8mp-optee-os.nix {};
+  src = pkgs.fetchgit {
+    url = "https://github.com/nxp-imx/imx-mkimage.git";
+    rev = "c4365450fb115d87f245df2864fee1604d97c06a";
+    sha256 = "sha256-KVIVHwBpAwd1RKy3RrYxGIniE45CDlN5RQTXsMg1Jwk=";
+  };
+  shortRev = builtins.substring 0 8 src.rev;
 in {
   imx8m-boot = pkgs.stdenv.mkDerivation rec {
+    inherit src;
     name = "imx8mp-mkimage";
     version = "lf-6.1.55-2.2.0";
-    src = pkgs.fetchgit {
-      url = "https://github.com/nxp-imx/imx-mkimage.git";
-      rev = "c4365450fb115d87f245df2864fee1604d97c06a";
-      sha256 = "sha256-xycEaWKVM63BlDyBKNN0OefyK6iX/fQOTvv4fRVM55U=";
-      leaveDotGit = true;
-    };
 
     postPatch = ''
+      substituteInPlace Makefile \
+          --replace 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
       substituteInPlace Makefile \
           --replace 'CC = gcc' 'CC = clang'
       patchShebangs scripts

--- a/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
+++ b/nxp/imx8mq-evk/bsp/imx8mq-boot.nix
@@ -14,18 +14,21 @@ with pkgs; let
   imx8mq-firmware = pkgs.callPackage ./imx8mq-firmware.nix {};
   imx8mq-uboot = pkgs.callPackage ./imx8mq-uboot.nix {};
   imx8mq-optee-os = pkgs.callPackage ./imx8mq-optee-os.nix {};
+  src = pkgs.fetchgit {
+    url = "https://github.com/nxp-imx/imx-mkimage.git";
+    rev = "c4365450fb115d87f245df2864fee1604d97c06a";
+    sha256 = "sha256-KVIVHwBpAwd1RKy3RrYxGIniE45CDlN5RQTXsMg1Jwk=";
+  };
+  shortRev = builtins.substring 0 8 src.rev;
 in {
   imx8m-boot = pkgs.stdenv.mkDerivation rec {
+    inherit src;
     name = "imx8mq-mkimage";
     version = "lf-6.1.55-2.2.0";
-    src = pkgs.fetchgit {
-      url = "https://github.com/nxp-imx/imx-mkimage.git";
-      rev = "c4365450fb115d87f245df2864fee1604d97c06a";
-      sha256 = "sha256-xycEaWKVM63BlDyBKNN0OefyK6iX/fQOTvv4fRVM55U=";
-      leaveDotGit = true;
-    };
 
     postPatch = ''
+      substituteInPlace Makefile \
+          --replace 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
       substituteInPlace Makefile \
           --replace 'CC = gcc' 'CC = clang'
       patchShebangs scripts


### PR DESCRIPTION

###### Description of changes
**Update correct hash for imx mkimage utility**
- Don't fetch dotGit directory.
- DotGit directory gets different object packs when it is pulled from different nixpkgs versions which causes Hash mismatch.
 e.g. nixpkgs revs: 2631b0b7abcea6e640ce31cd78ea58910d31e650
 and 2795c506fe8fb7b03c36ccb51f75b6df0ab2553f produces different hash due to differences in dotgit object packs.
- Patch Makefile not use git revision from .git.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

