### PR TITLE
Address libusb rename in pinebook configuration for issue #1488

### DIFF
--- a/pine64/pinebook-pro/keyboard-updater/default.nix
+++ b/pine64/pinebook-pro/keyboard-updater/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, xxd, libusb }:
+{ stdenv, fetchFromGitHub, xxd, libusb1 }:
 
 stdenv.mkDerivation {
   pname = "pinebook-pro-keyboard-updater";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    libusb
+    libusb1
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes
This updates the changed name of libusb. Tested on my pinebook and it seems to worked for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

