### PR TITLE
asus: fix charge-upto script

### DIFF
--- a/asus/battery.nix
+++ b/asus/battery.nix
@@ -6,7 +6,8 @@
 }:
 let
   p = pkgs.writeScriptBin "charge-upto" ''
-    echo ''${0:-100} > /sys/class/power_supply/BAT?/charge_control_end_threshold
+    #!${pkgs.bash}/bin/bash
+    echo ''${1:-100} > /sys/class/power_supply/BAT?/charge_control_end_threshold
   '';
   cfg = config.hardware.asus.battery;
 in


### PR DESCRIPTION
###### Description of changes
 Added shebang and fix script argument. Fixed:

- Error while executing:
```
/run/current-system/sw/bin/charge-upto: line 1: /sys/class/power_supply/BAT?/charge_control_end_threshold: No such file or directory
```
- Incorrect argument: `${0}`is the script name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

