### PR TITLE
Adding Power Management on Asus fa507nv

### DIFF
--- a/asus/fa507nv/default.nix
+++ b/asus/fa507nv/default.nix
@@ -39,6 +39,7 @@
   };
 
   hardware.nvidia = {
+    powerManagement.enable = true;
     modesetting.enable = lib.mkDefault true;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;

--- a/asus/fa507nv/default.nix
+++ b/asus/fa507nv/default.nix
@@ -39,7 +39,7 @@
   };
 
   hardware.nvidia = {
-    powerManagement.enable = true;
+    powerManagement.enable = lib.mkDefault true;
     modesetting.enable = lib.mkDefault true;
     open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;


### PR DESCRIPTION
I personally own this laptop, I am running gnome and on sleep the graphics always corrupt without fail, this setting has been the only way to correct it.

###### Description of changes
Just adding power Management on the ASUS fa507nv for the reason above

###### Things done
Just adding power Management on the ASUS fa507nv for the reason above

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

