### PR TITLE
apple/t2: kernel 6.14 -> 6.15; sync patches

### DIFF
--- a/apple/t2/pkgs/linux-t2/latest.json
+++ b/apple/t2/pkgs/linux-t2/latest.json
@@ -1,49 +1,61 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/60a2912ad2d05f8a2d6c68a94641d912c3a555fd/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/8ec11f3aaa314d25e18842851a2124c0031e2e3f/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-e3RPvWPj2QASGOS4kieO8YFekrXsBCJtfF82OPlOn2E="
+      "hash": "sha256-00K3LmId2Ag6s5K76p7mB2a0oEXp815yRd+U5wxWPMc="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
       "hash": "sha256-wkveNo1qwAwXWDGTFed4ZDbuBnJbwKgWLmTHK9qq0oM="
     },
     {
-      "name": "1005-HID-hid-appletb-bl-add-driver-for-the-backlight-of-A.patch",
-      "hash": "sha256-kEscS1FAyDxLZPOPInYTXFEf4fouBEa4zGctX14hSu8="
+      "name": "1003-Fix-sparse-errors.patch",
+      "hash": "sha256-nuCOPWa4Hp+HCCBe6Y++M4g1k4plOWzy2hqHXlJbp9g="
     },
     {
-      "name": "1006-HID-hid-appletb-kbd-add-driver-for-the-keyboard-mode.patch",
-      "hash": "sha256-eVEuvnoRItaDjwWu41nn9bTkgHgY+1SL/hFAvUR2IlY="
+      "name": "1004-Fix-freezing-on-turning-off-camera.patch",
+      "hash": "sha256-rFrSUhiNXgQbfgKjryJktYxYcchXE1PI49Q1gW001+0="
     },
     {
-      "name": "1007-HID-multitouch-support-getting-the-contact-ID-from.patch",
-      "hash": "sha256-A4tExJafroVAv/Hbdt7farJM6RYl/DU5KwSbzqcdEVY="
+      "name": "1007-HID-multitouch-Get-the-contact-ID-from-HID_DG_TRANSD.patch",
+      "hash": "sha256-JF5PjByo4S1Rd/B5luAzOXDv+iakCnJfmujIQuUiT1A="
     },
     {
       "name": "1008-HID-multitouch-support-getting-the-tip-state-from-HI.patch",
-      "hash": "sha256-GwK+d87p3UMy66037dzq6/Zearj8gnRHhqSdZczRadY="
+      "hash": "sha256-m/NAKoHRC/HwxG5fFZxFl6DtY4Xv8kPBWvdKdtadrrk="
     },
     {
       "name": "1009-HID-multitouch-take-cls-maxcontacts-into-account-for.patch",
-      "hash": "sha256-fywzHnCQ657UFye1ckiufral3pBwBGtKdxWqWqaFHM0="
+      "hash": "sha256-h6jk9yw/4txd8PATpMxB9mIzik9+X1zP6p4K35AqdXw="
     },
     {
-      "name": "1010-HID-multitouch-allow-specifying-if-a-device-is-direc.patch",
-      "hash": "sha256-87SOnLgeG60Svu2Z9QUyP9P6cZ1Gznt6ZYLFImfx+vY="
+      "name": "1010-HID-multitouch-specify-that-Apple-Touch-Bar-is-direc.patch",
+      "hash": "sha256-5PbLynVnQqlJKPTWhcmwXCkYDEopLBQWnxWvZUt0EN4="
     },
     {
-      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bars.patch",
-      "hash": "sha256-TJjXAlQ4WEROnq/xd6/4JHTuEJjqT7dLLcE4etKdzc0="
+      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bar.patch",
+      "hash": "sha256-dIzEOj89D2rIEc2/mjq3TkIfI3ZHzu0VRDQQOzp+Snc="
     },
     {
-      "name": "1014-drm-format-helper-Add-conversion-from-XRGB8888-to-BG.patch",
-      "hash": "sha256-Ky19+cCiYDaHBh2o5IhZO8J1ExDT7o8K9cgPz+AL8Cg="
+      "name": "1013-lib-vsprintf-Add-support-for-generic-FourCCs-by-exte.patch",
+      "hash": "sha256-g8M3j1ZPND10/LtPD/txaSoJGV9Lp+g5bgn+vQc56p4="
     },
     {
-      "name": "1015-drm-tiny-add-driver-for-Apple-Touch-Bars-in-x86-Macs.patch",
-      "hash": "sha256-Ga0LlaS1jWTXSKh1ClcETPJctAymC6jYBQK9wwDU4Xs="
+      "name": "1014-printf-add-tests-for-generic-FourCCs.patch",
+      "hash": "sha256-5Z4cFBMAY695OEU/CxiGQkUz68zmKdxssD+yp1DCYgs="
+    },
+    {
+      "name": "1015-drm-appletbdrm-use-p4cl-instead-of-p4cc.patch",
+      "hash": "sha256-rZej0ZbpPv+8NROuYnf4Jpu9scCsmbKWyz7yf5A3G3s="
+    },
+    {
+      "name": "1016-vsprintf-Use-p4chR-instead-of-p4cn-for-reading-data-.patch",
+      "hash": "sha256-/Ork2CmYk6SG213Owk+nGsw7KTEVDLRzQTeWcKrPZGw="
+    },
+    {
+      "name": "1017-checkpatch-remove-p4cn.patch",
+      "hash": "sha256-lnMnjnMiR9WSNf/XYsiOwFdC9xKv8zSluWiR584xFPU="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
@@ -51,7 +63,7 @@
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
-      "hash": "sha256-XKwlyJZjJLQz39mc0/S7sPnRnwrqMsq9OKy+QCO+oho="
+      "hash": "sha256-aE+MEu/jRrZBa+3Q03quOHUsIseRED6A7N/K9kEVtbM="
     },
     {
       "name": "3001-applesmc-convert-static-structures-to-drvdata.patch",
@@ -91,7 +103,7 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-yfkTKKokb/+JtTwE0Dzht14S0nrSIwLFAFND90P/Cis="
+      "hash": "sha256-QM/FtDft4N4imJBuEHg6cH3e8vEyMPLt0alDhugLPy8="
     },
     {
       "name": "4002-HID-quirks-remove-T2-devices-from-hid_mouse_ignore_l.patch",
@@ -119,7 +131,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-py4DNKBsUWvw6o730ApmNdUlSyabOFnFDoAPrF40DNE="
+      "hash": "sha256-io17Kk6FDscDoDshddK9TqSPuXVFTzjvRUwOGTl5cjM="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",

--- a/apple/t2/pkgs/linux-t2/latest.nix
+++ b/apple/t2/pkgs/linux-t2/latest.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_6_14, ... }@args:
+{ callPackage, linux_6_15, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_6_14;
+  kernel = linux_6_15;
   patchesFile = ./latest.json;
 }

--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/0543a832ecf1400798e8aef6727110ec21c3484a/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/e08a76e1f1234885b9b68be6c843bf91833e8b0a/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
@@ -10,6 +10,14 @@
       "hash": "sha256-DXj4CmE7TKMGrAhQDOR5RVw9YHmyQMiXZsmxYfkKAEA="
     },
     {
+      "name": "1003-Fix-sparse-errors.patch",
+      "hash": "sha256-nuCOPWa4Hp+HCCBe6Y++M4g1k4plOWzy2hqHXlJbp9g="
+    },
+    {
+      "name": "1004-Fix-freezing-on-turning-off-camera.patch",
+      "hash": "sha256-rFrSUhiNXgQbfgKjryJktYxYcchXE1PI49Q1gW001+0="
+    },
+    {
       "name": "1005-HID-hid-appletb-bl-add-driver-for-the-backlight-of-A.patch",
       "hash": "sha256-kEscS1FAyDxLZPOPInYTXFEf4fouBEa4zGctX14hSu8="
     },
@@ -18,24 +26,28 @@
       "hash": "sha256-eVEuvnoRItaDjwWu41nn9bTkgHgY+1SL/hFAvUR2IlY="
     },
     {
-      "name": "1007-HID-multitouch-support-getting-the-contact-ID-from.patch",
-      "hash": "sha256-A4tExJafroVAv/Hbdt7farJM6RYl/DU5KwSbzqcdEVY="
+      "name": "1007-HID-multitouch-Get-the-contact-ID-from-HID_DG_TRANSD.patch",
+      "hash": "sha256-JF5PjByo4S1Rd/B5luAzOXDv+iakCnJfmujIQuUiT1A="
     },
     {
       "name": "1008-HID-multitouch-support-getting-the-tip-state-from-HI.patch",
-      "hash": "sha256-GwK+d87p3UMy66037dzq6/Zearj8gnRHhqSdZczRadY="
+      "hash": "sha256-m/NAKoHRC/HwxG5fFZxFl6DtY4Xv8kPBWvdKdtadrrk="
     },
     {
       "name": "1009-HID-multitouch-take-cls-maxcontacts-into-account-for.patch",
-      "hash": "sha256-fywzHnCQ657UFye1ckiufral3pBwBGtKdxWqWqaFHM0="
+      "hash": "sha256-h6jk9yw/4txd8PATpMxB9mIzik9+X1zP6p4K35AqdXw="
     },
     {
-      "name": "1010-HID-multitouch-allow-specifying-if-a-device-is-direc.patch",
-      "hash": "sha256-87SOnLgeG60Svu2Z9QUyP9P6cZ1Gznt6ZYLFImfx+vY="
+      "name": "1010-HID-multitouch-specify-that-Apple-Touch-Bar-is-direc.patch",
+      "hash": "sha256-5PbLynVnQqlJKPTWhcmwXCkYDEopLBQWnxWvZUt0EN4="
     },
     {
-      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bars.patch",
-      "hash": "sha256-TJjXAlQ4WEROnq/xd6/4JHTuEJjqT7dLLcE4etKdzc0="
+      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bar.patch",
+      "hash": "sha256-dIzEOj89D2rIEc2/mjq3TkIfI3ZHzu0VRDQQOzp+Snc="
+    },
+    {
+      "name": "1013-lib-vsprintf-Add-support-for-generic-FourCCs-by-exte.patch",
+      "hash": "sha256-h3gxaKtvdm/GSd+AP1sPC9avWHOsceUxTmoua/3rIf4="
     },
     {
       "name": "1014-drm-format-helper-Add-conversion-from-XRGB8888-to-BG.patch",
@@ -43,7 +55,7 @@
     },
     {
       "name": "1015-drm-tiny-add-driver-for-Apple-Touch-Bars-in-x86-Macs.patch",
-      "hash": "sha256-zFeDJeoM/XS+Ds3DBLEcv4JbUhlEk9z4rHQ4t6XaghA="
+      "hash": "sha256-tDjK/VipVQbuNOURW38gssqeRLy3s8I+DVq0+4zGnHs="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
@@ -119,7 +131,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-1VHKrO2haBqXDCef2xt2fHfCCPv2q/AhFmmM4Xxu24E="
+      "hash": "sha256-O3RNtpeZQENPEfyYi/0ZTLhAWBAw6pmxMS30NUxOTdk="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",


### PR DESCRIPTION
###### Description of changes

updates the latest kernel for apple/t2 from 6.14 to 6.15, and sync the patchset from the patches repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

