### PR TITLE
Updated hybrid nvidia offload mode to include amd video drivers

### DIFF
--- a/lenovo/legion/16arh7h/hybrid/default.nix
+++ b/lenovo/legion/16arh7h/hybrid/default.nix
@@ -13,7 +13,7 @@
   ];
 
   boot.kernelModules = ["amdgpu"];
-  services.xserver.videoDrivers = ["nvidia"];
+  services.xserver.videoDrivers = ["amdgpu" "nvidia"];
 
   hardware = {
     amdgpu.initrd.enable = false;


### PR DESCRIPTION
###### Description of changes
Hybrid mode now includes amd video drivers for lenovo legion 16arh7h

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

