### PR TITLE
framework-intel-core-ultra-series1: preset device name for audio enhancement

### DIFF
--- a/framework/13-inch/intel-core-ultra-series1/default.nix
+++ b/framework/13-inch/intel-core-ultra-series1/default.nix
@@ -41,4 +41,6 @@
     ''For Intel NPU support, set the option: hardware.enableRedistributableFirmware = true;''
   ];
 
+  hardware.framework.laptop13.audioEnhancement.rawDeviceName =
+    lib.mkDefault "alsa_output.pci-0000_00_1f.3.analog-stereo";
 }


### PR DESCRIPTION
###### Description of changes

There is an awesome audio enhancement feature in the Framework 13 profiles.

On `framework-13-7040-amd` it can be enabled by setting `hardware.framework.laptop13.audioEnhancement = true;`.
On `framework-intel-core-ultra-series1`, however, this is not enough, because the raw audio device name is not preconfigured in the profile.

This PR adds the device name the same [way it's done in the AMD profile](https://github.com/NixOS/nixos-hardware/blob/497ae1357f1ac97f1aea31a4cb74ad0d534ef41f/framework/13-inch/7040-amd/default.nix#L43).

⚠️ I don't know if there was a specific reason not to do this in the first place. Could it be that these Intel laptops have varying device names? I only have one laptop of this kind to test this with.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

