### PR TITLE
framework/12-inch: Fix tabletmode 

### DIFF
--- a/framework/12-inch/13th-gen-intel/default.nix
+++ b/framework/12-inch/13th-gen-intel/default.nix
@@ -4,4 +4,10 @@
     ../common
     ../../../common/cpu/intel
   ];
+
+  # If this module isn't built into the kernel, we need to make sure it loads
+  # before soc_button_array. Otherwise the tablet mode gpio doesn't work.
+  # If correctly loaded, dmesg should show
+  # input: gpio-keys as /devices/platform/INT33D3:00
+  boot.initrd.kernelModules = [ "pinctrl_tigerlake" ];
 }


### PR DESCRIPTION
###### Description of changes

NixOS kernels don't have pinctrl_tigerlake built-in, we need to make sure it loads before soc_button_array. Adding it to the initrd ensures that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

