### PR TITLE
Add dell precision-5680 hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ See code for all available configurations.
 | [Dell Precision 5530](dell/precision/5530)                                        | `<nixos-hardware/dell/precision/5530>`                  | `dell-precision-5530`              |
 | [Dell Precision 5560](dell/precision/5560)                                        | `<nixos-hardware/dell/precision/5560>`                  | `dell-precision-5560`              |
 | [Dell Precision 5570](dell/precision/5570)                                        | `<nixos-hardware/dell/precision/5570>`                  | `dell-precision-5570`              |
+| [Dell Precision 5680](dell/precision/5680)                                        | `<nixos-hardware/dell/precision/5680>`                  | `dell-precision-5680`              |
 | [Dell Precision 7520](dell/precision/7520)                                        | `<nixos-hardware/dell/precision/7520>`                  | `dell-precision-7520`              |
 | [Dell XPS 13 7390](dell/xps/13-7390)                                              | `<nixos-hardware/dell/xps/13-7390>`                     | `dell-xps-13-7390`                 |
 | [Dell XPS 13 9300](dell/xps/13-9300)                                              | `<nixos-hardware/dell/xps/13-9300>`                     | `dell-xps-13-9300`                 |

--- a/dell/precision/5680/default.nix
+++ b/dell/precision/5680/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  ...
+}:
+{
+  imports = [
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+  ];
+
+  boot = {
+    kernelModules = [ "kvm-intel" ];
+    initrd.availableKernelModules = [
+      "xhci_pci"
+      "ahci"
+      "thunderbolt"
+      "nvme"
+      "usb_storage"
+      "sd_mod"
+      "rtsx_pci_sdmmc"
+    ];
+  };
+
+  hardware = {
+    # Audio
+    enableRedistributableFirmware = lib.mkDefault true;
+
+    # Webcam
+    ipu6 = {
+      enable = lib.mkDefault true;
+      platform = lib.mkDefault "ipu6ep";
+    };
+
+    bluetooth = {
+      enable = lib.mkDefault true;
+      powerOnBoot = lib.mkDefault true;
+    };
+
+    graphics.enable = lib.mkDefault true;
+    intel-gpu-tools.enable = lib.mkDefault true;
+
+    nvidia = {
+      modesetting.enable = lib.mkDefault true;
+      nvidiaSettings = lib.mkDefault true;
+      open = lib.mkDefault false;
+
+      powerManagement = {
+        enable = lib.mkDefault true;
+        finegrained = lib.mkDefault true;
+      };
+
+      prime = {
+        intelBusId = lib.mkDefault "PCI:00:02:0";
+        nvidiaBusId = lib.mkDefault "PCI:01:00:0";
+      };
+    };
+  };
+
+  services = {
+    fwupd.enable = lib.mkDefault true; # update firmware
+    hardware.bolt.enable = lib.mkDefault true; # use thunderbolt
+    thermald.enable = lib.mkDefault true; # cpu temp management
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
           dell-precision-5530 = import ./dell/precision/5530;
           dell-precision-5560 = import ./dell/precision/5560;
           dell-precision-5570 = import ./dell/precision/5570;
+          dell-precision-5680 = import ./dell/precision/5680;
           dell-precision-7520 = import ./dell/precision/7520;
           dell-xps-13-7390 = import ./dell/xps/13-7390;
           dell-xps-13-9300 = import ./dell/xps/13-9300;


### PR DESCRIPTION
###### Description of changes
Add dell precision-5680 hardware

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

