### PR TITLE
xiaomi/redmibook/15-pro-2021: fix declaration of device.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -355,6 +355,7 @@
           tuxedo-infinitybook-pro14-gen9-intel = import ./tuxedo/infinitybook/pro14/gen9/intel;
           tuxedo-pulse-14-gen3 = import ./tuxedo/pulse/14/gen3;
           tuxedo-pulse-15-gen2 = import ./tuxedo/pulse/15/gen2;
+          xiaomi-redmibook-15-pro-2021 = import ./xiaomi/redmibook/15-pro-2021;
           xiaomi-redmibook-16-pro-2024 = import ./xiaomi/redmibook/16-pro-2024;
 
           common-cpu-amd = import ./common/cpu/amd;


### PR DESCRIPTION
###### Description of changes

I don't know how this line got deleted but till this commit 8b1f894089789eb39eacf0d6891d1e17cc3a84ab this line exist after this commit the line has been deleted idk how did this happen.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

