### PR TITLE
rpi4: Introduce raspberry-pi."4".enable

### DIFF
--- a/raspberry-pi/4/cpu-revision.nix
+++ b/raspberry-pi/4/cpu-revision.nix
@@ -1,24 +1,23 @@
-{
-  hardware.deviceTree.overlays = [
-    {
-      name = "rpi4-cpu-revision";
-      dtsText = ''
-        /dts-v1/;
-        /plugin/;
+{ config, lib, ... }:
+lib.mkIf config.hardware.raspberry-pi."4".enable {
+  hardware.deviceTree.overlays = [{
+    name = "rpi4-cpu-revision";
+    dtsText = ''
+      /dts-v1/;
+      /plugin/;
 
-        / {
-          compatible = "raspberrypi,4-model-b";
+      / {
+        compatible = "raspberrypi,4-model-b";
 
-          fragment@0 {
-            target-path = "/";
-            __overlay__ {
-              system {
-                linux,revision = <0x00d03114>;
-              };
+        fragment@0 {
+          target-path = "/";
+          __overlay__ {
+            system {
+              linux,revision = <0x00d03114>;
             };
           };
         };
-      '';
-    }
-  ];
+      };
+    '';
+  }];
 }

--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -27,31 +27,41 @@
     ./xhci.nix
   ];
 
-  boot = {
-    kernelPackages = lib.mkDefault pkgs.linuxKernel.packages.linux_rpi4;
-    initrd.availableKernelModules = [
-      "usbhid"
-      "usb_storage"
-      "vc4"
-      "pcie_brcmstb" # required for the pcie bus to work
-      "reset-raspberrypi" # required for vl805 firmware to load
-    ];
-
-    loader = {
-      grub.enable = lib.mkDefault false;
-      generic-extlinux-compatible.enable = lib.mkDefault true;
+  options = {
+    hardware.raspberry-pi."4" = {
+      enable = lib.mkEnableOption "basic config for a RaspberryPi 4";
     };
   };
 
-  hardware.deviceTree.filter = lib.mkDefault "bcm2711-rpi-*.dtb";
+  config = lib.mkIf config.hardware.raspberry-pi."4".enable {
+    
 
-  assertions = [
-    {
-      assertion = (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.1");
-      message = "This version of raspberry pi 4 dts overlays requires a newer kernel version (>=6.1). Please upgrade nixpkgs for this system.";
-    }
-  ];
+  boot = {
+      kernelPackages = lib.mkDefault pkgs.linuxKernel.packages.linux_rpi4;
+      initrd.availableKernelModules = [
+        "usbhid"
+        "usb_storage"
+        "vc4"
+        "pcie_brcmstb" # required for the pcie bus to work
+        "reset-raspberrypi" # required for vl805 firmware to load
+      ];
 
-  # Required for the Wireless firmware
-  hardware.enableRedistributableFirmware = true;
+      loader = {
+        grub.enable = lib.mkDefault false;
+        generic-extlinux-compatible.enable = lib.mkDefault true;
+      };
+    };
+
+    hardware.deviceTree.filter = lib.mkDefault "bcm2711-rpi-*.dtb";
+
+    assertions = [{
+      assertion =
+        (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.1");
+      message =
+        "This version of raspberry pi 4 dts overlays requires a newer kernel version (>=6.1). Please upgrade nixpkgs for this system.";
+    }];
+
+    # Required for the Wireless firmware
+    hardware.enableRedistributableFirmware = true;
+  };
 }


### PR DESCRIPTION
###### Description of changes

Don't enable anything unless explicitly enabled. Otherwise e.g. the specified kernel complicates running a x86_64 vm of a rpi4 NixOS system.

In general, NixOS modules shouldn't ever just define things and always guard them e.g. by `enable` options.

This PR guards the unconditional configs from `default.nix` and `cpu-revision.nix` with a new flag `hardware.raspberry-pi."4".enable`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

