### PR TITLE
Add Lenovo Thinkpad X1 13th Gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad X1 (10th Gen)](lenovo/thinkpad/x1/10th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/10th-gen>`          |
 | [Lenovo ThinkPad X1 (11th Gen)](lenovo/thinkpad/x1/11th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/11th-gen>`          |
 | [Lenovo ThinkPad X1 (12th Gen)](lenovo/thinkpad/x1/12th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/12th-gen>`          |
+| [Lenovo ThinkPad X1 (13th Gen)](lenovo/thinkpad/x1/13th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/13th-gen>`          |
 | [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>`      |
 | [Lenovo ThinkPad X1 Extreme Gen 3](lenovo/thinkpad/x1-extreme/gen3)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen3>`      |
 | [Lenovo ThinkPad X1 Extreme Gen 4](lenovo/thinkpad/x1-extreme/gen4)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen4>`      |

--- a/flake.nix
+++ b/flake.nix
@@ -249,6 +249,7 @@
         lenovo-thinkpad-x1-10th-gen = import ./lenovo/thinkpad/x1/10th-gen;
         lenovo-thinkpad-x1-11th-gen = import ./lenovo/thinkpad/x1/11th-gen;
         lenovo-thinkpad-x1-12th-gen = import ./lenovo/thinkpad/x1/12th-gen;
+        lenovo-thinkpad-x1-13th-gen = import ./lenovo/thinkpad/x1/13th-gen;
         lenovo-thinkpad-x1-extreme = import ./lenovo/thinkpad/x1-extreme;
         lenovo-thinkpad-x1-extreme-gen2 = import ./lenovo/thinkpad/x1-extreme/gen2;
         lenovo-thinkpad-x1-extreme-gen3 = import ./lenovo/thinkpad/x1-extreme/gen3;

--- a/lenovo/thinkpad/x1/13th-gen/default.nix
+++ b/lenovo/thinkpad/x1/13th-gen/default.nix
@@ -1,0 +1,12 @@
+{lib, ...}:
+
+{
+  imports = [
+    ../../../../common/pc/ssd
+    ../../../../common/cpu/intel/lunar-lake
+  ];
+
+  hardware.trackpoint.device = "TPPS/2 Synaptics TrackPoint";
+
+  services.thermald.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes

Added Lenovo Thinkpad X1 13th Gen (Lunar Lake).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

