### PR TITLE
add optional config that makes lgpio and pigpio work

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -8,6 +8,7 @@
     ./cpu-revision.nix
     ./digi-amp-plus.nix
     ./dwc2.nix
+    ./gpio.nix
     ./i2c.nix
     ./leds.nix
     ./modesetting.nix

--- a/raspberry-pi/4/gpio.nix
+++ b/raspberry-pi/4/gpio.nix
@@ -1,0 +1,36 @@
+{ pkgs, lib, config, ... }:
+{
+  options.hardware.raspberry-pi."4".gpio = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      description =
+        "Enable udev rules and kernelParams that make lgpio and pigpio work";
+      default = false;
+    };
+  };
+  config = let
+    cfg = config.hardware.raspberry-pi."4".gpio;
+    in
+      lib.mkIf cfg.enable {
+        users.groups.gpio = lib.mkDefault { };
+
+        # the bit that matters to lgpio here is
+        # "${pkgs.coreutils}/bin/chgrp gpio /dev/%k && chmod 660 /dev/%k"
+        # see https://github.com/NixOS/nixpkgs/pull/352308
+
+        # sudo udevadm test --action=add /dev/gpiochip0 to test
+
+        # import lgpio; lgpio.gpiochip_open(0) should show "1" and not raise
+        # an exception
+
+        services.udev.extraRules = lib.mkBefore ''
+          KERNEL=="gpiomem", GROUP="gpio", MODE="0660"
+          SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/chgrp gpio /dev/%k && chmod 660 /dev/%k && ${pkgs.coreutils}/bin/chgrp -R gpio /sys/class/gpio && ${pkgs.coreutils}/bin/chmod -R g=u /sys/class/gpio'"
+          SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/chgrp -R gpio /sys%p && ${pkgs.coreutils}/bin/chmod -R g=u /sys%p'"
+       '';
+
+        boot.kernelParams = [
+          "iomem=relaxed" # for pigpiod
+        ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add an optional module via hardware.raspberry-pi."4".gpio.enable that allows lgpio and pgpiod to work.  Without this configuration, pigpiod won't start (it needs the `iomem=relaxed` kernel parameter), and lgpio won't work for users in the `gpio` group because the `/dev/gpiochip*` devices have the wrong permissions.

See also https://github.com/NixOS/nixpkgs/pull/352308

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X ] Tested the changes in your own NixOS Configuration
- [ X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

