### PR TITLE
dell-precision-3490: add variant without nvidia GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ See code for all available configurations.
 | [Dell Latitude E7240](dell/latitude/e7240)                                        | `<nixos-hardware/dell/latitude/e7240>`                  |
 | [Dell Optiplex 3050](dell/optiplex/3050)                                          | `<nixos-hardware/dell/optiplex/3050>`                   |
 | [Dell Poweredge R7515](dell/poweredge/r7515)                                      | `<nixos-hardware/dell/poweredge/r7515>`                 |
-| [Dell Precision 3490](dell/precision/3490)                                        | `<nixos-hardware/dell/precision/3490>`                  |
+| [Dell Precision 3490, nvidia](dell/precision/3490/nvidia)                         | `<nixos-hardware/dell/precision/3490/nvidia>`           |
+| [Dell Precision 3490, intel](dell/precision/3490/intel)                           | `<nixos-hardware/dell/precision/3490/intel>`            |
 | [Dell Precision 3541](dell/precision/3541)                                        | `<nixos-hardware/dell/precision/3541>`                  |
 | [Dell Precision 5490](dell/precision/5490)                                        | `<nixos-hardware/dell/precision/5490>`                  |
 | [Dell Precision 5530](dell/precision/5530)                                        | `<nixos-hardware/dell/precision/5530>`                  |

--- a/dell/precision/3490/default.nix
+++ b/dell/precision/3490/default.nix
@@ -1,21 +1,16 @@
 {
+  warnings = [
+    ''
+      DEPRECATED: The <nixos-hardware/dell/precision/3490> module has been deprecated.
+
+      Either use
+        <nixos-hardware/dell/precision/3490/nvidia>
+      for NVIDIA graphics or
+        <nixos-hardware/dell/precision/3490/intel>
+      for Intel graphics.
+    ''
+  ];
   imports = [
-    ../../../common/cpu/intel/meteor-lake
-    ../../../common/gpu/nvidia/ada-lovelace
-    ../../../common/pc/laptop
+    ./nvidia/default.nix
   ];
-
-  boot.initrd.availableKernelModules = [
-    "nvme"
-    "sd_mod"
-    "thunderbolt"
-    "usb_storage"
-    "vmd"
-    "xhci_pci"
-  ];
-
-  hardware.nvidia.prime = {
-    intelBusId = "PCI:0:2:0";
-    nvidiaBusId = "PCI:1:0:0";
-  };
 }

--- a/dell/precision/3490/intel/default.nix
+++ b/dell/precision/3490/intel/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ../shared.nix
+  ];
+}

--- a/dell/precision/3490/nvidia/default.nix
+++ b/dell/precision/3490/nvidia/default.nix
@@ -1,0 +1,12 @@
+{
+  imports = [
+    ../shared.nix
+    ../../../../common/gpu/nvidia/ada-lovelace
+  ];
+
+
+  hardware.nvidia.prime = {
+    intelBusId = "PCI:0:2:0";
+    nvidiaBusId = "PCI:1:0:0";
+  };
+}

--- a/dell/precision/3490/shared.nix
+++ b/dell/precision/3490/shared.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ../../../common/cpu/intel/meteor-lake
+    ../../../common/pc/laptop
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,11 @@
         dell-latitude-e7240 = import ./dell/latitude/e7240;
         dell-optiplex-3050 = import ./dell/optiplex/3050;
         dell-poweredge-r7515 = import ./dell/poweredge/r7515;
-        dell-precision-3490 = import ./dell/precision/3490;
+        dell-precision-3490 =
+          deprecated "1491" "dell-precision-3490"
+            (import ./dell/precision/3490);
+        dell-precision-3490-nvidia = import ./dell/precision/3490/nvidia;
+        dell-precision-3490-intel = import ./dell/precision/3490/intel;
         dell-precision-3541 = import ./dell/precision/3541;
         dell-precision-5490 = import ./dell/precision/5490;
         dell-precision-5530 = import ./dell/precision/5530;


### PR DESCRIPTION
###### Description of changes

This PR adds the 3490 variant without the nvidia GPU.

The `dell-precision-3490` output is now deprecated, and `*-nvidia` and `*-intel` output are created.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

