### PR TITLE
gpd/duo: init GPD Duo profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ See code for all available configurations.
 | [Gigabyte B550](gigabyte/b550)                                                    | `<nixos-hardware/gigabyte/b550>`                        | `gigabyte-b550`                        |
 | [Gigabyte B650](gigabyte/b650)                                                    | `<nixos-hardware/gigabyte/b650>`                        | `gigabyte-b650`                        |
 | [GMKtec NucBox G3 Plus](gmktec/nucbox/g3-plus)                                    | `<nixos-hardware/gmktec/nucbox/g3-plus>`                | `gmktec-nucbox-g3-plus`                |
+| [GPD Duo](gpd/duo)                                                                | `<nixos-hardware/gpd/duo>`                              | `gpd-duo`                         |
 | [GPD MicroPC](gpd/micropc)                                                        | `<nixos-hardware/gpd/micropc>`                          | `gpd-micropc`                          |
 | [GPD P2 Max](gpd/p2-max)                                                          | `<nixos-hardware/gpd/p2-max>`                           | `gpd-p2-max`                           |
 | [GPD Pocket 3](gpd/pocket-3)                                                      | `<nixos-hardware/gpd/pocket-3>`                         | `gpd-pocket-3`                         |

--- a/flake.nix
+++ b/flake.nix
@@ -194,6 +194,7 @@
           google-pixelbook = import ./google/pixelbook;
           google-brya = import ./google/brya;
           google-rex = import ./google/rex;
+          gpd-duo = import ./gpd/duo;
           gpd-micropc = import ./gpd/micropc;
           gpd-p2-max = import ./gpd/p2-max;
           gpd-pocket-3 = import ./gpd/pocket-3;

--- a/gpd/duo/default.nix
+++ b/gpd/duo/default.nix
@@ -1,0 +1,60 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.hardware.gpd.duo;
+in
+with lib;
+{
+  imports = [
+    ./duo-specific
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../../common/hidpi.nix
+  ];
+
+  options = {
+    hardware.gpd.duo.preventWakeOnAC = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Stop the system waking from suspend when the AC is plugged
+        in. The catch: it also disables waking from the keyboard.
+
+        See:
+        https://community.frame.work/t/tracking-framework-amd-ryzen-7040-series-lid-wakeup-behavior-feedback/39128/45
+      '';
+    };
+  };
+
+  config = {
+    # Workaround applied upstream in Linux >=6.7 (on BIOS 03.03)
+    # https://github.com/torvalds/linux/commit/a55bdad5dfd1efd4ed9ffe518897a21ca8e4e193
+    services.udev.extraRules =
+      mkIf (versionOlder config.boot.kernelPackages.kernel.version "6.7" && cfg.preventWakeOnAC)
+        ''
+          # Prevent wake when plugging in AC during suspend. Trade-off: keyboard wake disabled. See:
+          # https://community.frame.work/t/tracking-framework-amd-ryzen-7040-series-lid-wakeup-behavior-feedback/39128/45
+          ACTION=="add", SUBSYSTEM=="serio", DRIVERS=="atkbd", ATTR{power/wakeup}="disabled"
+        '';
+
+    # Replace 'left' with 'right' or 'inverted' as needed
+    # Fixes DUO stupid inverted display at boot
+    # Enable kernel module for your graphics (adjust if needed)
+    boot.kernelModules = [ "amdgpu" ];
+
+    # Set the eDP-1 panel video parameters for display rotation
+    boot.kernelParams = mkBefore [
+      "video=eDP-1:2880x1800,panel_orientation=upside_down"
+      "video=DP-3:2880x1800,panel_orientation=normal"
+      "i2c_touchscreen_props=GXTP7380:touchscreen-inverted-x:touchscreen-inverted-y"
+    ];
+
+    hardware.gpd.duo.audioEnhancement.rawDeviceName =
+      mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
+  };
+}

--- a/gpd/duo/duo-specific/amd.nix
+++ b/gpd/duo/duo-specific/amd.nix
@@ -1,0 +1,27 @@
+{ lib, config, ... }:
+with lib;
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+  ];
+
+  boot.kernelParams = [
+    # There seems to be an issue with panel self-refresh (PSR) that
+    # causes hangs for users.
+    #
+    # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
+    # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
+    "amdgpu.dcdebugmask=0x210"
+  ]
+  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+  ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "6.8") [
+    "rtc_cmos.use_acpi_alarm=1"
+  ];
+
+  # AMD has better battery life with PPD over TLP:
+  # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13
+  services.power-profiles-daemon.enable = mkDefault true;
+  services.tlp.enable = mkDefault false;
+}

--- a/gpd/duo/duo-specific/audio.nix
+++ b/gpd/duo/duo-specific/audio.nix
@@ -1,0 +1,391 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.gpd.duo.audioEnhancement;
+in
+with lib;
+{
+  options = {
+    hardware.gpd.duo.audioEnhancement = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Create a new audio device called "DUO Speakers",
+          which applies sound tuning before sending the audio out to the speakers.
+          This option requires PipeWire and WirePlumber.
+
+          The filter chain includes the following:
+            - Pyschoacoustic bass enhancement
+            - Loudness compensation
+            - Equalizer
+            - Slight compression
+
+          This option has been optimised for the Framework Laptop 13 AMD 7040 series, but should work on all models.
+
+          Before applying, ensure the speakers are set to 100%,
+          because the volumes compound and the raw speaker device will be hidden by default.
+
+          You might also need to re-select the default output device.
+
+          In some cases, the added bass will vibrate the keyboard cable leading to a rattling sound,
+          a piece of foam can be used to mitigate this.
+        '';
+      };
+
+      hideRawDevice = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Hide the raw speaker device.
+          This option is enabled by default, because keeping the raw speaker device can lead to volume conflicts.
+        '';
+      };
+
+      rawDeviceName = mkOption {
+        type = types.str;
+        example = "alsa_output.pci-0000_c1_00.6.analog-stereo";
+        description = ''
+          The name of the raw speaker device. This will vary by device.
+          You can get this by running `pw-dump | grep -C 20 pci-0000`.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      outputName = cfg.rawDeviceName;
+      prettyName = "Duo Speakers";
+
+      # These are pre-made decibel to linear value conversions, since Nix doesn't have pow().
+      # Use the formula `10 ** (db / 20)` to calculate.
+      db = {
+        "-18.1" = 0.1244514611771385;
+        "-5.48" = 0.5321082592667942;
+        "-4.76" = 0.5780960474057181;
+        "8.1" = 2.5409727055493048;
+        "-36" = 1.5848931924611134e-2;
+      };
+
+      json = pkgs.formats.json { };
+
+      # The filter chain, heavily inspired by the asahi-audio project: https://github.com/AsahiLinux/asahi-audio
+      filter-chain = json.generate "filter-chain.json" {
+        "node.description" = prettyName;
+        "media.name" = prettyName;
+        "filter.graph" = {
+          nodes = [
+            # Psychoacoustic bass extension,
+            # it creates harmonics of the missing bass to fool our ears into hearing it.
+            {
+              type = "lv2";
+              plugin = "https://chadmed.au/bankstown";
+              name = "bassex";
+              control = {
+                bypass = 0;
+                amt = 1.2;
+                sat_second = 1.3;
+                sat_third = 2.5;
+                blend = 1.0;
+                ceil = 200.0;
+                floor = 20.0;
+              };
+            }
+            # Loudness compensation,
+            # it ensures that the sound profile stays consistent across different volumes.
+            {
+              type = "lv2";
+              plugin = "http://lsp-plug.in/plugins/lv2/loud_comp_stereo";
+              name = "el";
+              control = {
+                enabled = 1;
+                input = 1.0;
+                fft = 4;
+              };
+            }
+            # 8-band equalizer,
+            # it tries to lessen frequencies where the laptop might resonate,
+            # and tries to make the frequency curve more pleasing;
+            # this is the "Lappy McTopface" profile (https://github.com/ceiphr/ee-framework-presets)
+            # further tuned for the Framework Laptop 13 AMD 7040 series
+            # and might need some tuning on other models.
+            {
+              type = "lv2";
+              plugin = "http://lsp-plug.in/plugins/lv2/para_equalizer_x8_lr";
+              name = "fw13eq";
+              control = {
+                mode = 0;
+                react = 0.2;
+                zoom = db."-36";
+
+                fl_0 = 101.0;
+                fml_0 = 0;
+                ftl_0 = 5;
+                gl_0 = db."-18.1";
+                huel_0 = 0.0;
+                ql_0 = 4.36;
+                sl_0 = 0;
+                wl_0 = 4.0;
+
+                fl_1 = 451.0;
+                fml_1 = 0;
+                ftl_1 = 1;
+                gl_1 = db."-5.48";
+                huel_1 = 3.125e-2;
+                ql_1 = 2.46;
+                sl_1 = 0;
+                wl_1 = 4.0;
+
+                fl_2 = 918.0;
+                fml_2 = 0;
+                ftl_2 = 1;
+                gl_2 = db."-4.76";
+                huel_2 = 6.25e-2;
+                ql_2 = 2.44;
+                sl_2 = 0;
+                wl_2 = 4.0;
+
+                fl_3 = 9700.0;
+                fml_3 = 0;
+                ftl_3 = 1;
+                gl_3 = db."8.1";
+                huel_3 = 9.375e-2;
+                ql_3 = 2.0;
+                sl_3 = 0;
+                wl_3 = 4.0;
+
+                fr_0 = 101.0;
+                fmr_0 = 0;
+                ftr_0 = 5;
+                gr_0 = db."-18.1";
+                huer_0 = 0.0;
+                qr_0 = 4.36;
+                sr_0 = 0;
+                wr_0 = 4.0;
+
+                fr_1 = 451.0;
+                fmr_1 = 0;
+                ftr_1 = 1;
+                gr_1 = db."-5.48";
+                huer_1 = 3.125e-2;
+                qr_1 = 2.46;
+                sr_1 = 0;
+                wr_1 = 4.0;
+
+                fr_2 = 918.0;
+                fmr_2 = 0;
+                ftr_2 = 1;
+                gr_2 = db."-4.76";
+                huer_2 = 6.25e-2;
+                qr_2 = 2.44;
+                sr_2 = 0;
+                wr_2 = 4.0;
+
+                fr_3 = 9700.0;
+                fmr_3 = 0;
+                ftr_3 = 1;
+                gr_3 = db."8.1";
+                huer_3 = 9.375e-2;
+                qr_3 = 2.0;
+                sr_3 = 0;
+                wr_3 = 4.0;
+              };
+            }
+            # Compressors. The settings were taken from the asahi-audio project.
+            {
+              type = "lv2";
+              plugin = "http://lsp-plug.in/plugins/lv2/mb_compressor_stereo";
+              name = "woofer_bp";
+              control = {
+                mode = 0;
+                ce_0 = 1;
+                sla_0 = 5.0;
+                cr_0 = 1.75;
+                al_0 = 0.725;
+                at_0 = 1.0;
+                rt_0 = 100;
+                kn_0 = 0.125;
+                cbe_1 = 1;
+                sf_1 = 200.0;
+                ce_1 = 0;
+                cbe_2 = 0;
+                ce_2 = 0;
+                cbe_3 = 0;
+                ce_3 = 0;
+                cbe_4 = 0;
+                ce_4 = 0;
+                cbe_5 = 0;
+                ce_5 = 0;
+                cbe_6 = 0;
+                ce_6 = 0;
+              };
+            }
+            {
+              type = "lv2";
+              plugin = "http://lsp-plug.in/plugins/lv2/compressor_stereo";
+              name = "woofer_lim";
+              control = {
+                sla = 5.0;
+                al = 1.0;
+                at = 1.0;
+                rt = 100.0;
+                cr = 15.0;
+                kn = 0.5;
+              };
+            }
+          ];
+
+          # Now, we're chaining together the modules instantiated above.
+          links = [
+            {
+              output = "bassex:out_l";
+              input = "el:in_l";
+            }
+            {
+              output = "bassex:out_r";
+              input = "el:in_r";
+            }
+
+            {
+              output = "el:out_l";
+              input = "fw13eq:in_l";
+            }
+            {
+              output = "el:out_r";
+              input = "fw13eq:in_r";
+            }
+            {
+              output = "fw13eq:out_l";
+              input = "woofer_bp:in_l";
+            }
+            {
+              output = "fw13eq:out_r";
+              input = "woofer_bp:in_r";
+            }
+            {
+              output = "woofer_bp:out_l";
+              input = "woofer_lim:in_l";
+            }
+            {
+              output = "woofer_bp:out_r";
+              input = "woofer_lim:in_r";
+            }
+          ];
+
+          inputs = [
+            "bassex:in_l"
+            "bassex:in_r"
+          ];
+          outputs = [
+            "woofer_lim:out_l"
+            "woofer_lim:out_r"
+          ];
+
+          # This makes pipewire's volume control actually control the loudness comp module
+          "capture.volumes" = [
+            {
+              control = "el:volume";
+              min = -47.5;
+              max = 0.0;
+              scale = "cubic";
+            }
+          ];
+        };
+        "capture.props" = {
+          "node.name" = "audio_effect.laptop-convolver";
+          "media.class" = "Audio/Sink";
+          "audio.channels" = "2";
+          "audio.position" = [
+            "FL"
+            "FR"
+          ];
+          "audio.allowed-rates" = [
+            44100
+            48000
+            88200
+            96000
+            176400
+            192000
+          ];
+          "device.api" = "dsp";
+          "node.virtual" = "false";
+
+          # Lower seems to mean "more preferred",
+          # bluetooth devices seem to be ~1000, speakers seem to be ~2000
+          # since this is between the two, bluetooth devices take over when they connect,
+          # and hand over to this instead of the speakers when they disconnect.
+          "priority.session" = 1500;
+          "priority.driver" = 1500;
+          "state.default-volume" = 0.343;
+          "device.icon-name" = "audio-card-analog-pci";
+        };
+        "playback.props" = {
+          "node.name" = "audio_effect.laptop-convolver";
+          "target.object" = outputName;
+          "node.passive" = "true";
+          "audio.channels" = "2";
+          "audio.allowed-rates" = [
+            44100
+            48000
+            88200
+            96000
+            176400
+            192000
+          ];
+          "audio.position" = [
+            "FL"
+            "FR"
+          ];
+          "device.icon-name" = "audio-card-analog-pci";
+        };
+      };
+
+      configPackage =
+        (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/99-laptop.conf" ''
+          monitor.alsa.rules = [
+            {
+              matches = [{ node.name = "${outputName}" }]
+              actions = {
+                update-props = {
+                  audio.allowed-rates = [44100, 48000, 88200, 96000, 176400, 192000]
+                }
+              }
+            }
+          ]
+
+          node.software-dsp.rules = [
+            {
+              matches = [{ node.name = "${outputName}" }]
+              actions = {
+                create-filter = {
+                  filter-path = "${filter-chain}"
+                  hide-parent = ${boolToString cfg.hideRawDevice}
+                }
+              }
+            }
+          ]
+
+          wireplumber.profiles = {
+            main = { node.software-dsp = "required" }
+          }
+        '')
+        // {
+          passthru.requiredLv2Packages = with pkgs; [
+            lsp-plugins
+            bankstown-lv2
+          ];
+        };
+    in
+    {
+      services.pipewire.wireplumber.configPackages = [ configPackage ];
+
+      # Pipewire is needed for this.
+      services.pipewire.enable = mkDefault true;
+    }
+  );
+}

--- a/gpd/duo/duo-specific/bluetooth.nix
+++ b/gpd/duo/duo-specific/bluetooth.nix
@@ -1,0 +1,56 @@
+# There is apparently a bug that affects Framework computers that causes black
+# screen on resume from sleep or hibernate with kernel version 6.11.  Framework
+# have published a workaround; this applies that workaround.
+#
+# https://fosstodon.org/@frameworkcomputer/113406887743149089
+# https://github.com/FrameworkComputer/linux-docs/blob/main/hibernation/kernel-6-11-workarounds/suspend-hibernate-bluetooth-workaround.md#workaround-for-suspendhibernate-black-screen-on-resume-kernel-611
+{
+  config,
+  lib,
+  pkgs,
+  ...
+# TODO: drop this if linux 6.11 goes EOL
+}:
+with lib;
+mkIf
+  (
+    (config.boot.kernelPackages.kernelAtLeast "6.11") && (config.boot.kernelPackages.kernelOlder "6.12")
+  )
+  {
+    systemd.services = {
+      bluetooth-rfkill-suspend = {
+        description = "Soft block Bluetooth on suspend/hibernate";
+        before = [ "sleep.target" ];
+        unitConfig.StopWhenUnneeded = true;
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.util-linux}/bin/rfkill block bluetooth";
+          ExecStartPost = "${pkgs.coreutils}/bin/sleep 3";
+          RemainAfterExit = true;
+        };
+        wantedBy = [
+          "suspend.target"
+          "hibernate.target"
+          "suspend-then-hibernate.target"
+        ];
+      };
+
+      bluetooth-rfkill-resume = {
+        description = "Unblock Bluetooth on resume";
+        after = [
+          "suspend.target"
+          "hibernate.target"
+          "suspend-then-hibernate.target"
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.util-linux}/bin/rfkill unblock bluetooth";
+        };
+        wantedBy = [
+          "suspend.target"
+          "hibernate.target"
+          "suspend-then-hibernate.target"
+        ];
+      };
+    };
+  }

--- a/gpd/duo/duo-specific/default.nix
+++ b/gpd/duo/duo-specific/default.nix
@@ -1,0 +1,20 @@
+{ lib, pkgs, ... }:
+with lib;
+{
+  imports = [
+    ../../../common/cpu/amd/raphael/igpu.nix
+    ./bluetooth.nix
+    ./amd.nix
+    ./audio.nix
+    ./power
+  ];
+
+  # Fix TRRS headphones missing a mic
+  # https://community.frame.work/t/headset-microphone-on-linux/12387/3
+  boot.extraModprobeConfig = mkIf (versionOlder pkgs.linux.version "6.6.8") ''
+    options snd-hda-intel model=dell-headset-multi
+  '';
+
+  # Needed for desktop environments to detect/manage display brightness
+  hardware.sensor.iio.enable = mkDefault true;
+}

--- a/gpd/duo/duo-specific/power/default.nix
+++ b/gpd/duo/duo-specific/power/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./ppt.nix
+    ./power-saving.nix
+  ];
+}

--- a/gpd/duo/duo-specific/power/power-saving.nix
+++ b/gpd/duo/duo-specific/power/power-saving.nix
@@ -1,0 +1,18 @@
+{ lib, config, ... }:
+with lib;
+let
+  cfg = config.hardware.gpd.duo.powerManagement;
+in
+{
+  options.hardware.gpd.duo.powerManagement = {
+    enable = mkEnableOption "Enable power-profiles-daemon and disable TLP for the GPD Duo" // {
+      # Default increase PPT to the BIOS default when power adapter plugin to increase performance.
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.power-profiles-daemon.enable = mkDefault true;
+    services.tlp.enable = mkForce false;
+  };
+}

--- a/gpd/duo/duo-specific/power/ppt.nix
+++ b/gpd/duo/duo-specific/power/ppt.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.hardware.gpd.ppt;
+in
+{
+  options.hardware.gpd.ppt = {
+    enable = mkEnableOption "Enable PPT control for device by ryzenadj." // {
+      # Default increase PPT to the BIOS default when power adapter plugin to increase performance.
+      default = true;
+    };
+
+    adapter = {
+      fast-limit = mkOption {
+        description = "Fast PTT Limit(milliwatt) when power adapter plugin.";
+        default = 35000;
+        type = types.ints.unsigned;
+      };
+      slow-limit = mkOption {
+        description = "Slow PTT Limit(milliwatt) when power adapter plugin.";
+        default = 32000;
+        type = types.ints.unsigned;
+      };
+      stapm-limit = mkOption {
+        description = "Stapm PTT Limit(milliwatt) when power adapter plugin.";
+        default = 28000;
+        type = types.ints.unsigned;
+      };
+    };
+
+    battery = {
+      fast-limit = mkOption {
+        description = "Fast PTT Limit(milliwatt) when using battery.";
+        default = 24000;
+        type = types.ints.unsigned;
+      };
+      slow-limit = mkOption {
+        description = "Slow PTT Limit(milliwatt) when using battery.";
+        default = 22000;
+        type = types.ints.unsigned;
+      };
+      stapm-limit = mkOption {
+        description = "Stapm PTT Limit(milliwatt) when using battery.";
+        default = 22000;
+        type = types.ints.unsigned;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.ryzenadj ];
+    services.udev.extraRules = ''
+      SUBSYSTEM=="power_supply", KERNEL=="ADP1", ATTR{online}=="1", RUN+="${getExe pkgs.ryzenadj} --stapm-limit ${toString cfg.adapter.stapm-limit} --fast-limit ${toString cfg.adapter.fast-limit} --slow-limit ${toString cfg.adapter.slow-limit}"
+      SUBSYSTEM=="power_supply", KERNEL=="ADP1", ATTR{online}=="0", RUN+="${getExe pkgs.ryzenadj} --stapm-limit ${toString cfg.battery.stapm-limit} --fast-limit ${toString cfg.battery.fast-limit} --slow-limit ${toString cfg.battery.slow-limit}"
+    '';
+  };
+}


### PR DESCRIPTION
- Fix boot screen invertion.
- Add audio fixes for the Framework 13, given a shared chipset.
- Add Bluetooth fixes.
- Import AMD 7000-series GPU fix (Raphael).
- Add GPD PPT (TDP) control from GPD Win Max 2
- Set `panel_orientation` kernel parameter.
- Add AC wakeup fix as a config option; disabled by default.
- Enable `power-profiles-daemon` by default, and disable TLP - can be configured.
- Disable both PSR and PSR-SU on amdgpu module.
- Fix touchscreen properties - upside down rotation

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

