### PR TITLE
Add missing README entries and re-align columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,358 +84,365 @@ All contributors and users are welcome to join!
 
 See code for all available configurations.
 
-| Model                                                                             | Path                                                    | Flake Module                       |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------- |
-| [Acer Aspire 4810T](acer/aspire/4810t)                                            | `<nixos-hardware/acer/aspire/4810t>`                    | `acer-aspire-4810t`                |
-| [Airis N990](airis/n990)                                                          | `<nixos-hardware/airis/n990>`                           | `airis-n990`                       |
-| [Apple iMac 14.2](apple/imac/14-2)                                                | `<nixos-hardware/apple/imac/14-2>`                      | `apple-imac-14-2`                  |
-| [Apple iMac 18.2](apple/imac/18-2)                                                | `<nixos-hardware/apple/imac/18-2>`                      | `apple-imac-18-2`                  |
-| [Apple MacBook Air 3,X](apple/macbook-air/3)                                      | `<nixos-hardware/apple/macbook-air/3>`                  | `apple-macbook-air-3`              |
-| [Apple MacBook Air 4,X](apple/macbook-air/4)                                      | `<nixos-hardware/apple/macbook-air/4>`                  | `apple-macbook-air-4`              |
-| [Apple MacBook Air 5,X](apple/macbook-air/5)                                      | `<nixos-hardware/apple/macbook-air/5>`                  | `apple-macbook-air-5`              |
-| [Apple MacBook Air 6,X](apple/macbook-air/6)                                      | `<nixos-hardware/apple/macbook-air/6>`                  | `apple-macbook-air-6`              |
-| [Apple MacBook Air 7,X](apple/macbook-air/7)                                      | `<nixos-hardware/apple/macbook-air/7>`                  | `apple-macbook-air-7`              |
-| [Apple MacBook Pro 8,1](apple/macbook-pro/8-1)                                    | `<nixos-hardware/apple/macbook-pro/8-1>`                | `apple-macbook-pro-8-1`            |
-| [Apple MacBook Pro 10,1](apple/macbook-pro/10-1)                                  | `<nixos-hardware/apple/macbook-pro/10-1>`               | `apple-macbook-pro-10-1`           |
-| [Apple MacBook Pro 11,1](apple/macbook-pro/11-1)                                  | `<nixos-hardware/apple/macbook-pro/11-1>`               | `apple-macbook-pro-11-1`           |
-| [Apple MacBook Pro 11,4](apple/macbook-pro/11-4)                                  | `<nixos-hardware/apple/macbook-pro/11-4>`               | `apple-macbook-pro-11-4`           |
-| [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                                  | `<nixos-hardware/apple/macbook-pro/11-5>`               | `apple-macbook-pro-11-5`           |
-| [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                                  | `<nixos-hardware/apple/macbook-pro/12-1>`               | `apple-macbook-pro-12-1`           |
-| [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                                  | `<nixos-hardware/apple/macbook-pro/14-1>`               | `apple-macbook-pro-14-1`           |
-| [Apple MacMini (2010, Intel, Nvidia)](apple/macmini/4)                            | `<nixos-hardware/apple/macmini/4>`                      | `apple-macmini-4-1`                |
-| [Apple Macs with a T2 Chip](apple/t2)                                             | `<nixos-hardware/apple/t2>`                             | `apple-t2`                         |
-| [Aoostar R1 N100](aoostar/r1/n100)                                                | `<nixos-hardware/aoostar/r1/n100>`                      | `aoostar-r1-n100`                  |
-| [Asus Pro WS X570-ACE](asus/pro-ws-x570-ace)                                      | `<nixos-hardware/asus/pro-ws-x570-ace>`                 | `asus-pro-ws-x570-ace`             |
-| [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                                     | `<nixos-hardware/asus/ally/rc71l>`                      | `asus-ally-rc71l`                  |
-| [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/amdgpu)                      | `<nixos-hardware/asus/flow/gv302x/amdgpu>`              | `asus-flow-gv302x-amdgpu`          |
-| [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/nvidia)                      | `<nixos-hardware/asus/flow/gv302x/nvidia>`              | `asus-flow-gv302x-nvidia`          |
-| [Asus ROG GL552VW](asus/rog-gl552vw)                                              | `<nixos-hardware/asus/rog-gl552vw>`                     | `asus-rog-gl552vw`                 |
-| [Asus ROG Strix G513IM](asus/rog-strix/g513im)                                    | `<nixos-hardware/asus/rog-strix/g513im>`                | `asus-rog-strix-g513im`            |
-| [Asus ROG Strix G533ZW](asus/rog-strix/g533zw)                                    | `<nixos-hardware/asus/rog-strix/g533zw>`                | `asus-rog-strix-g533zw`            |
-| [Asus ROG Strix G533Q](asus/rog-strix/g533q)                                    | `<nixos-hardware/asus/rog-strix/g533q>`                | `asus-rog-strix-g533zw`            |
-| [Asus ROG Strix G713IE](asus/rog-strix/g713ie)                                    | `<nixos-hardware/asus/rog-strix/g713ie>`                | `asus-rog-strix-g713ie`            |
-| [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                                    | `<nixos-hardware/asus/rog-strix/g733qs>`                | `asus-rog-strix-g733qs`            |
-| [Asus ROG Strix X570-E GAMING](asus/rog-strix/x570e)                              | `<nixos-hardware/asus/rog-strix/x570e>`                 | `asus-rog-strix-x570e`             |
-| [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                                | `<nixos-hardware/asus/zephyrus/ga401>`                  | `asus-zephyrus-ga401`              |
-| [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                                | `<nixos-hardware/asus/zephyrus/ga402>`                  | `asus-zephyrus-ga402`              |
-| [Asus ROG Zephyrus G14 GA402X\* (2023)](asus/zephyrus/ga402x/amdgpu)              | `<nixos-hardware/asus/zephyrus/ga402x/amdgpu>`          | `asus-zephyrus-ga402x-amdgpu`      |
-| [Asus ROG Zephyrus G14 GA402X\* (2023)](asus/zephyrus/ga402x/nvidia)              | `<nixos-hardware/asus/zephyrus/ga402x/nvidia>`          | `asus-zephyrus-ga402x-nvidia`      |
-| [Asus ROG Zephyrus G15 GA502](asus/zephyrus/ga502)                                | `<nixos-hardware/asus/zephyrus/ga502>`                  | `asus-zephyrus-ga502`              |
-| [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                                | `<nixos-hardware/asus/zephyrus/ga503>`                  | `asus-zephyrus-ga503`              |
-| [Asus ROG Zephyrus G16 GU605MY](asus/zephyrus/gu605my)                            | `<nixos-hardware/asus/zephyrus/gu605my>`                | `asus-zephyrus-gu605my`            |
-| [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                              | `<nixos-hardware/asus/zephyrus/gu603h>`                 | `asus-zephyrus-gu603h`             |
-| [Asus TUF FX504GD](asus/fx504gd)                                                  | `<nixos-hardware/asus/fx504gd>`                         | `asus-fx504gd`                     |
-| [Asus TUF FX506HM](asus/fx506hm)                                                  | `<nixos-hardware/asus/fx506hm>`                         | `asus-fx506hm`                     |
-| [Asus TUF FA506IC](asus/fa506ic)                                                  | `<nixos-hardware/asus/fa506ic>`                         | `asus-fa506ic`                     |
-| [Asus TUF FA507RM](asus/fa507rm)                                                  | `<nixos-hardware/asus/fa507rm>`                         | `asus-fa507rm`                     |
-| [Asus TUF FA507NV](asus/fa507nv)                                                  | `<nixos-hardware/asus/fa507nv>`                         | `asus-fa507nv`                     |
-| [Asus Zenbook Duo 14 UX481](asus/zenbook/ux481/intelgpu/)                         | `<nixos-hardware/asus/zenbook/ux481/intelgpu>`          | `asus-zenbook-ux481-intelgpu`      |
-| [Asus Zenbook Duo 14 UX481](asus/zenbook/ux481/nvidia/)                           | `<nixos-hardware/asus/zenbook/ux481/nvidia>`            | `asus-zenbook-ux481-nvidia`        |
-| [Asus Zenbook Flip S13 UX371](asus/zenbook/ux371/)                                | `<nixos-hardware/asus/zenbook/ux371>`                   | `asus-zenbook-ux371`               |
-| [Asus Zenbook Pro 15 UX535](asus/zenbook/ux535/)                                  | `<nixos-hardware/asus/zenbook/ux535>`                   | `asus-zenbook-ux535`               |
-| [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                              | `<nixos-hardware/beagleboard/pocketbeagle>`             | `beagleboard-pocketbeagle`         |
-| [Chuwi MiniBook X](chuwi/minibook-x)                                              | `<nixos-hardware/chuwi/minibook-x>`                     | `chuwi-minibook-x`                 |
-| [Deciso DEC series](deciso/dec)                                                   | `<nixos-hardware/deciso/dec>`                           | `deciso-dec`                       |
-| [Dell G3 3779](dell/g3/3779)                                                      | `<nixos-hardware/dell/g3/3779>`                         | `dell-g3-3779`                     |
-| [Dell G3 3579](dell/g3/3579)                                                      | `<nixos-hardware/dell/g3/3579>`                         | `dell-g3-3579`                     |
-| [Dell Inspiron 3442](dell/inspiron/3442)                                          | `<nixos-hardware/dell/inspiron/3442>`                   | `dell-inspiron-3442`               |
-| [Dell Inspiron 14 5420](dell/inspiron/14-5420)                                    | `<nixos-hardware/dell/inspiron/14-5420>`                | `dell-inspiron-14-5420`            |
-| [Dell Inspiron 5509](dell/inspiron/5509)                                          | `<nixos-hardware/dell/inspiron/5509>`                   | `dell-inspiron-5509`               |
-| [Dell Inspiron 5515](dell/inspiron/5515)                                          | `<nixos-hardware/dell/inspiron/5515>`                   | `dell-inspiron-5515`               |
-| [Dell Inspiron 7405](dell/inspiron/7405)                                          | `<nixos-hardware/dell/inspiron/7405>`                   | `dell-inspiron-7405`               |
-| [Dell Inspiron 7460](dell/inspiron/7460)                                          | `<nixos-hardware/dell/inspiron/7460>`                   | `dell-inspiron-7460`               |
-| [Dell Inspiron 7559](dell/inspiron/7559)                                          | `<nixos-hardware/dell/inspiron/7559>`                   | `dell-inspiron-7559`               |
-| [Dell Latitude 3340](dell/latitude/3340)                                          | `<nixos-hardware/dell/latitude/3340>`                   | `dell-latitude-3340`               |
-| [Dell Latitude 3480](dell/latitude/3480)                                          | `<nixos-hardware/dell/latitude/3480>`                   | `dell-latitude-3480`               |
-| [Dell Latitude 5490](dell/latitude/5490)                                          | `<nixos-hardware/dell/latitude/5490>`                   | `dell-latitude-5490`               |
-| [Dell Latitude 5520](dell/latitude/5520)                                          | `<nixos-hardware/dell/latitude/5520>`                   | `dell-latitude-5520`               |
-| [Dell Latitude 7280](dell/latitude/7280)                                          | `<nixos-hardware/dell/latitude/7280>`                   | `dell-latitude-7280`               |
-| [Dell Latitude 7390](dell/latitude/7390)                                          | `<nixos-hardware/dell/latitude/7390>`                   | `dell-latitude-7390`               |
-| [Dell Latitude 7420](dell/latitude/7420)                                          | `<nixos-hardware/dell/latitude/7420>`                   | `dell-latitude-7420`               |
-| [Dell Latitude 7430](dell/latitude/7430)                                          | `<nixos-hardware/dell/latitude/7430>`                   | `dell-latitude-7430`               |
-| [Dell Latitude 7490](dell/latitude/7490)                                          | `<nixos-hardware/dell/latitude/7490>`                   | `dell-latitude-7490`               |
-| [Dell Latitude 9430](dell/latitude/9430)                                          | `<nixos-hardware/dell/latitude/9430>`                   | `dell-latitude-9430`               |
-| [Dell Latitude E7240](dell/latitude/e7240)                                        | `<nixos-hardware/dell/latitude/e7240>`                  | `dell-latitude-e7240`              |
-| [Dell Optiplex 3050](dell/optiplex/3050)                                          | `<nixos-hardware/dell/optiplex/3050>`                   | `dell-optiplex-3050`               |
-| [Dell Poweredge R7515](dell/poweredge/r7515)                                      | `<nixos-hardware/dell/poweredge/r7515>`                 | `dell-poweredge-r7515`             |
-| [Dell Precision 3490, nvidia](dell/precision/3490/nvidia)                         | `<nixos-hardware/dell/precision/3490/nvidia>`           | `dell-precision-3490-nvidia`       |
-| [Dell Precision 3490, intel](dell/precision/3490/intel)                           | `<nixos-hardware/dell/precision/3490/intel>`            | `dell-precision-3490-intel`        |
-| [Dell Precision 3541](dell/precision/3541)                                        | `<nixos-hardware/dell/precision/3541>`                  | `dell-precision-3541`              |
-| [Dell Precision 5490](dell/precision/5490)                                        | `<nixos-hardware/dell/precision/5490>`                  | `dell-precision-5490`              |
-| [Dell Precision 5530](dell/precision/5530)                                        | `<nixos-hardware/dell/precision/5530>`                  | `dell-precision-5530`              |
-| [Dell Precision 5560](dell/precision/5560)                                        | `<nixos-hardware/dell/precision/5560>`                  | `dell-precision-5560`              |
-| [Dell Precision 5570](dell/precision/5570)                                        | `<nixos-hardware/dell/precision/5570>`                  | `dell-precision-5570`              |
-| [Dell Precision 7520](dell/precision/7520)                                        | `<nixos-hardware/dell/precision/7520>`                  | `dell-precision-7520`              |
-| [Dell XPS 13 7390](dell/xps/13-7390)                                              | `<nixos-hardware/dell/xps/13-7390>`                     | `dell-xps-13-7390`                 |
-| [Dell XPS 13 9300](dell/xps/13-9300)                                              | `<nixos-hardware/dell/xps/13-9300>`                     | `dell-xps-13-9300`                 |
-| [Dell XPS 13 9310](dell/xps/13-9310)                                              | `<nixos-hardware/dell/xps/13-9310>`                     | `dell-xps-13-9310`                 |
-| [Dell XPS 13 9315](dell/xps/13-9315)                                              | `<nixos-hardware/dell/xps/13-9315>`                     | `dell-xps-13-9315`                 |
-| [Dell XPS 13 9333](dell/xps/13-9333)                                              | `<nixos-hardware/dell/xps/13-9333>`                     | `dell-xps-13-9333`                 |
-| [Dell XPS 13 9343](dell/xps/13-9343)                                              | `<nixos-hardware/dell/xps/13-9343>`                     | `dell-xps-13-9343`                 |
-| [Dell XPS 13 9350](dell/xps/13-9350)                                              | `<nixos-hardware/dell/xps/13-9350>`                     | `dell-xps-13-9350`                 |
-| [Dell XPS 13 9360](dell/xps/13-9360)                                              | `<nixos-hardware/dell/xps/13-9360>`                     | `dell-xps-13-9360`                 |
-| [Dell XPS 13 9370](dell/xps/13-9370)                                              | `<nixos-hardware/dell/xps/13-9370>`                     | `dell-xps-13-9370`                 |
-| [Dell XPS 13 9380](dell/xps/13-9380)                                              | `<nixos-hardware/dell/xps/13-9380>`                     | `dell-xps-13-9380`                 |
-| [Dell XPS 15 7590, nvidia](dell/xps/15-7590/nvidia)                               | `<nixos-hardware/dell/xps/15-7590/nvidia>`              | `dell-xps-15-7590-nvidia`          |
-| [Dell XPS 15 7590](dell/xps/15-7590)                                              | `<nixos-hardware/dell/xps/15-7590>`                     | `dell-xps-15-7590`                 |
-| [Dell XPS 15 9500, nvidia](dell/xps/15-9500/nvidia)                               | `<nixos-hardware/dell/xps/15-9500/nvidia>`              | `dell-xps-15-9500-nvidia`          |
-| [Dell XPS 15 9500](dell/xps/15-9500)                                              | `<nixos-hardware/dell/xps/15-9500>`                     | `dell-xps-15-9500`                 |
-| [Dell XPS 15 9510, nvidia](dell/xps/15-9510/nvidia)                               | `<nixos-hardware/dell/xps/15-9510/nvidia>`              | `dell-xps-15-9510-nvidia`          |
-| [Dell XPS 15 9510](dell/xps/15-9510)                                              | `<nixos-hardware/dell/xps/15-9510>`                     | `dell-xps-15-9510`                 |
-| [Dell XPS 15 9520, nvidia](dell/xps/15-9520/nvidia)                               | `<nixos-hardware/dell/xps/15-9520/nvidia>`              | `dell-xps-15-9520-nvidia`          |
-| [Dell XPS 15 9520](dell/xps/15-9520)                                              | `<nixos-hardware/dell/xps/15-9520>`                     | `dell-xps-15-9520`                 |
-| [Dell XPS 15 9530, nvidia](dell/xps/15-9530/nvidia)                               | `<nixos-hardware/dell/xps/15-9530/nvidia>`              | `dell-xps-15-9530-nvidia`          |
-| [Dell XPS 15 9530](dell/xps/15-9530)                                              | `<nixos-hardware/dell/xps/15-9530>`                     | `dell-xps-15-9530`                 |
-| [Dell XPS 15 9550, nvidia](dell/xps/15-9550/nvidia)                               | `<nixos-hardware/dell/xps/15-9550/nvidia>`              | `dell-xps-15-9550-nvidia`          |
-| [Dell XPS 15 9550](dell/xps/15-9550)                                              | `<nixos-hardware/dell/xps/15-9550>`                     | `dell-xps-15-9550`                 |
-| [Dell XPS 15 9560, intel only](dell/xps/15-9560/intel)                            | `<nixos-hardware/dell/xps/15-9560/intel>`               | `dell-xps-15-9560-intel`           |
-| [Dell XPS 15 9560, nvidia only](dell/xps/15-9560/nvidia)                          | `<nixos-hardware/dell/xps/15-9560/nvidia>`              | `dell-xps-15-9560-nvidia`          |
-| [Dell XPS 15 9560](dell/xps/15-9560)                                              | `<nixos-hardware/dell/xps/15-9560>`                     | `dell-xps-15-9560`                 |
-| [Dell XPS 15 9570, intel only](dell/xps/15-9570/intel)                            | `<nixos-hardware/dell/xps/15-9570/intel>`               | `dell-xps-15-9570-intel`           |
-| [Dell XPS 15 9570, nvidia](dell/xps/15-9570/nvidia)                               | `<nixos-hardware/dell/xps/15-9570/nvidia>`              | `dell-xps-15-9570-nvidia`          |
-| [Dell XPS 15 9570](dell/xps/15-9570)                                              | `<nixos-hardware/dell/xps/15-9570>`                     | `dell-xps-15-9570`                 |
-| [Dell XPS 17 9700, intel](dell/xps/17-9700/intel)                                 | `<nixos-hardware/dell/xps/17-9700/intel`                | `dell-xps-17-9700-intel`           |
-| [Dell XPS 17 9700, nvidia](dell/xps/17-9700/nvidia)                               | `<nixos-hardware/dell/xps/17-9700/nvidia>`              | `dell-xps-17-9700-nvidia`          |
-| [Dell XPS 17 9710, intel only](dell/xps/17-9710/intel)                            | `<nixos-hardware/dell/xps/17-9710/intel>`               | `dell-xps-17-9710-intel`           |
-| [Framework 11th Gen Intel Core](framework/13-inch/11th-gen-intel)                 | `<nixos-hardware/framework/13-inch/11th-gen-intel>`     | `framework-11th-gen-intel` |
-| [Framework 12th Gen Intel Core](framework/12-inch/13th-gen-intel)         | `<nixos-hardware/framework/12-inch/13th-gen-intel>`     | `framework-12th-gen-intel` |
-| [Framework 13th Gen Intel Core](framework/13-inch/13th-gen-intel)                 | `<nixos-hardware/framework/13-inch/13th-gen-intel>`     | `framework-13th-gen-intel` |
+| Model                                                                             | Path                                                    | Flake Module                           |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------- |
+| [Acer Aspire 4810T](acer/aspire/4810t)                                            | `<nixos-hardware/acer/aspire/4810t>`                    | `acer-aspire-4810t`                    |
+| [Airis N990](airis/n990)                                                          | `<nixos-hardware/airis/n990>`                           | `airis-n990`                           |
+| [Apple iMac 14.2](apple/imac/14-2)                                                | `<nixos-hardware/apple/imac/14-2>`                      | `apple-imac-14-2`                      |
+| [Apple iMac 18.2](apple/imac/18-2)                                                | `<nixos-hardware/apple/imac/18-2>`                      | `apple-imac-18-2`                      |
+| [Apple MacBook Air 3,X](apple/macbook-air/3)                                      | `<nixos-hardware/apple/macbook-air/3>`                  | `apple-macbook-air-3`                  |
+| [Apple MacBook Air 4,X](apple/macbook-air/4)                                      | `<nixos-hardware/apple/macbook-air/4>`                  | `apple-macbook-air-4`                  |
+| [Apple MacBook Air 5,X](apple/macbook-air/5)                                      | `<nixos-hardware/apple/macbook-air/5>`                  | `apple-macbook-air-5`                  |
+| [Apple MacBook Air 6,X](apple/macbook-air/6)                                      | `<nixos-hardware/apple/macbook-air/6>`                  | `apple-macbook-air-6`                  |
+| [Apple MacBook Air 7,X](apple/macbook-air/7)                                      | `<nixos-hardware/apple/macbook-air/7>`                  | `apple-macbook-air-7`                  |
+| [Apple MacBook Pro 8,1](apple/macbook-pro/8-1)                                    | `<nixos-hardware/apple/macbook-pro/8-1>`                | `apple-macbook-pro-8-1`                |
+| [Apple MacBook Pro 10,1](apple/macbook-pro/10-1)                                  | `<nixos-hardware/apple/macbook-pro/10-1>`               | `apple-macbook-pro-10-1`               |
+| [Apple MacBook Pro 11,1](apple/macbook-pro/11-1)                                  | `<nixos-hardware/apple/macbook-pro/11-1>`               | `apple-macbook-pro-11-1`               |
+| [Apple MacBook Pro 11,4](apple/macbook-pro/11-4)                                  | `<nixos-hardware/apple/macbook-pro/11-4>`               | `apple-macbook-pro-11-4`               |
+| [Apple MacBook Pro 11,5](apple/macbook-pro/11-5)                                  | `<nixos-hardware/apple/macbook-pro/11-5>`               | `apple-macbook-pro-11-5`               |
+| [Apple MacBook Pro 12,1](apple/macbook-pro/12-1)                                  | `<nixos-hardware/apple/macbook-pro/12-1>`               | `apple-macbook-pro-12-1`               |
+| [Apple MacBook Pro 14,1](apple/macbook-pro/14-1)                                  | `<nixos-hardware/apple/macbook-pro/14-1>`               | `apple-macbook-pro-14-1`               |
+| [Apple MacMini (2010, Intel, Nvidia)](apple/macmini/4)                            | `<nixos-hardware/apple/macmini/4>`                      | `apple-macmini-4-1`                    |
+| [Apple Macs with a T2 Chip](apple/t2)                                             | `<nixos-hardware/apple/t2>`                             | `apple-t2`                             |
+| [Aoostar R1 N100](aoostar/r1/n100)                                                | `<nixos-hardware/aoostar/r1/n100>`                      | `aoostar-r1-n100`                      |
+| [Asus Pro WS X570-ACE](asus/pro-ws-x570-ace)                                      | `<nixos-hardware/asus/pro-ws-x570-ace>`                 | `asus-pro-ws-x570-ace`                 |
+| [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                                     | `<nixos-hardware/asus/ally/rc71l>`                      | `asus-ally-rc71l`                      |
+| [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/amdgpu)                      | `<nixos-hardware/asus/flow/gv302x/amdgpu>`              | `asus-flow-gv302x-amdgpu`              |
+| [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/nvidia)                      | `<nixos-hardware/asus/flow/gv302x/nvidia>`              | `asus-flow-gv302x-nvidia`              |
+| [Asus ROG GL552VW](asus/rog-gl552vw)                                              | `<nixos-hardware/asus/rog-gl552vw>`                     | `asus-rog-gl552vw`                     |
+| [Asus ROG Strix G513IM](asus/rog-strix/g513im)                                    | `<nixos-hardware/asus/rog-strix/g513im>`                | `asus-rog-strix-g513im`                |
+| [Asus ROG Strix G533ZW](asus/rog-strix/g533zw)                                    | `<nixos-hardware/asus/rog-strix/g533zw>`                | `asus-rog-strix-g533zw`                |
+| [Asus ROG Strix G533Q](asus/rog-strix/g533q)                                      | `<nixos-hardware/asus/rog-strix/g533q>`                 | `asus-rog-strix-g533zw`                |
+| [Asus ROG Strix G713IE](asus/rog-strix/g713ie)                                    | `<nixos-hardware/asus/rog-strix/g713ie>`                | `asus-rog-strix-g713ie`                |
+| [Asus ROG Strix G733QS](asus/rog-strix/g733qs)                                    | `<nixos-hardware/asus/rog-strix/g733qs>`                | `asus-rog-strix-g733qs`                |
+| [Asus ROG Strix X570-E GAMING](asus/rog-strix/x570e)                              | `<nixos-hardware/asus/rog-strix/x570e>`                 | `asus-rog-strix-x570e`                 |
+| [Asus ROG Zephyrus G14 GA401](asus/zephyrus/ga401)                                | `<nixos-hardware/asus/zephyrus/ga401>`                  | `asus-zephyrus-ga401`                  |
+| [Asus ROG Zephyrus G14 GA402](asus/zephyrus/ga402)                                | `<nixos-hardware/asus/zephyrus/ga402>`                  | `asus-zephyrus-ga402`                  |
+| [Asus ROG Zephyrus G14 GA402X\* (2023)](asus/zephyrus/ga402x/amdgpu)              | `<nixos-hardware/asus/zephyrus/ga402x/amdgpu>`          | `asus-zephyrus-ga402x-amdgpu`          |
+| [Asus ROG Zephyrus G14 GA402X\* (2023)](asus/zephyrus/ga402x/nvidia)              | `<nixos-hardware/asus/zephyrus/ga402x/nvidia>`          | `asus-zephyrus-ga402x-nvidia`          |
+| [Asus ROG Zephyrus G15 GA502](asus/zephyrus/ga502)                                | `<nixos-hardware/asus/zephyrus/ga502>`                  | `asus-zephyrus-ga502`                  |
+| [Asus ROG Zephyrus G15 GA503](asus/zephyrus/ga503)                                | `<nixos-hardware/asus/zephyrus/ga503>`                  | `asus-zephyrus-ga503`                  |
+| [Asus ROG Zephyrus G16 GU605MY](asus/zephyrus/gu605my)                            | `<nixos-hardware/asus/zephyrus/gu605my>`                | `asus-zephyrus-gu605my`                |
+| [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                              | `<nixos-hardware/asus/zephyrus/gu603h>`                 | `asus-zephyrus-gu603h`                 |
+| [Asus TUF FX504GD](asus/fx504gd)                                                  | `<nixos-hardware/asus/fx504gd>`                         | `asus-fx504gd`                         |
+| [Asus TUF FX506HM](asus/fx506hm)                                                  | `<nixos-hardware/asus/fx506hm>`                         | `asus-fx506hm`                         |
+| [Asus TUF FA506IC](asus/fa506ic)                                                  | `<nixos-hardware/asus/fa506ic>`                         | `asus-fa506ic`                         |
+| [Asus TUF FA507RM](asus/fa507rm)                                                  | `<nixos-hardware/asus/fa507rm>`                         | `asus-fa507rm`                         |
+| [Asus TUF FA507NV](asus/fa507nv)                                                  | `<nixos-hardware/asus/fa507nv>`                         | `asus-fa507nv`                         |
+| [Asus Zenbook Duo 14 UX481](asus/zenbook/ux481/intelgpu/)                         | `<nixos-hardware/asus/zenbook/ux481/intelgpu>`          | `asus-zenbook-ux481-intelgpu`          |
+| [Asus Zenbook Duo 14 UX481](asus/zenbook/ux481/nvidia/)                           | `<nixos-hardware/asus/zenbook/ux481/nvidia>`            | `asus-zenbook-ux481-nvidia`            |
+| [Asus Zenbook Flip S13 UX371](asus/zenbook/ux371/)                                | `<nixos-hardware/asus/zenbook/ux371>`                   | `asus-zenbook-ux371`                   |
+| [Asus Zenbook Pro 15 UX535](asus/zenbook/ux535/)                                  | `<nixos-hardware/asus/zenbook/ux535>`                   | `asus-zenbook-ux535`                   |
+| [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                              | `<nixos-hardware/beagleboard/pocketbeagle>`             | `beagleboard-pocketbeagle`             |
+| [Chuwi MiniBook X](chuwi/minibook-x)                                              | `<nixos-hardware/chuwi/minibook-x>`                     | `chuwi-minibook-x`                     |
+| [Deciso DEC series](deciso/dec)                                                   | `<nixos-hardware/deciso/dec>`                           | `deciso-dec`                           |
+| [Dell G3 3779](dell/g3/3779)                                                      | `<nixos-hardware/dell/g3/3779>`                         | `dell-g3-3779`                         |
+| [Dell G3 3579](dell/g3/3579)                                                      | `<nixos-hardware/dell/g3/3579>`                         | `dell-g3-3579`                         |
+| [Dell Inspiron 3442](dell/inspiron/3442)                                          | `<nixos-hardware/dell/inspiron/3442>`                   | `dell-inspiron-3442`                   |
+| [Dell Inspiron 14 5420](dell/inspiron/14-5420)                                    | `<nixos-hardware/dell/inspiron/14-5420>`                | `dell-inspiron-14-5420`                |
+| [Dell Inspiron 5509](dell/inspiron/5509)                                          | `<nixos-hardware/dell/inspiron/5509>`                   | `dell-inspiron-5509`                   |
+| [Dell Inspiron 5515](dell/inspiron/5515)                                          | `<nixos-hardware/dell/inspiron/5515>`                   | `dell-inspiron-5515`                   |
+| [Dell Inspiron 7405](dell/inspiron/7405)                                          | `<nixos-hardware/dell/inspiron/7405>`                   | `dell-inspiron-7405`                   |
+| [Dell Inspiron 7460](dell/inspiron/7460)                                          | `<nixos-hardware/dell/inspiron/7460>`                   | `dell-inspiron-7460`                   |
+| [Dell Inspiron 7559](dell/inspiron/7559)                                          | `<nixos-hardware/dell/inspiron/7559>`                   | `dell-inspiron-7559`                   |
+| [Dell Latitude 3340](dell/latitude/3340)                                          | `<nixos-hardware/dell/latitude/3340>`                   | `dell-latitude-3340`                   |
+| [Dell Latitude 3480](dell/latitude/3480)                                          | `<nixos-hardware/dell/latitude/3480>`                   | `dell-latitude-3480`                   |
+| [Dell Latitude 5490](dell/latitude/5490)                                          | `<nixos-hardware/dell/latitude/5490>`                   | `dell-latitude-5490`                   |
+| [Dell Latitude 5520](dell/latitude/5520)                                          | `<nixos-hardware/dell/latitude/5520>`                   | `dell-latitude-5520`                   |
+| [Dell Latitude 7280](dell/latitude/7280)                                          | `<nixos-hardware/dell/latitude/7280>`                   | `dell-latitude-7280`                   |
+| [Dell Latitude 7390](dell/latitude/7390)                                          | `<nixos-hardware/dell/latitude/7390>`                   | `dell-latitude-7390`                   |
+| [Dell Latitude 7420](dell/latitude/7420)                                          | `<nixos-hardware/dell/latitude/7420>`                   | `dell-latitude-7420`                   |
+| [Dell Latitude 7430](dell/latitude/7430)                                          | `<nixos-hardware/dell/latitude/7430>`                   | `dell-latitude-7430`                   |
+| [Dell Latitude 7490](dell/latitude/7490)                                          | `<nixos-hardware/dell/latitude/7490>`                   | `dell-latitude-7490`                   |
+| [Dell Latitude 9430](dell/latitude/9430)                                          | `<nixos-hardware/dell/latitude/9430>`                   | `dell-latitude-9430`                   |
+| [Dell Latitude E7240](dell/latitude/e7240)                                        | `<nixos-hardware/dell/latitude/e7240>`                  | `dell-latitude-e7240`                  |
+| [Dell Optiplex 3050](dell/optiplex/3050)                                          | `<nixos-hardware/dell/optiplex/3050>`                   | `dell-optiplex-3050`                   |
+| [Dell Poweredge R7515](dell/poweredge/r7515)                                      | `<nixos-hardware/dell/poweredge/r7515>`                 | `dell-poweredge-r7515`                 |
+| [Dell Precision 3490, nvidia](dell/precision/3490/nvidia)                         | `<nixos-hardware/dell/precision/3490/nvidia>`           | `dell-precision-3490-nvidia`           |
+| [Dell Precision 3490, intel](dell/precision/3490/intel)                           | `<nixos-hardware/dell/precision/3490/intel>`            | `dell-precision-3490-intel`            |
+| [Dell Precision 3541](dell/precision/3541)                                        | `<nixos-hardware/dell/precision/3541>`                  | `dell-precision-3541`                  |
+| [Dell Precision 5490](dell/precision/5490)                                        | `<nixos-hardware/dell/precision/5490>`                  | `dell-precision-5490`                  |
+| [Dell Precision 5530](dell/precision/5530)                                        | `<nixos-hardware/dell/precision/5530>`                  | `dell-precision-5530`                  |
+| [Dell Precision 5560](dell/precision/5560)                                        | `<nixos-hardware/dell/precision/5560>`                  | `dell-precision-5560`                  |
+| [Dell Precision 5570](dell/precision/5570)                                        | `<nixos-hardware/dell/precision/5570>`                  | `dell-precision-5570`                  |
+| [Dell Precision 7520](dell/precision/7520)                                        | `<nixos-hardware/dell/precision/7520>`                  | `dell-precision-7520`                  |
+| [Dell XPS 13 7390](dell/xps/13-7390)                                              | `<nixos-hardware/dell/xps/13-7390>`                     | `dell-xps-13-7390`                     |
+| [Dell XPS 13 9300](dell/xps/13-9300)                                              | `<nixos-hardware/dell/xps/13-9300>`                     | `dell-xps-13-9300`                     |
+| [Dell XPS 13 9310](dell/xps/13-9310)                                              | `<nixos-hardware/dell/xps/13-9310>`                     | `dell-xps-13-9310`                     |
+| [Dell XPS 13 9315](dell/xps/13-9315)                                              | `<nixos-hardware/dell/xps/13-9315>`                     | `dell-xps-13-9315`                     |
+| [Dell XPS 13 9333](dell/xps/13-9333)                                              | `<nixos-hardware/dell/xps/13-9333>`                     | `dell-xps-13-9333`                     |
+| [Dell XPS 13 9343](dell/xps/13-9343)                                              | `<nixos-hardware/dell/xps/13-9343>`                     | `dell-xps-13-9343`                     |
+| [Dell XPS 13 9350](dell/xps/13-9350)                                              | `<nixos-hardware/dell/xps/13-9350>`                     | `dell-xps-13-9350`                     |
+| [Dell XPS 13 9360](dell/xps/13-9360)                                              | `<nixos-hardware/dell/xps/13-9360>`                     | `dell-xps-13-9360`                     |
+| [Dell XPS 13 9370](dell/xps/13-9370)                                              | `<nixos-hardware/dell/xps/13-9370>`                     | `dell-xps-13-9370`                     |
+| [Dell XPS 13 9380](dell/xps/13-9380)                                              | `<nixos-hardware/dell/xps/13-9380>`                     | `dell-xps-13-9380`                     |
+| [Dell XPS 15 7590, nvidia](dell/xps/15-7590/nvidia)                               | `<nixos-hardware/dell/xps/15-7590/nvidia>`              | `dell-xps-15-7590-nvidia`              |
+| [Dell XPS 15 7590](dell/xps/15-7590)                                              | `<nixos-hardware/dell/xps/15-7590>`                     | `dell-xps-15-7590`                     |
+| [Dell XPS 15 9500, nvidia](dell/xps/15-9500/nvidia)                               | `<nixos-hardware/dell/xps/15-9500/nvidia>`              | `dell-xps-15-9500-nvidia`              |
+| [Dell XPS 15 9500](dell/xps/15-9500)                                              | `<nixos-hardware/dell/xps/15-9500>`                     | `dell-xps-15-9500`                     |
+| [Dell XPS 15 9510, nvidia](dell/xps/15-9510/nvidia)                               | `<nixos-hardware/dell/xps/15-9510/nvidia>`              | `dell-xps-15-9510-nvidia`              |
+| [Dell XPS 15 9510](dell/xps/15-9510)                                              | `<nixos-hardware/dell/xps/15-9510>`                     | `dell-xps-15-9510`                     |
+| [Dell XPS 15 9520, nvidia](dell/xps/15-9520/nvidia)                               | `<nixos-hardware/dell/xps/15-9520/nvidia>`              | `dell-xps-15-9520-nvidia`              |
+| [Dell XPS 15 9520](dell/xps/15-9520)                                              | `<nixos-hardware/dell/xps/15-9520>`                     | `dell-xps-15-9520`                     |
+| [Dell XPS 15 9530, nvidia](dell/xps/15-9530/nvidia)                               | `<nixos-hardware/dell/xps/15-9530/nvidia>`              | `dell-xps-15-9530-nvidia`              |
+| [Dell XPS 15 9530](dell/xps/15-9530)                                              | `<nixos-hardware/dell/xps/15-9530>`                     | `dell-xps-15-9530`                     |
+| [Dell XPS 15 9550, nvidia](dell/xps/15-9550/nvidia)                               | `<nixos-hardware/dell/xps/15-9550/nvidia>`              | `dell-xps-15-9550-nvidia`              |
+| [Dell XPS 15 9550](dell/xps/15-9550)                                              | `<nixos-hardware/dell/xps/15-9550>`                     | `dell-xps-15-9550`                     |
+| [Dell XPS 15 9560, intel only](dell/xps/15-9560/intel)                            | `<nixos-hardware/dell/xps/15-9560/intel>`               | `dell-xps-15-9560-intel`               |
+| [Dell XPS 15 9560, nvidia only](dell/xps/15-9560/nvidia)                          | `<nixos-hardware/dell/xps/15-9560/nvidia>`              | `dell-xps-15-9560-nvidia`              |
+| [Dell XPS 15 9560](dell/xps/15-9560)                                              | `<nixos-hardware/dell/xps/15-9560>`                     | `dell-xps-15-9560`                     |
+| [Dell XPS 15 9570, intel only](dell/xps/15-9570/intel)                            | `<nixos-hardware/dell/xps/15-9570/intel>`               | `dell-xps-15-9570-intel`               |
+| [Dell XPS 15 9570, nvidia](dell/xps/15-9570/nvidia)                               | `<nixos-hardware/dell/xps/15-9570/nvidia>`              | `dell-xps-15-9570-nvidia`              |
+| [Dell XPS 15 9570](dell/xps/15-9570)                                              | `<nixos-hardware/dell/xps/15-9570>`                     | `dell-xps-15-9570`                     |
+| [Dell XPS 17 9700, intel](dell/xps/17-9700/intel)                                 | `<nixos-hardware/dell/xps/17-9700/intel`                | `dell-xps-17-9700-intel`               |
+| [Dell XPS 17 9700, nvidia](dell/xps/17-9700/nvidia)                               | `<nixos-hardware/dell/xps/17-9700/nvidia>`              | `dell-xps-17-9700-nvidia`              |
+| [Dell XPS 17 9710, intel only](dell/xps/17-9710/intel)                            | `<nixos-hardware/dell/xps/17-9710/intel>`               | `dell-xps-17-9710-intel`               |
+| [Framework 11th Gen Intel Core](framework/13-inch/11th-gen-intel)                 | `<nixos-hardware/framework/13-inch/11th-gen-intel>`     | `framework-11th-gen-intel`             |
+| [Framework 12th Gen Intel Core](framework/12-inch/12th-gen-intel)                 | `<nixos-hardware/framework/12-inch/12th-gen-intel>`     | `framework-12th-gen-intel`             |
+| [Framework 13th Gen Intel Core](framework/13-inch/13th-gen-intel)                 | `<nixos-hardware/framework/13-inch/13th-gen-intel>`     | `framework-13th-gen-intel`             |
 | [Framework Intel Core Ultra Series 1](framework/13-inch/intel-core-ultra-series1) | `<nixos-hardware/framework/13-inch/intel-core-ultra-series1>`     | `framework-intel-core-ultra-series1` |
-| [Framework 13 AMD Ryzen 7040 Series](framework/13-inch/7040-amd)                  | `<nixos-hardware/framework/13-inch/7040-amd>`           | `framework-13-7040-amd`      |
-| [Framework 13 AMD AI 300 Series](framework/13-inch/amd-ai-300-series)             | `<nixos-hardware/framework/13-inch/amd-ai-300-series>`  | `framework-amd-ai-300-series` |
-| [Framework 12 13th Gen Intel Core](framework/12-inch/13th-gen-intel)              | `<nixos-hardware/framework/12-inch/13th-gen-intel>`     | `framework-12-13th-gen-intel` |
-| [Framework 16 AMD Ryzen 7040 Series](framework/16-inch/7040-amd)                  | `<nixos-hardware/framework/16-inch/7040-amd>`           | `framework-16-7040-amd`      |
-| [Framework 16 AMD Ryzen AI 300 Series](framework/16-inch/amd-ai-300-series)       | `<nixos-hardware/framework/16-inch/amd-ai-300-series>`  | `framework-16-amd-ai-300-series`  |
-| [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                                    | `<nixos-hardware/friendlyarm/nanopc-t4>`                | `friendlyarm-nanopc-t4`           |
-| [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                                  | `<nixos-hardware/friendlyarm/nanopi-r5s>`               | `friendlyarm-nanopi-r5s`          |
-| [Focus M2 Gen 1](focus/m2/gen1)                                                   | `<nixos-hardware/focus/m2/gen1>`                        | `focus-m2-gen1`                   |
-| [Fydetab Duo](fydetab/duo)                                                        | `<nixos-hardware/fydetab/duo>`                          | `fydetab-duo`                     |
-| [Gigabyte B550](gigabyte/b550)                                                    | `<nixos-hardware/gigabyte/b550>`                        | `gigabyte-b550`                   |
-| [Gigabyte B650](gigabyte/b650)                                                    | `<nixos-hardware/gigabyte/b650>`                        | `gigabyte-b650`                   |
-| [GMKtec NucBox G3 Plus](gmktec/nucbox/g3-plus)                                    | `<nixos-hardware/gmktec/nucbox/g3-plus>`                | `gmktec-nucbox-g3-plus`           |
-| [GPD MicroPC](gpd/micropc)                                                        | `<nixos-hardware/gpd/micropc>`                          | `gpd-micropc`                     |
-| [GPD P2 Max](gpd/p2-max)                                                          | `<nixos-hardware/gpd/p2-max>`                           | `gpd-p2-max`                      |
-| [GPD Pocket 3](gpd/pocket-3)                                                      | `<nixos-hardware/gpd/pocket-3>`                         | `gpd-pocket-3`                    |
-| [GPD Pocket 4](gpd/pocket-4)                                                      | `<nixos-hardware/gpd/pocket-4>`                         | `gpd-pocket-4`                    |
-| [GPD WIN 2](gpd/win-2)                                                            | `<nixos-hardware/gpd/win-2>`                            | `gpd-win-2`                       |
-| [GPD WIN Max 2 2023](gpd/win-max-2/2023)                                          | `<nixos-hardware/gpd/win-max-2/2023>`                   | `gpd-win-max-2-2023`              |
-| [GPD WIN Mini 2024](gpd/win-mini/2024)                                            | `<nixos-hardware/gpd/win-mini/2024>`                    | `gpd-win-mini-2024`               |
-| [Google Pixelbook](google/pixelbook)                                              | `<nixos-hardware/google/pixelbook>`                     | `google-pixelbook`                |
-| [HP Elitebook 2560p](hp/elitebook/2560p)                                          | `<nixos-hardware/hp/elitebook/2560p>`                   | `hp-elitebook-2560p`              |
-| [HP Elitebook 830g6](hp/elitebook/830/g6)                                         | `<nixos-hardware/hp/elitebook/830/g6>`                  | `hp-elitebook-830g6`             |
-| [HP Elitebook 845g7](hp/elitebook/845/g7)                                         | `<nixos-hardware/hp/elitebook/845/g7>`                  | `hp-elitebook-845g7`             |
-| [HP Elitebook 845g8](hp/elitebook/845/g8)                                         | `<nixos-hardware/hp/elitebook/845/g8>`                  | `hp-elitebook-845g8`             |
-| [HP Elitebook 845g9](hp/elitebook/845/g9)                                         | `<nixos-hardware/hp/elitebook/845/g9>`                  | `hp-elitebook-845g9`             |
-| [HP Laptop 14s-dq2024nf](hp/laptop/14s-dq2024nf)                                  | `<nixos-hardware/hp/laptop/14s-dq2024nf>`               | `hp-laptop-14s-dq2024nf`          |
-| [HP Notebook 14-df0023](hp/notebook/14-df0023)                                    | `<nixos-hardware/hp/notebook/14-df0023>`                | `hp-notebook-14-df0023`           |
-| [HP Probook 440G5](hp/probook/440g5)                                              | `<nixos-hardware/hp/probook/440g5>`                     | `hp-probook-440G5`                |
-| [HP Probook 460G11](hp/probook/460g11)                                              | `<nixos-hardware/hp/probook/460g11>`                     | `hp-probook-46011`                |
-| [Huawei Matebook X Pro (2020)](huawei/machc-wa)                                   | `<nixos-hardware/huawei/machc-wa>`                      | `huawei-machc-wa`                 |
-| [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)                       | `<nixos-hardware/nxp/imx8qm-mek>`                       | `nxp-imx8qm-mek`                  |
-| [Intel NUC 5i5RYB](intel/nuc/5i5ryb/)                                             | `<nixos-hardware/intel/nuc/5i5ryb>`                     | `intel-nuc-5i5ryb`                |
-| [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                                             | `<nixos-hardware/intel/nuc/8i7beh>`                     | `intel-nuc-8i7beh`                |
-| [Lenovo IdeaCentre K330](lenovo/ideacentre/k330)                                  | `<nixos-hardware/lenovo/ideacentre/k330>`               | `lenovo-ideacentre-k330`          |
-| [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                                  | `<nixos-hardware/lenovo/ideapad/15alc6>`                | `lenovo-ideapad-15alc6`           |
-| [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)                         | `<nixos-hardware/lenovo/ideapad/15arh05>`               | `lenovo-ideapad-15arh05`          |
-| [Lenovo IdeaPad Gaming 3 15ach6](lenovo/ideapad/15ach6)                           | `<nixos-hardware/lenovo/ideapad/15ach6>`                | `lenovo-ideapad-15ach6`           |
-| [Lenovo IdeaPad 5 Pro 14imh9](lenovo/ideapad/14imh9)                              | `<nixos-hardware/lenovo/ideapad/14imh9>`                | `lenovo-ideapad-14imh9`           |
-| [Lenovo IdeaPad 5 Pro 16ach6](lenovo/ideapad/16ach6)                              | `<nixos-hardware/lenovo/ideapad/16ach6>`                | `lenovo-ideapad-16ach6`           |
-| [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                                        | `<nixos-hardware/lenovo/ideapad/z510>`                  | `lenovo-ideapad-z510`             |
-| [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                                    | `<nixos-hardware/lenovo/ideapad/slim-5>`                | `lenovo-ideapad-slim-5`           |
-| [Lenovo IdeaPad Slim 5 16iah8](lenovo/ideapad/16iah8)                             | `<nixos-hardware/lenovo/ideapad/16iah8`                 | `lenovo-ideapad-s5-16iah8`           |
-| [Lenovo IdeaPad 2-in-1 16ahp9](lenovo/ideapad/16ahp9)                             | `<nixos-hardware/lenovo/ideapad/16ahp9>`                | `lenovo-ideapad-16ahp9`           |
-| [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)                            | `<nixos-hardware/lenovo/ideapad/s145-15api>`            | `lenovo-ideapad-s145-15api`       |
-| [Lenovo Legion 5 15ach6h](lenovo/legion/15ach6h)                                  | `<nixos-hardware/lenovo/legion/15ach6h>`                | `lenovo-legion-15ach6h`           |
-| [Lenovo Legion 5 15ach6h (Hybrid)](lenovo/legion/15ach6h/hybrid)                  | `<nixos-hardware/lenovo/legion/15ach6h/hybrid>`         | `lenovo-legion-15ach6h-hybrid`    |
-| [Lenovo Legion 5 15ach6h (Nvidia)](lenovo/legion/15ach6h/hybrid)                  | `<nixos-hardware/lenovo/legion/15ach6h/nvidia>`         | `lenovo-legion-15ach6h-nvidia`    |
-| [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                                | `<nixos-hardware/lenovo/legion/15arh05h>`               | `lenovo-legion-15arh05h`          |
-| [Lenovo Legion 7 Slim 15ach6](lenovo/legion/15ach6)                               | `<nixos-hardware/lenovo/legion/15ach6>`                 | `lenovo-legion-15ach6`            |
-| [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                              | `<nixos-hardware/lenovo/legion/16ach6h>`                | `lenovo-legion-16ach6h`           |
-| [Lenovo Legion 5 Pro 16ach6h (Hybrid)](lenovo/legion/16ach6h/hybrid)              | `<nixos-hardware/lenovo/legion/16ach6h/hybrid>`         | `lenovo-legion-16ach6h-hybrid`    |
-| [Lenovo Legion 5 Pro 16ach6h (Nvidia)](lenovo/legion/16ach6h/nvidia)              | `<nixos-hardware/lenovo/legion/16ach6h/nvidia>`         | `lenovo-legion-16ach6h-nvidia`    |
-| [Lenovo Legion 5 Pro 16arh7h (IGPU Only)](lenovo/legion/16arh7h/igpu-only)        | `<nixos-hardware/lenovo/legion/16arh7h/igpu-only>`      | `lenovo-legion-16arh7h-igpu-only` |
-| [Lenovo Legion 5 Pro 16arh7h (Hybrid)](lenovo/legion/16arh7h/hybrid)              | `<nixos-hardware/lenovo/legion/16arh7h/hybrid>`         | `lenovo-legion-16arh7h-hybrid`    |
-| [Lenovo Legion 5 Pro 16IAH7H (Intel)](lenovo/legion/16iah7h/)                     | `<nixos-hardware/lenovo/legion/16iah7h>`                | `lenovo-legion-16iah7h`           |
-| [Lenovo Legion 7 16achg6 (Hybrid)](lenovo/legion/16achg6/hybrid)                  | `<nixos-hardware/lenovo/legion/16achg6/hybrid>`         | `lenovo-legion-16achg6-hybrid`    |
-| [Lenovo Legion 7 16achg6 (Nvidia)](lenovo/legion/16achg6/nvidia)                  | `<nixos-hardware/lenovo/legion/16achg6/nvidia>`         | `lenovo-legion-16achg6-nvidia`    |
-| [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)                     | `<nixos-hardware/lenovo/legion/16irx8h>`                | `lenovo-legion-16irx8h`           |
-| [Lenovo Legion 7 Pro 16irx9h (Intel)](lenovo/legion/16irx9h)                      | `<nixos-hardware/lenovo/legion/16irx9h>`                | `lenovo-legion-16irx9h`           |
-| [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)                        | `<nixos-hardware/lenovo/legion/16arha7>`                | `lenovo-legion-16arha7`           |
-| [Lenovo Legion T5 AMR5](lenovo/legion/t526amr5)                                   | `<nixos-hardware/lenovo/legion/t526amr5>`               | `lenovo-legion-t526amr5`          |
+| [Framework 13 AMD Ryzen 7040 Series](framework/13-inch/7040-amd)                  | `<nixos-hardware/framework/13-inch/7040-amd>`           | `framework-13-7040-amd`                |
+| [Framework 13 AMD AI 300 Series](framework/13-inch/amd-ai-300-series)             | `<nixos-hardware/framework/13-inch/amd-ai-300-series>`  | `framework-amd-ai-300-series`          |
+| [Framework 12 13th Gen Intel Core](framework/12-inch/13th-gen-intel)              | `<nixos-hardware/framework/12-inch/13th-gen-intel>`     | `framework-12-13th-gen-intel`          |
+| [Framework 16 AMD Ryzen 7040 Series](framework/16-inch/7040-amd)                  | `<nixos-hardware/framework/16-inch/7040-amd>`           | `framework-16-7040-amd`                |
+| [Framework 16 AMD Ryzen AI 300 Series](framework/16-inch/amd-ai-300-series)       | `<nixos-hardware/framework/16-inch/amd-ai-300-series>`  | `framework-16-amd-ai-300-series`       |
+| [FriendlyARM NanoPC-T4](friendlyarm/nanopc-t4)                                    | `<nixos-hardware/friendlyarm/nanopc-t4>`                | `friendlyarm-nanopc-t4`                |
+| [FriendlyARM NanoPi R5s](friendlyarm/nanopi-r5s)                                  | `<nixos-hardware/friendlyarm/nanopi-r5s>`               | `friendlyarm-nanopi-r5s`               |
+| [Focus M2 Gen 1](focus/m2/gen1)                                                   | `<nixos-hardware/focus/m2/gen1>`                        | `focus-m2-gen1`                        |
+| [Fydetab Duo](fydetab/duo)                                                        | `<nixos-hardware/fydetab/duo>`                          | `fydetab-duo`                          |
+| [Gigabyte B550](gigabyte/b550)                                                    | `<nixos-hardware/gigabyte/b550>`                        | `gigabyte-b550`                        |
+| [Gigabyte B650](gigabyte/b650)                                                    | `<nixos-hardware/gigabyte/b650>`                        | `gigabyte-b650`                        |
+| [GMKtec NucBox G3 Plus](gmktec/nucbox/g3-plus)                                    | `<nixos-hardware/gmktec/nucbox/g3-plus>`                | `gmktec-nucbox-g3-plus`                |
+| [GPD MicroPC](gpd/micropc)                                                        | `<nixos-hardware/gpd/micropc>`                          | `gpd-micropc`                          |
+| [GPD P2 Max](gpd/p2-max)                                                          | `<nixos-hardware/gpd/p2-max>`                           | `gpd-p2-max`                           |
+| [GPD Pocket 3](gpd/pocket-3)                                                      | `<nixos-hardware/gpd/pocket-3>`                         | `gpd-pocket-3`                         |
+| [GPD Pocket 4](gpd/pocket-4)                                                      | `<nixos-hardware/gpd/pocket-4>`                         | `gpd-pocket-4`                         |
+| [GPD WIN 2](gpd/win-2)                                                            | `<nixos-hardware/gpd/win-2>`                            | `gpd-win-2`                            |
+| [GPD WIN Max 2 2023](gpd/win-max-2/2023)                                          | `<nixos-hardware/gpd/win-max-2/2023>`                   | `gpd-win-max-2-2023`                   |
+| [GPD WIN Mini 2024](gpd/win-mini/2024)                                            | `<nixos-hardware/gpd/win-mini/2024>`                    | `gpd-win-mini-2024`                    |
+| [Google Pixelbook](google/pixelbook)                                              | `<nixos-hardware/google/pixelbook>`                     | `google-pixelbook`                     |
+| [HP Elitebook 2560p](hp/elitebook/2560p)                                          | `<nixos-hardware/hp/elitebook/2560p>`                   | `hp-elitebook-2560p`                   |
+| [HP Elitebook 830g6](hp/elitebook/830/g6)                                         | `<nixos-hardware/hp/elitebook/830/g6>`                  | `hp-elitebook-830g6`                   |
+| [HP Elitebook 845g7](hp/elitebook/845/g7)                                         | `<nixos-hardware/hp/elitebook/845/g7>`                  | `hp-elitebook-845g7`                   |
+| [HP Elitebook 845g8](hp/elitebook/845/g8)                                         | `<nixos-hardware/hp/elitebook/845/g8>`                  | `hp-elitebook-845g8`                   |
+| [HP Elitebook 845g9](hp/elitebook/845/g9)                                         | `<nixos-hardware/hp/elitebook/845/g9>`                  | `hp-elitebook-845g9`                   |
+| [HP Laptop 14s-dq2024nf](hp/laptop/14s-dq2024nf)                                  | `<nixos-hardware/hp/laptop/14s-dq2024nf>`               | `hp-laptop-14s-dq2024nf`               |
+| [HP Notebook 14-df0023](hp/notebook/14-df0023)                                    | `<nixos-hardware/hp/notebook/14-df0023>`                | `hp-notebook-14-df0023`                |
+| [HP Probook 440G5](hp/probook/440G5)                                              | `<nixos-hardware/hp/probook/440G5>`                     | `hp-probook-440G5`                     |
+| [HP Laptop 14s-dq2024nf](hp/laptop/14s-dq2024nf)                                  | `<nixos-hardware/hp/laptop/14s-dq2024nf>`               | `hp-laptop-14s-dq2024nf`               |
+| [HP Probook 460G11](hp/probook/460g11)                                            | `<nixos-hardware/hp/probook/460g11>`                    | `hp-probook-46011`                     |
+| [Huawei Matebook X Pro (2020)](huawei/machc-wa)                                   | `<nixos-hardware/huawei/machc-wa>`                      | `huawei-machc-wa`                      |
+| [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)                       | `<nixos-hardware/nxp/imx8qm-mek>`                       | `nxp-imx8qm-mek`                       |
+| [Intel NUC 5i5RYB](intel/nuc/5i5ryb/)                                             | `<nixos-hardware/intel/nuc/5i5ryb>`                     | `intel-nuc-5i5ryb`                     |
+| [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                                             | `<nixos-hardware/intel/nuc/8i7beh>`                     | `intel-nuc-8i7beh`                     |
+| [Kobol Helios4](kobol/helios4)                                                    | `<nixos-hardware/kobol/helios4>`                        | `kobol-helios-4`                       |
+| [Lenovo IdeaCentre K330](lenovo/ideacentre/k330)                                  | `<nixos-hardware/lenovo/ideacentre/k330>`               | `lenovo-ideacentre-k330`               |
+| [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                                  | `<nixos-hardware/lenovo/ideapad/15alc6>`                | `lenovo-ideapad-15alc6`                |
+| [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)                         | `<nixos-hardware/lenovo/ideapad/15arh05>`               | `lenovo-ideapad-15arh05`               |
+| [Lenovo IdeaPad Gaming 3 15ach6](lenovo/ideapad/15ach6)                           | `<nixos-hardware/lenovo/ideapad/15ach6>`                | `lenovo-ideapad-15ach6`                |
+| [Lenovo IdeaPad 5 Pro 14imh9](lenovo/ideapad/14imh9)                              | `<nixos-hardware/lenovo/ideapad/14imh9>`                | `lenovo-ideapad-14imh9`                |
+| [Lenovo IdeaPad 5 Pro 16ach6](lenovo/ideapad/16ach6)                              | `<nixos-hardware/lenovo/ideapad/16ach6>`                | `lenovo-ideapad-16ach6`                |
+| [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                                        | `<nixos-hardware/lenovo/ideapad/z510>`                  | `lenovo-ideapad-z510`                  |
+| [Lenovo IdeaPad Slim 5](lenovo/ideapad/slim-5)                                    | `<nixos-hardware/lenovo/ideapad/slim-5>`                | `lenovo-ideapad-slim-5`                |
+| [Lenovo IdeaPad Slim 5 16iah8](lenovo/ideapad/16iah8)                             | `<nixos-hardware/lenovo/ideapad/16iah8`                 | `lenovo-ideapad-s5-16iah8`             |
+| [Lenovo IdeaPad 2-in-1 16ahp9](lenovo/ideapad/16ahp9)                             | `<nixos-hardware/lenovo/ideapad/16ahp9>`                | `lenovo-ideapad-16ahp9`                |
+| [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)                            | `<nixos-hardware/lenovo/ideapad/s145-15api>`            | `lenovo-ideapad-s145-15api`            |
+| [Lenovo Legion 5 15ach6h](lenovo/legion/15ach6h)                                  | `<nixos-hardware/lenovo/legion/15ach6h>`                | `lenovo-legion-15ach6h`                |
+| [Lenovo Legion 5 15ach6h (Hybrid)](lenovo/legion/15ach6h/hybrid)                  | `<nixos-hardware/lenovo/legion/15ach6h/hybrid>`         | `lenovo-legion-15ach6h-hybrid`         |
+| [Lenovo Legion 5 15ach6h (Nvidia)](lenovo/legion/15ach6h/hybrid)                  | `<nixos-hardware/lenovo/legion/15ach6h/nvidia>`         | `lenovo-legion-15ach6h-nvidia`         |
+| [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                                | `<nixos-hardware/lenovo/legion/15arh05h>`               | `lenovo-legion-15arh05h`               |
+| [Lenovo Legion 7 Slim 15ach6](lenovo/legion/15ach6)                               | `<nixos-hardware/lenovo/legion/15ach6>`                 | `lenovo-legion-15ach6`                 |
+| [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                              | `<nixos-hardware/lenovo/legion/16ach6h>`                | `lenovo-legion-16ach6h`                |
+| [Lenovo Legion 5 Pro 16ach6h (Hybrid)](lenovo/legion/16ach6h/hybrid)              | `<nixos-hardware/lenovo/legion/16ach6h/hybrid>`         | `lenovo-legion-16ach6h-hybrid`         |
+| [Lenovo Legion 5 Pro 16ach6h (Nvidia)](lenovo/legion/16ach6h/nvidia)              | `<nixos-hardware/lenovo/legion/16ach6h/nvidia>`         | `lenovo-legion-16ach6h-nvidia`         |
+| [Lenovo Legion 5 Pro 16arh7h (IGPU Only)](lenovo/legion/16arh7h/igpu-only)        | `<nixos-hardware/lenovo/legion/16arh7h/igpu-only>`      | `lenovo-legion-16arh7h-igpu-only`      |
+| [Lenovo Legion 5 Pro 16arh7h (Hybrid)](lenovo/legion/16arh7h/hybrid)              | `<nixos-hardware/lenovo/legion/16arh7h/hybrid>`         | `lenovo-legion-16arh7h-hybrid`         |
+| [Lenovo Legion 5 Pro 16IAH7H (Intel)](lenovo/legion/16iah7h/)                     | `<nixos-hardware/lenovo/legion/16iah7h>`                | `lenovo-legion-16iah7h`                |
+| [Lenovo Legion 7 16achg6 (Hybrid)](lenovo/legion/16achg6/hybrid)                  | `<nixos-hardware/lenovo/legion/16achg6/hybrid>`         | `lenovo-legion-16achg6-hybrid`         |
+| [Lenovo Legion 7 16achg6 (Nvidia)](lenovo/legion/16achg6/nvidia)                  | `<nixos-hardware/lenovo/legion/16achg6/nvidia>`         | `lenovo-legion-16achg6-nvidia`         |
+| [Lenovo Legion 7i Pro 16irx8h (Intel)](lenovo/legion/16irx8h)                     | `<nixos-hardware/lenovo/legion/16irx8h>`                | `lenovo-legion-16irx8h`                |
+| [Lenovo Legion 7 Pro 16irx9h (Intel)](lenovo/legion/16irx9h)                      | `<nixos-hardware/lenovo/legion/16irx9h>`                | `lenovo-legion-16irx9h`                |
+| [Lenovo Legion Slim 5](lenovo/legion/16aph8/)                                     | `<nixos-hardware/lenovo/legion/16aph8>`                 | `lenovo-legion-16aph8`                 |
+| [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)                        | `<nixos-hardware/lenovo/legion/16arha7>`                | `lenovo-legion-16arha7`                |
+| [Lenovo Legion T5 AMR5](lenovo/legion/t526amr5)                                   | `<nixos-hardware/lenovo/legion/t526amr5>`               | `lenovo-legion-t526amr5`               |
 | [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                                   | `<nixos-hardware/lenovo/legion/15ich>`                  | `lenovo-legion-y530-15ich`             |
-| [Lenovo ThinkPad A475](lenovo/thinkpad/a475)                                      | `<nixos-hardware/lenovo/thinkpad/a475>`                 | `lenovo-thinkpad-a475`            |
-| [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                              | `<nixos-hardware/lenovo/thinkpad/e14/amd>`              | `lenovo-thinkpad-e14-amd`         |
-| [Lenovo ThinkPad E14 (Intel - Gen 1)](lenovo/thinkpad/e14/intel)                  | `<nixos-hardware/lenovo/thinkpad/e14/intel>`            | `lenovo-thinkpad-e14-intel`       |
-| [Lenovo ThinkPad E14 (Intel - Gen 4)](lenovo/thinkpad/e14/intel/gen4)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen4>`       | `lenovo-thinkpad-e14-intel-gen4`  |
-| [Lenovo ThinkPad E14 (Intel - Gen 6)](lenovo/thinkpad/e14/intel/gen6)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen6>`       | `lenovo-thinkpad-e14-intel-gen6`  |
-| [Lenovo ThinkPad E15 (Intel)](lenovo/thinkpad/e15/intel)                          | `<nixos-hardware/lenovo/thinkpad/e15/intel>`            | `lenovo-thinkpad-e15-intel`       |
-| [Lenovo ThinkPad E470](lenovo/thinkpad/e470)                                      | `<nixos-hardware/lenovo/thinkpad/e470>`                 | `lenovo-thinkpad-e470`            |
-| [Lenovo ThinkPad E495](lenovo/thinkpad/e495)                                      | `<nixos-hardware/lenovo/thinkpad/e495>`                 | `lenovo-thinkpad-e495`            |
-| [Lenovo ThinkPad L13 Yoga](lenovo/thinkpad/l13/yoga)                              | `<nixos-hardware/lenovo/thinkpad/l13/yoga>`             | `lenovo-thinkpad-l13-yoga`        |
-| [Lenovo ThinkPad L13](lenovo/thinkpad/l13)                                        | `<nixos-hardware/lenovo/thinkpad/l13>`                  | `lenovo-thinkpad-l13`             |
-| [Lenovo ThinkPad L14 (AMD)](lenovo/thinkpad/l14/amd)                              | `<nixos-hardware/lenovo/thinkpad/l14/amd>`              | `lenovo-thinkpad-l14-amd`         |
-| [Lenovo ThinkPad L14 (Intel)](lenovo/thinkpad/l14/intel)                          | `<nixos-hardware/lenovo/thinkpad/l14/intel>`            | `lenovo-thinkpad-l14-intel`       |
-| [Lenovo ThinkPad L480](lenovo/thinkpad/l480)                                      | `<nixos-hardware/lenovo/thinkpad/l480>`                 | `lenovo-thinkpad-l480`            |
-| [Lenovo ThinkPad P1 Gen 3](lenovo/thinkpad/p1/3th-gen)                            | `<nixos-hardware/lenovo/thinkpad/p1/3th-gen>`           | `lenovo-thinkpad-p1-gen3`     |
-| [Lenovo ThinkPad P14s AMD Gen 1](lenovo/thinkpad/p14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen1>`        | `lenovo-thinkpad-p14s-amd-gen1`  |
-| [Lenovo ThinkPad P14s AMD Gen 2](lenovo/thinkpad/p14s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen2>`        | `lenovo-thinkpad-p14s-amd-gen2`  |
-| [Lenovo ThinkPad P14s AMD Gen 3](lenovo/thinkpad/p14s/amd/gen3)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen3>`        | `lenovo-thinkpad-p14s-amd-gen3`  |
-| [Lenovo ThinkPad P14s AMD Gen 4](lenovo/thinkpad/p14s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen4>`        | `lenovo-thinkpad-p14s-amd-gen4`  |
-| [Lenovo ThinkPad P14s AMD Gen 5](lenovo/thinkpad/p14s/amd/gen5)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen5>`        | `lenovo-thinkpad-p14s-amd-gen5`  |
-| [Lenovo ThinkPad P14s Intel Gen 2](lenovo/thinkpad/p14s/intel/gen2)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen2>`      | `lenovo-thinkpad-p14s-intel-gen2`|
-| [Lenovo ThinkPad P14s Intel Gen 3](lenovo/thinkpad/p14s/intel/gen3)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen3>`      | `lenovo-thinkpad-p14s-intel-gen3`|
-| [Lenovo ThinkPad P14s Intel Gen 5](lenovo/thinkpad/p14s/intel/gen5)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen5>`      | `lenovo-thinkpad-p14s-intel-gen5`|
-| [Lenovo ThinkPad P16s AMD Gen 1](lenovo/thinkpad/p16s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen1>`        | `lenovo-thinkpad-p16s-amd-gen1`  |
-| [Lenovo ThinkPad P16s AMD Gen 2](lenovo/thinkpad/p16s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen2>`        | `lenovo-thinkpad-p16s-amd-gen2`  |
-| [Lenovo ThinkPad P16s AMD Gen 4](lenovo/thinkpad/p16s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen4>`        | `lenovo-thinkpad-p16s-amd-gen4`  |
-| [Lenovo ThinkPad P16s Intel Gen 2](lenovo/thinkpad/p16s/intel/gen2)               | `<nixos-hardware/lenovo/thinkpad/p16s/intel/gen2>`      | `lenovo-thinkpad-p16s-intel-gen2`|
-| [Lenovo ThinkPad P1](lenovo/thinkpad/p1)                                          | `<nixos-hardware/lenovo/thinkpad/p1>`                   | `lenovo-thinkpad-p1`              |
-| [Lenovo ThinkPad P43s](lenovo/thinkpad/p43s)                                      | `<nixos-hardware/lenovo/thinkpad/p43s>`                 | `lenovo-thinkpad-p43s`            |
-| [Lenovo ThinkPad P50](lenovo/thinkpad/p50)                                        | `<nixos-hardware/lenovo/thinkpad/p50>`                  | `lenovo-thinkpad-p50`              |
-| [Lenovo ThinkPad P51](lenovo/thinkpad/p51)                                        | `<nixos-hardware/lenovo/thinkpad/p51>`                  | `lenovo-thinkpad-p51`              |
-| [Lenovo ThinkPad P52](lenovo/thinkpad/p52)                                        | `<nixos-hardware/lenovo/thinkpad/p52>`                  | `lenovo-thinkpad-p52`              |
-| [Lenovo ThinkPad P53](lenovo/thinkpad/p53)                                        | `<nixos-hardware/lenovo/thinkpad/p53>`                  | `lenovo-thinkpad-p53`              |
-| [Lenovo ThinkPad T14 AMD Gen 1](lenovo/thinkpad/t14/amd/gen1)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen1>`         | `lenovo-thinkpad-t14-amd-gen1`    |
-| [Lenovo ThinkPad T14 AMD Gen 2](lenovo/thinkpad/t14/amd/gen2)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen2>`         | `lenovo-thinkpad-t14-amd-gen2`    |
-| [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`         | `lenovo-thinkpad-t14-amd-gen3`    |
-| [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         | `lenovo-thinkpad-t14-amd-gen4`    |
-| [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         | `lenovo-thinkpad-t14-amd-gen5`    |
-| [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                                        | `<nixos-hardware/lenovo/thinkpad/t14>`                  | `lenovo-thinkpad-t14`              |
-| [Lenovo ThinkPad T14 Intel Gen 1](lenovo/thinkpad/t14/intel/gen1)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1>`       | `lenovo-thinkpad-t14-intel-gen1`              |
-| [Lenovo ThinkPad T14 Intel Gen 1 (Nvidia)](lenovo/thinkpad/t14/intel/gen1/nvidia) | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1/nvidia>`| `lenovo-thinkpad-t14-intel-gen1-nvidia` |
-| [Lenovo ThinkPad T14 Intel Gen 6](lenovo/thinkpad/t14/intel/gen6)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen6>`       | `lenovo-thinkpad-t14-intel-gen6`   |
-| [Lenovo ThinkPad T14s AMD Gen 1](lenovo/thinkpad/t14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`        | `lenovo-thinkpad-t14s-amd-gen1`    |
-| [Lenovo ThinkPad T14s AMD Gen 4](lenovo/thinkpad/t14s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen4>`        | `lenovo-thinkpad-t14s-amd-gen4`    |
-| [Lenovo ThinkPad T14s](lenovo/thinkpad/t14s)                                      | `<nixos-hardware/lenovo/thinkpad/t14s>`                 | `lenovo-thinkpad-t14s`             |
-| [Lenovo ThinkPad T410](lenovo/thinkpad/t410)                                      | `<nixos-hardware/lenovo/thinkpad/t410>`                 | `lenovo-thinkpad-t410`             |
-| [Lenovo ThinkPad T420](lenovo/thinkpad/t420)                                      | `<nixos-hardware/lenovo/thinkpad/t420>`                 | `lenovo-thinkpad-t420`             |
-| [Lenovo ThinkPad T430](lenovo/thinkpad/t430)                                      | `<nixos-hardware/lenovo/thinkpad/t430>`                 | `lenovo-thinkpad-t430`             |
-| [Lenovo ThinkPad T440p](lenovo/thinkpad/t440p)                                    | `<nixos-hardware/lenovo/thinkpad/t440p>`                | `lenovo-thinkpad-t440p`            |
-| [Lenovo ThinkPad T440s](lenovo/thinkpad/t440s)                                    | `<nixos-hardware/lenovo/thinkpad/t440s>`                | `lenovo-thinkpad-t440s`            |
-| [Lenovo ThinkPad T450s](lenovo/thinkpad/t450s)                                    | `<nixos-hardware/lenovo/thinkpad/t450s>`                | `lenovo-thinkpad-t450s`            |
-| [Lenovo ThinkPad T460](lenovo/thinkpad/t460)                                      | `<nixos-hardware/lenovo/thinkpad/t460>`                 | `lenovo-thinkpad-t460`             |
-| [Lenovo ThinkPad T460p](lenovo/thinkpad/t460p)                                    | `<nixos-hardware/lenovo/thinkpad/t460p>`                | `lenovo-thinkpad-t460p`            |
-| [Lenovo ThinkPad T460s](lenovo/thinkpad/t460s)                                    | `<nixos-hardware/lenovo/thinkpad/t460s>`                | `lenovo-thinkpad-t460s`            |
-| [Lenovo ThinkPad T470s](lenovo/thinkpad/t470s)                                    | `<nixos-hardware/lenovo/thinkpad/t470s>`                | `lenovo-thinkpad-t470s`            |
-| [Lenovo ThinkPad T480](lenovo/thinkpad/t480)                                      | `<nixos-hardware/lenovo/thinkpad/t480>`                 | `lenovo-thinkpad-t480`             |
-| [Lenovo ThinkPad T480s](lenovo/thinkpad/t480s)                                    | `<nixos-hardware/lenovo/thinkpad/t480s>`                | `lenovo-thinkpad-t480s`            |
-| [Lenovo ThinkPad T490](lenovo/thinkpad/t490)                                      | `<nixos-hardware/lenovo/thinkpad/t490>`                 | `lenovo-thinkpad-t490`             |
-| [Lenovo ThinkPad T490s](lenovo/thinkpad/t490s)                                    | `<nixos-hardware/lenovo/thinkpad/t490s>`                | `lenovo-thinkpad-t490s`            |
-| [Lenovo ThinkPad T495](lenovo/thinkpad/t495)                                      | `<nixos-hardware/lenovo/thinkpad/t495>`                 | `lenovo-thinkpad-t495`             |
-| [Lenovo ThinkPad T520](lenovo/thinkpad/t520)                                      | `<nixos-hardware/lenovo/thinkpad/t520>`                 | `lenovo-thinkpad-t520`             |
-| [Lenovo ThinkPad T550](lenovo/thinkpad/t550)                                      | `<nixos-hardware/lenovo/thinkpad/t550>`                 | `lenovo-thinkpad-t550`             |
-| [Lenovo ThinkPad T590](lenovo/thinkpad/t590)                                      | `<nixos-hardware/lenovo/thinkpad/t590>`                 | `lenovo-thinkpad-t590`             |
-| [Lenovo ThinkPad W520](lenovo/thinkpad/w520)                                      | `<nixos-hardware/lenovo/thinkpad/w520>`                 | `lenovo-thinkpad-w520`             |
-| [Lenovo ThinkPad X1 Yoga](lenovo/thinkpad/x1/yoga)                                | `<nixos-hardware/lenovo/thinkpad/x1/yoga>`              | `lenovo-thinkpad-x1-yoga`          |
-| [Lenovo ThinkPad X1 Yoga Gen 7](lenovo/thinkpad/x1/yoga/7th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/7th-gen>`      | `lenovo-thinkpad-x1-yoga-7th-gen` |
-| [Lenovo ThinkPad X1 Yoga Gen 8](lenovo/thinkpad/x1/yoga/8th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/8th-gen>`      | `lenovo-thinkpad-x1-yoga-8th-gen` |
-| [Lenovo ThinkPad X1 (2nd Gen)](lenovo/thinkpad/x1/2nd-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/2nd-gen>`           | `lenovo-thinkpad-x1-2nd-gen`      |
-| [Lenovo ThinkPad X1 (6th Gen)](lenovo/thinkpad/x1/6th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`           | `lenovo-thinkpad-x1-6th-gen`      |
-| [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`           | `lenovo-thinkpad-x1-7th-gen`      |
-| [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`           | `lenovo-thinkpad-x1-9th-gen`      |
-| [Lenovo ThinkPad X1 (10th Gen)](lenovo/thinkpad/x1/10th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/10th-gen>`          | `lenovo-thinkpad-x1-10th-gen`     |
-| [Lenovo ThinkPad X1 (11th Gen)](lenovo/thinkpad/x1/11th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/11th-gen>`          | `lenovo-thinkpad-x1-11th-gen`     |
-| [Lenovo ThinkPad X1 (12th Gen)](lenovo/thinkpad/x1/12th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/12th-gen>`          | `lenovo-thinkpad-x1-12th-gen`     |
-| [Lenovo ThinkPad X1 (13th Gen)](lenovo/thinkpad/x1/13th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/13th-gen>`          | `lenovo-thinkpad-x1-13th-gen`     |
-| [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>`      | `lenovo-thinkpad-x1-extreme-gen2` |
-| [Lenovo ThinkPad X1 Extreme Gen 3](lenovo/thinkpad/x1-extreme/gen3)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen3>`      | `lenovo-thinkpad-x1-extreme-gen3` |
-| [Lenovo ThinkPad X1 Extreme Gen 4](lenovo/thinkpad/x1-extreme/gen4)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen4>`      | `lenovo-thinkpad-x1-extreme-gen4` |
-| [Lenovo ThinkPad X1 Nano Gen 1](lenovo/thinkpad/x1-nano/gen1)                     | `<nixos-hardware/lenovo/thinkpad/x1-nano/gen1>`         | `lenovo-thinkpad-x1-nano-gen1`    |
-| [Lenovo ThinkPad X13s](lenovo/thinkpad/x13s)                                      | `<nixos-hardware/lenovo/thinkpad/x13s>`                 | `lenovo-thinkpad-x13s`             |
-| [Lenovo ThinkPad X13 Yoga](lenovo/thinkpad/x13/yoga)                              | `<nixos-hardware/lenovo/thinkpad/x13/yoga>`             | `lenovo-thinkpad-x13-yoga`        |
-| [Lenovo ThinkPad X13 Yoga (3th Gen)](lenovo/thinkpad/x13/yoga/3th-gen)            | `<nixos-hardware/lenovo/thinkpad/x13/yoga/3th-gen>`     | `lenovo-thinkpad-x13-yoga-3th-gen` |
-| [Lenovo ThinkPad X13 (Intel)](lenovo/thinkpad/x13/intel)                          | `<nixos-hardware/lenovo/thinkpad/x13/intel>`            | `lenovo-thinkpad-x13-intel`       |
-| [Lenovo ThinkPad X13 (AMD)](lenovo/thinkpad/x13/amd)                              | `<nixos-hardware/lenovo/thinkpad/x13/amd>`              | `lenovo-thinkpad-x13-amd`         |
-| [Lenovo ThinkPad X140e](lenovo/thinkpad/x140e)                                    | `<nixos-hardware/lenovo/thinkpad/x140e>`                | `lenovo-thinkpad-x140e`           |
-| [Lenovo ThinkPad X200s](lenovo/thinkpad/x200s)                                    | `<nixos-hardware/lenovo/thinkpad/x200s>`                | `lenovo-thinkpad-x200s`           |
-| [Lenovo ThinkPad X220](lenovo/thinkpad/x220)                                      | `<nixos-hardware/lenovo/thinkpad/x220>`                 | `lenovo-thinkpad-x220`            |
-| [Lenovo ThinkPad X230](lenovo/thinkpad/x230)                                      | `<nixos-hardware/lenovo/thinkpad/x230>`                 | `lenovo-thinkpad-x230`            |
-| [Lenovo ThinkPad X250](lenovo/thinkpad/x250)                                      | `<nixos-hardware/lenovo/thinkpad/x250>`                 | `lenovo-thinkpad-x250`            |
-| [Lenovo ThinkPad X260](lenovo/thinkpad/x260)                                      | `<nixos-hardware/lenovo/thinkpad/x260>`                 | `lenovo-thinkpad-x260`            |
-| [Lenovo ThinkPad X270](lenovo/thinkpad/x270)                                      | `<nixos-hardware/lenovo/thinkpad/x270>`                 | `lenovo-thinkpad-x270`            |
-| [Lenovo ThinkPad X280](lenovo/thinkpad/x280)                                      | `<nixos-hardware/lenovo/thinkpad/x280>`                 | `lenovo-thinkpad-x280`            |
-| [Lenovo ThinkPad X390](lenovo/thinkpad/x390)                                      | `<nixos-hardware/lenovo/thinkpad/x390>`                 | `lenovo-thinkpad-x390`            |
-| [Lenovo ThinkPad Z Series](lenovo/thinkpad/z)                                     | `<nixos-hardware/lenovo/thinkpad/z>`                    | `lenovo-thinkpad-z`               |
-| [Lenovo ThinkPad Z13 Gen 1](lenovo/thinkpad/z/gen1/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/gen1/z13>`           | `lenovo-thinkpad-z13-gen1`      |
-| [Lenovo ThinkPad Z13 Gen 2](lenovo/thinkpad/z/gen2/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/gen2/z13>`           | `lenovo-thinkpad-z13-gen2`      |
-| [Lenovo XiaoXin Pro 14imh9 2024](lenovo/ideapad/14imh9)                           | `<nixos-hardware/lenovo/ideapad/14imh9>`                | `lenovo-ideapad-14imh9`           |
-| [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                                 | `<nixos-hardware/lenovo/yoga/6/13ALC6>`                 | `lenovo-yoga-6-13ALC6`            |
-| [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/amdgpu)               | `<nixos-hardware/lenovo/yoga/7/14ARH7/amdgpu>`          | `lenovo-yoga-7-14ARH7-amdgpu`     |
-| [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)               | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          | `lenovo-yoga-7-14ARH7-nvidia`     |
-| [Lenovo Yoga Slim 7i Pro X 14IAH7 (Integrated)](lenovo/yoga/7/14IAH7/integrated)  | `<nixos-hardware/lenovo/yoga/7/14IAH7/integrated>`      | `lenovo-yoga-7-14IAH7-integrated` |
-| [Lenovo Yoga Slim 7i Pro X 14IAH7 (Hybrid)](lenovo/yoga/7/14IAH7/hybrid)          | `<nixos-hardware/lenovo/yoga/7/14IAH7/hybrid>`          | `lenovo-yoga-7-14IAH7-hybrid`     |
-| [Lenovo Yoga Slim 7 14ILL10](lenovo/yoga/7/14ILL10)                               | `<nixos-hardware/lenovo/yoga/7/14ILL10>`                | `lenovo-yoga-7-14ILL10`           |
-| [LENOVO Yoga 7 Slim Gen8](lenovo/yoga/7/slim/gen8)                                | `<nixos-hardware/lenovo/yoga/7/slim/gen8>`              | `lenovo-yoga-7-slim-gen8`         |
-| [Linglong Nova Studio](linglong/nova-studio)                                      | `<nixos-hardware/linglong/nova-studio>`                 | `linglong-nova-studio`            |
-| [MSI B550-A PRO](msi/b550-a-pro)                                                  | `<nixos-hardware/msi/b550-a-pro>`                       | `msi-b550-a-pro`                  |
-| [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                            | `<nixos-hardware/msi/b350-tomahawk>`                    | `msi-b350-tomahawk`               |
-| [MSI B550 TOMAHAWK](msi/b550-tomahawk)                                            | `<nixos-hardware/msi/b550-tomahawk>`                    | `msi-b550-tomahawk`               |
-| [MSI GS60 2QE](msi/gs60)                                                          | `<nixos-hardware/msi/gs60>`                             | `msi-gs60`                        |
-| [MSI GL62/CX62](msi/gl62)                                                         | `<nixos-hardware/msi/gl62>`                             | `msi-gl62`                        |
-| [MSI GL65 10SDR-492](msi/gl65/10SDR-492)                                          | `<nixos-hardware/msi/gl65/10SDR-492>`                   | `msi-gl65-10SDR-492`              |
-| [Microchip Icicle Kit](microchip/icicle-kit)                                      | `<nixos-hardware/microchip/icicle-kit>`                 | `microchip-icicle-kit`            |
-| [Microsoft Surface Go](microsoft/surface/surface-go)                              | `<nixos-hardware/microsoft/surface/surface-go>`         | `microsoft-surface-go`    |
-| [Microsoft Surface Pro (Intel)](microsoft/surface/surface-pro-intel)              | `<nixos-hardware/microsoft/surface/surface-pro-intel>`  | `microsoft-surface-pro-intel` |
-| [Microsoft Surface Laptop (AMD)](microsoft/surface/surface-laptop-amd)            | `<nixos-hardware/microsoft/surface/surface-laptop-amd>` | `microsoft-surface-laptop-amd` |
-| [Microsoft Surface Range (Common Modules)](microsoft/surface/common)              | `<nixos-hardware/microsoft/surface/common>`             | `microsoft-surface-common`        |
-| [Microsoft Surface Pro 3](microsoft/surface-pro/3)                                | `<nixos-hardware/microsoft/surface-pro/3>`              | `microsoft-surface-pro-3`         |
-| [Microsoft Surface Pro 9](microsoft/surface-pro/9)                                | `<nixos-hardware/microsoft/surface-pro/9>`              | `microsoft-surface-pro-9`         |
-| [Morefine M600](morefine/m600)                                                    | `<nixos-hardware/morefine/m600>`                        | `morefine-m600`                  |
-| [Minisforum V3](minisforum/v3)                                                    | `<nixos-hardware/minisforum/v3>`                        | `minisforum-v3`                  |
-| [MNT Reform with RK3588 module](mnt/reform/rk3588)                                | `<nixos-hardware/mnt/reform/rk3588`                     | `mnt-reform-rk3588`              |
-| [MECHREVO Yilong15Pro](mechrevo/GM5HG0A)                                          | `<nixos-hardware/mechrevo/GM5HG0A>`                     | `mechrevo-gm5hg0a`               |
-| [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                                   | `<nixos-hardware/nxp/imx8mp-evk>`                       | `nxp-imx8mp-evk`                 |
-| [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                                   | `<nixos-hardware/nxp/imx8mq-evk>`                       | `nxp-imx8mq-evk`                 |
-| [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)                        | `<nixos-hardware/hardkernel/odroid-hc4>`                | `hardkernel-odroid-hc4`           |
-| [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h3>`                 | `hardkernel-odroid-h3`            |
-| [Hardkernel Odroid H4](hardkernel/odroid-h4/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h4>`                 | `hardkernel-odroid-h4`            |
-| [Omen 14-fb0798ng](omen/14-fb0798ng)                                              | `<nixos-hardware/omen/14-fb0798ng>`                     | `omen-14-fb0798ng`                |
-| [Omen 15-ce002ns](omen/15-ce002ns)                                                | `<nixos-hardware/omen/15-ce002ns>`                      | `omen-15-ce002ns`                 |
-| [Omen 15-en0010ca](omen/15-en0010ca)                                              | `<nixos-hardware/omen/15-en0010ca>`                     | `omen-15-en0010ca`                |
-| [Omen 16-n0005ne](omen/16-n0005ne)                                                | `<nixos-hardware/omen/16-n0005ne>`                      | `omen-16-n0005ne`                 |
-| [Omen 16-n0280nd](/omen/16-n0280nd)                                               | `<nixos-hardware/omen/16-n0280nd>`                      | `omen-16-n0280nd`                 |
-| [Omen 15-en1007sa](omen/15-en1007sa)                                              | `<nixos-hardware/omen/15-en1007sa>`                     | `omen-15-en1007sa`                |
-| [Omen 15-en0002np](omen/15-en0002np)                                              | `<nixos-hardware/omen/15-en0002np>`                     | `omen-15-en0002np`                |
-| [One-Netbook OneNetbook 4](onenetbook/4)                                          | `<nixos-hardware/onenetbook/4>`                         | `onenetbook-4`                    |
-| [Panasonic Let's Note CF-LX3](panasonic/letsnote/cf-lx3)                          | `<nixos-hardware/panasonic/letsnote/cf-lx3>`            | `panasonic-letsnote-cf-lx3`       |
-| [Panasonic Let's Note CF-LX4](panasonic/letsnote/cf-lx4)                          | `<nixos-hardware/panasonic/letsnote/cf-lx4>`            | `letsnote-cf-lx4`       |
-| [PC Engines APU](pcengines/apu)                                                   | `<nixos-hardware/pcengines/apu>`                        | `pcengines-apu`                   |
-| [PINE64 Pinebook Pro](pine64/pinebook-pro/)                                       | `<nixos-hardware/pine64/pinebook-pro>`                  | `pine64-pinebook-pro`             |
-| [PINE64 RockPro64](pine64/rockpro64/)                                             | `<nixos-hardware/pine64/rockpro64>`                     | `pine64-rockpro64`                |
-| [PINE64 STAR64](pine64/star64/)                                                   | `<nixos-hardware/pine64/star64>`                        | `pine64-star64`                   |
-| [Protectli VP4670](protectli/vp4670/)                                             | `<nixos-hardware/protectli/vp4670>`                     | `protectli-vp4670`                |
-| [Purism Librem 13v3](purism/librem/13v3)                                          | `<nixos-hardware/purism/librem/13v3>`                   | `purism-librem-13v3`              |
-| [Purism Librem 15v3](purism/librem/15v3)                                          | `<nixos-hardware/purism/librem/15v3>`                   | `purism-librem-15v3`              |
-| [Purism Librem 5r4](purism/librem/5r4)                                            | `<nixos-hardware/purism/librem/5r4>`                    | `purism-librem-5r4`                |
-| [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   | `rock-4c-plus`              |
-| [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        | `rock-5b`                   |
-| [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      | `rock-pi-4` |
-| [Radxa ROCK Pi E](radxa/rock-pi-e)                                                | `<nixos-hardware/radxa/rock-pi-e>`                      | `rock-pi-e`|
-| [Raspberry Pi 2](raspberry-pi/2)                                                  | `<nixos-hardware/raspberry-pi/2>`                       | `raspberry-pi-2`|
-| [Raspberry Pi 3](raspberry-pi/3)                                                  | `<nixos-hardware/raspberry-pi/3>`                       | `raspberry-pi-3`|
-| [Raspberry Pi 4](raspberry-pi/4)                                                  | `<nixos-hardware/raspberry-pi/4>`                       | `raspberry-pi-4`|
-| [Raspberry Pi 5](raspberry-pi/5)                                                  | `<nixos-hardware/raspberry-pi/5>`                       | `raspberry-pi-5`|
-| [Samsung Series 9 NP900X3C](samsung/np900x3c)                                     | `<nixos-hardware/samsung/np900x3c>`                     | `samsung-np900x3c`|
-| [Slimbook Hero RPL-RTX](slimbook/hero/rpl-rtx)                                    | `<nixos-hardware/slimbook/hero/rpl-rtx>`                | `slimbook-hero-rpl-rtx`|
-| [StarFive VisionFive v1](starfive/visionfive/v1)                                  | `<nixos-hardware/starfive/visionfive/v1>`               | `starfive-visionfive-v1`|
-| [StarFive VisionFive 2](starfive/visionfive/v2)                                   | `<nixos-hardware/starfive/visionfive/v2>`               | `starfive-visionfive-2`|
-| [StarLabs StarLite 5 (I5)](starlabs/starlite/i5)                                  | `<nixos-hardware/starlabs/starlite/i5>`                 | `starlabs-starlite-i5`|
-| [Supermicro A1SRi-2758F](supermicro/a1sri-2758f)                                  | `<nixos-hardware/supermicro/a1sri-2758f>`               | `supermicro-a1sri-2758f`|
-| [Supermicro M11SDV-8C-LN4F](supermicro/m11sdv-8c-ln4f)                            | `<nixos-hardware/supermicro/m11sdv-8c-ln4f>`            | `supermicro-m11sdv-8c-ln4f`|
-| [Supermicro X10SLL-F](supermicro/x10sll-f)                                        | `<nixos-hardware/supermicro/x10sll-f>`                  | `supermicro-x10sll-f`|
-| [Supermicro X12SCZ-TLN4F](supermicro/x12scz-tln4f)                                | `<nixos-hardware/supermicro/x12scz-tln4f>`              | `supermicro-x12scz-tln4f`|
-| [System76 (generic)](system76)                                                    | `<nixos-hardware/system76>`                             | `system76`|
-| [System76 Darter Pro 6](system76/darp6)                                           | `<nixos-hardware/system76/darp6>`                       | `system76-darp6`|
-| [System76 Gazelle 18](system76/gaze18)                                            | `<nixos-hardware/system76/gaze18>`                      | `system76-gaze18`|
-| [System76 Galago Pro 5](system76/galp5-1650)                                      | `<nixos-hardware/system76/galp5-1650>`                  | `system76-galp5-1650`|
-| [System76 Thelio Mega](system76/thelio-mega)                                      | `<nixos-hardware/system76/thelio-mega>`                 | `system76-thelio-mega`|
-| [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                                   | `<nixos-hardware/toshiba/swanky>`                       | `toshiba-swanky`|
-| [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                                  | `<nixos-hardware/tuxedo/infinitybook/v4>`               | `tuxedo-infinitybook-v4`|
-| [TUXEDO Aura 15 - Gen1](tuxedo/aura/15/gen1)                                      | `<nixos-hardware/tuxedo/aura/15/gen1>`                  | `tuxedo-aura-15-gen1`|
-| [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)               | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       | `tuxedo-infinitybook-pro14-gen7`|
-| [TUXEDO InfinityBook Pro 14 - Gen9 - AMD](tuxedo/infinitybook/pro14/gen9/amd)     | `<nixos-hardware/tuxedo/infinitybook/pro14/gen9/amd>`   | `tuxedo-infinitybook-pro14-gen9-amd`|
-| [TUXEDO InfinityBook Pro 14 - Gen9 - INTEL](tuxedo/infinitybook/pro14/gen9/intel) | `<nixos-hardware/tuxedo/infinitybook/pro14/gen9/intel>` | `tuxedo-infinitybook-pro14-gen9-intel`|
-| [TUXEDO Pulse 14 - Gen3](tuxedo/pulse/14/gen3)                                    | `<nixos-hardware/tuxedo/pulse/14/gen3>`                 | `tuxedo-pulse-14-gen3`|
-| [TUXEDO Pulse 15 - Gen2](tuxedo/pulse/15/gen2)                                    | `<nixos-hardware/tuxedo/pulse/15/gen2>`                 | `tuxedo-pulse-15-gen2`|
-| [Xiaomi Redmibook 15 Pro 2021](xiaomi/redmibook/15-pro-2021)                      | `<nixos-hardware/xiaomi/redmibook/15-pro-2021>`         | `xiaomi-redmibook-15-pro-2021`|
-| [Xiaomi Redmibook 16 Pro 2024](xiaomi/redmibook/16-pro-2024)                      | `<nixos-hardware/xiaomi/redmibook/16-pro-2024>`         | `xiaomi-redmibook-16-pro-2024`|
+| [Lenovo ThinkPad A475](lenovo/thinkpad/a475)                                      | `<nixos-hardware/lenovo/thinkpad/a475>`                 | `lenovo-thinkpad-a475`                 |
+| [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                              | `<nixos-hardware/lenovo/thinkpad/e14/amd>`              | `lenovo-thinkpad-e14-amd`              |
+| [Lenovo ThinkPad E14 (Intel - Gen 1)](lenovo/thinkpad/e14/intel)                  | `<nixos-hardware/lenovo/thinkpad/e14/intel>`            | `lenovo-thinkpad-e14-intel`            |
+| [Lenovo ThinkPad E14 (Intel - Gen 4)](lenovo/thinkpad/e14/intel/gen4)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen4>`       | `lenovo-thinkpad-e14-intel-gen4`       |
+| [Lenovo ThinkPad E14 (Intel - Gen 6)](lenovo/thinkpad/e14/intel/gen6)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen6>`       | `lenovo-thinkpad-e14-intel-gen6`       |
+| [Lenovo ThinkPad E15 (Intel)](lenovo/thinkpad/e15/intel)                          | `<nixos-hardware/lenovo/thinkpad/e15/intel>`            | `lenovo-thinkpad-e15-intel`            |
+| [Lenovo ThinkPad E470](lenovo/thinkpad/e470)                                      | `<nixos-hardware/lenovo/thinkpad/e470>`                 | `lenovo-thinkpad-e470`                 |
+| [Lenovo ThinkPad E495](lenovo/thinkpad/e495)                                      | `<nixos-hardware/lenovo/thinkpad/e495>`                 | `lenovo-thinkpad-e495`                 |
+| [Lenovo ThinkPad L13 Yoga](lenovo/thinkpad/l13/yoga)                              | `<nixos-hardware/lenovo/thinkpad/l13/yoga>`             | `lenovo-thinkpad-l13-yoga`             |
+| [Lenovo ThinkPad L13](lenovo/thinkpad/l13)                                        | `<nixos-hardware/lenovo/thinkpad/l13>`                  | `lenovo-thinkpad-l13`                  |
+| [Lenovo ThinkPad L14 (AMD)](lenovo/thinkpad/l14/amd)                              | `<nixos-hardware/lenovo/thinkpad/l14/amd>`              | `lenovo-thinkpad-l14-amd`              |
+| [Lenovo ThinkPad L14 (Intel)](lenovo/thinkpad/l14/intel)                          | `<nixos-hardware/lenovo/thinkpad/l14/intel>`            | `lenovo-thinkpad-l14-intel`            |
+| [Lenovo ThinkPad L480](lenovo/thinkpad/l480)                                      | `<nixos-hardware/lenovo/thinkpad/l480>`                 | `lenovo-thinkpad-l480`                 |
+| [Lenovo ThinkPad P1 Gen 3](lenovo/thinkpad/p1/3th-gen)                            | `<nixos-hardware/lenovo/thinkpad/p1/3th-gen>`           | `lenovo-thinkpad-p1-gen3`              |
+| [Lenovo ThinkPad P14s AMD Gen 1](lenovo/thinkpad/p14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen1>`        | `lenovo-thinkpad-p14s-amd-gen1`        |
+| [Lenovo ThinkPad P14s AMD Gen 2](lenovo/thinkpad/p14s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen2>`        | `lenovo-thinkpad-p14s-amd-gen2`        |
+| [Lenovo ThinkPad P14s AMD Gen 3](lenovo/thinkpad/p14s/amd/gen3)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen3>`        | `lenovo-thinkpad-p14s-amd-gen3`        |
+| [Lenovo ThinkPad P14s AMD Gen 4](lenovo/thinkpad/p14s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen4>`        | `lenovo-thinkpad-p14s-amd-gen4`        |
+| [Lenovo ThinkPad P14s AMD Gen 5](lenovo/thinkpad/p14s/amd/gen5)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen5>`        | `lenovo-thinkpad-p14s-amd-gen5`        |
+| [Lenovo ThinkPad P14s Intel Gen 2](lenovo/thinkpad/p14s/intel/gen2)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen2>`      | `lenovo-thinkpad-p14s-intel-gen2`      |
+| [Lenovo ThinkPad P14s Intel Gen 3](lenovo/thinkpad/p14s/intel/gen3)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen3>`      | `lenovo-thinkpad-p14s-intel-gen3`      |
+| [Lenovo ThinkPad P14s Intel Gen 5](lenovo/thinkpad/p14s/intel/gen5)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen5>`      | `lenovo-thinkpad-p14s-intel-gen5`      |
+| [Lenovo ThinkPad P16s AMD Gen 1](lenovo/thinkpad/p16s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen1>`        | `lenovo-thinkpad-p16s-amd-gen1`        |
+| [Lenovo ThinkPad P16s AMD Gen 2](lenovo/thinkpad/p16s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen2>`        | `lenovo-thinkpad-p16s-amd-gen2`        |
+| [Lenovo ThinkPad P16s AMD Gen 4](lenovo/thinkpad/p16s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen4>`        | `lenovo-thinkpad-p16s-amd-gen4`        |
+| [Lenovo ThinkPad P16s Intel Gen 2](lenovo/thinkpad/p16s/intel/gen2)               | `<nixos-hardware/lenovo/thinkpad/p16s/intel/gen2>`      | `lenovo-thinkpad-p16s-intel-gen2`      |
+| [Lenovo ThinkPad P1](lenovo/thinkpad/p1)                                          | `<nixos-hardware/lenovo/thinkpad/p1>`                   | `lenovo-thinkpad-p1`                   |
+| [Lenovo ThinkPad P43s](lenovo/thinkpad/p43s)                                      | `<nixos-hardware/lenovo/thinkpad/p43s>`                 | `lenovo-thinkpad-p43s`                 |
+| [Lenovo ThinkPad P50](lenovo/thinkpad/p50)                                        | `<nixos-hardware/lenovo/thinkpad/p50>`                  | `lenovo-thinkpad-p50`                  |
+| [Lenovo ThinkPad P51](lenovo/thinkpad/p51)                                        | `<nixos-hardware/lenovo/thinkpad/p51>`                  | `lenovo-thinkpad-p51`                  |
+| [Lenovo ThinkPad P52](lenovo/thinkpad/p52)                                        | `<nixos-hardware/lenovo/thinkpad/p52>`                  | `lenovo-thinkpad-p52`                  |
+| [Lenovo ThinkPad P53](lenovo/thinkpad/p53)                                        | `<nixos-hardware/lenovo/thinkpad/p53>`                  | `lenovo-thinkpad-p53`                  |
+| [Lenovo ThinkPad T14 AMD Gen 1](lenovo/thinkpad/t14/amd/gen1)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen1>`         | `lenovo-thinkpad-t14-amd-gen1`         |
+| [Lenovo ThinkPad T14 AMD Gen 2](lenovo/thinkpad/t14/amd/gen2)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen2>`         | `lenovo-thinkpad-t14-amd-gen2`         |
+| [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`         | `lenovo-thinkpad-t14-amd-gen3`         |
+| [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         | `lenovo-thinkpad-t14-amd-gen4`         |
+| [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         | `lenovo-thinkpad-t14-amd-gen5`         |
+| [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                                        | `<nixos-hardware/lenovo/thinkpad/t14>`                  | `lenovo-thinkpad-t14`                  |
+| [Lenovo ThinkPad T14 Intel Gen 1](lenovo/thinkpad/t14/intel/gen1)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1>`       | `lenovo-thinkpad-t14-intel-gen1`       |
+| [Lenovo ThinkPad T14 Intel Gen 1 (Nvidia)](lenovo/thinkpad/t14/intel/gen1/nvidia) | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1/nvidia>`| `lenovo-thinkpad-t14-intel-gen1-nvidia`|
+| [Lenovo ThinkPad T14 Intel Gen 6](lenovo/thinkpad/t14/intel/gen6)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen6>`       | `lenovo-thinkpad-t14-intel-gen6`       |
+| [Lenovo ThinkPad T14s AMD Gen 1](lenovo/thinkpad/t14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`        | `lenovo-thinkpad-t14s-amd-gen1`        |
+| [Lenovo ThinkPad T14s AMD Gen 4](lenovo/thinkpad/t14s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen4>`        | `lenovo-thinkpad-t14s-amd-gen4`        |
+| [Lenovo ThinkPad T14s](lenovo/thinkpad/t14s)                                      | `<nixos-hardware/lenovo/thinkpad/t14s>`                 | `lenovo-thinkpad-t14s`                 |
+| [Lenovo ThinkPad T410](lenovo/thinkpad/t410)                                      | `<nixos-hardware/lenovo/thinkpad/t410>`                 | `lenovo-thinkpad-t410`                 |
+| [Lenovo ThinkPad T420](lenovo/thinkpad/t420)                                      | `<nixos-hardware/lenovo/thinkpad/t420>`                 | `lenovo-thinkpad-t420`                 |
+| [Lenovo ThinkPad T430](lenovo/thinkpad/t430)                                      | `<nixos-hardware/lenovo/thinkpad/t430>`                 | `lenovo-thinkpad-t430`                 |
+| [Lenovo ThinkPad T440p](lenovo/thinkpad/t440p)                                    | `<nixos-hardware/lenovo/thinkpad/t440p>`                | `lenovo-thinkpad-t440p`                |
+| [Lenovo ThinkPad T440s](lenovo/thinkpad/t440s)                                    | `<nixos-hardware/lenovo/thinkpad/t440s>`                | `lenovo-thinkpad-t440s`                |
+| [Lenovo ThinkPad T450s](lenovo/thinkpad/t450s)                                    | `<nixos-hardware/lenovo/thinkpad/t450s>`                | `lenovo-thinkpad-t450s`                |
+| [Lenovo ThinkPad T460](lenovo/thinkpad/t460)                                      | `<nixos-hardware/lenovo/thinkpad/t460>`                 | `lenovo-thinkpad-t460`                 |
+| [Lenovo ThinkPad T460p](lenovo/thinkpad/t460p)                                    | `<nixos-hardware/lenovo/thinkpad/t460p>`                | `lenovo-thinkpad-t460p`                |
+| [Lenovo ThinkPad T460s](lenovo/thinkpad/t460s)                                    | `<nixos-hardware/lenovo/thinkpad/t460s>`                | `lenovo-thinkpad-t460s`                |
+| [Lenovo ThinkPad T470s](lenovo/thinkpad/t470s)                                    | `<nixos-hardware/lenovo/thinkpad/t470s>`                | `lenovo-thinkpad-t470s`                |
+| [Lenovo ThinkPad T480](lenovo/thinkpad/t480)                                      | `<nixos-hardware/lenovo/thinkpad/t480>`                 | `lenovo-thinkpad-t480`                 |
+| [Lenovo ThinkPad T480s](lenovo/thinkpad/t480s)                                    | `<nixos-hardware/lenovo/thinkpad/t480s>`                | `lenovo-thinkpad-t480s`                |
+| [Lenovo ThinkPad T490](lenovo/thinkpad/t490)                                      | `<nixos-hardware/lenovo/thinkpad/t490>`                 | `lenovo-thinkpad-t490`                 |
+| [Lenovo ThinkPad T490s](lenovo/thinkpad/t490s)                                    | `<nixos-hardware/lenovo/thinkpad/t490s>`                | `lenovo-thinkpad-t490s`                |
+| [Lenovo ThinkPad T495](lenovo/thinkpad/t495)                                      | `<nixos-hardware/lenovo/thinkpad/t495>`                 | `lenovo-thinkpad-t495`                 |
+| [Lenovo ThinkPad T520](lenovo/thinkpad/t520)                                      | `<nixos-hardware/lenovo/thinkpad/t520>`                 | `lenovo-thinkpad-t520`                 |
+| [Lenovo ThinkPad T550](lenovo/thinkpad/t550)                                      | `<nixos-hardware/lenovo/thinkpad/t550>`                 | `lenovo-thinkpad-t550`                 |
+| [Lenovo ThinkPad T590](lenovo/thinkpad/t590)                                      | `<nixos-hardware/lenovo/thinkpad/t590>`                 | `lenovo-thinkpad-t590`                 |
+| [Lenovo ThinkPad W520](lenovo/thinkpad/w520)                                      | `<nixos-hardware/lenovo/thinkpad/w520>`                 | `lenovo-thinkpad-w520`                 |
+| [Lenovo ThinkPad X1 Yoga](lenovo/thinkpad/x1/yoga)                                | `<nixos-hardware/lenovo/thinkpad/x1/yoga>`              | `lenovo-thinkpad-x1-yoga`              |
+| [Lenovo ThinkPad X1 Yoga Gen 7](lenovo/thinkpad/x1/yoga/7th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/7th-gen>`      | `lenovo-thinkpad-x1-yoga-7th-gen`      |
+| [Lenovo ThinkPad X1 Yoga Gen 8](lenovo/thinkpad/x1/yoga/8th-gen/)                 | `<nixos-hardware/lenovo/thinkpad/x1/yoga/8th-gen>`      | `lenovo-thinkpad-x1-yoga-8th-gen`      |
+| [Lenovo ThinkPad X1 (2nd Gen)](lenovo/thinkpad/x1/2nd-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/2nd-gen>`           | `lenovo-thinkpad-x1-2nd-gen`           |
+| [Lenovo ThinkPad X1 (6th Gen)](lenovo/thinkpad/x1/6th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/6th-gen>`           | `lenovo-thinkpad-x1-6th-gen`           |
+| [Lenovo ThinkPad X1 (7th Gen)](lenovo/thinkpad/x1/7th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/7th-gen>`           | `lenovo-thinkpad-x1-7th-gen`           |
+| [Lenovo ThinkPad X1 (9th Gen)](lenovo/thinkpad/x1/9th-gen)                        | `<nixos-hardware/lenovo/thinkpad/x1/9th-gen>`           | `lenovo-thinkpad-x1-9th-gen`           |
+| [Lenovo ThinkPad X1 (10th Gen)](lenovo/thinkpad/x1/10th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/10th-gen>`          | `lenovo-thinkpad-x1-10th-gen`          |
+| [Lenovo ThinkPad X1 (11th Gen)](lenovo/thinkpad/x1/11th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/11th-gen>`          | `lenovo-thinkpad-x1-11th-gen`          |
+| [Lenovo ThinkPad X1 (12th Gen)](lenovo/thinkpad/x1/12th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/12th-gen>`          | `lenovo-thinkpad-x1-12th-gen`          |
+| [Lenovo ThinkPad X1 (13th Gen)](lenovo/thinkpad/x1/13th-gen)                      | `<nixos-hardware/lenovo/thinkpad/x1/13th-gen>`          | `lenovo-thinkpad-x1-13th-gen`          |
+| [Lenovo ThinkPad X1 Extreme Gen 2](lenovo/thinkpad/x1-extreme/gen2)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen2>`      | `lenovo-thinkpad-x1-extreme-gen2`      |
+| [Lenovo ThinkPad X1 Extreme Gen 3](lenovo/thinkpad/x1-extreme/gen3)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen3>`      | `lenovo-thinkpad-x1-extreme-gen3`      |
+| [Lenovo ThinkPad X1 Extreme Gen 4](lenovo/thinkpad/x1-extreme/gen4)               | `<nixos-hardware/lenovo/thinkpad/x1-extreme/gen4>`      | `lenovo-thinkpad-x1-extreme-gen4`      |
+| [Lenovo ThinkPad X1 Nano Gen 1](lenovo/thinkpad/x1-nano/gen1)                     | `<nixos-hardware/lenovo/thinkpad/x1-nano/gen1>`         | `lenovo-thinkpad-x1-nano-gen1`         |
+| [Lenovo ThinkPad X13s](lenovo/thinkpad/x13s)                                      | `<nixos-hardware/lenovo/thinkpad/x13s>`                 | `lenovo-thinkpad-x13s`                 |
+| [Lenovo ThinkPad X13 Yoga](lenovo/thinkpad/x13/yoga)                              | `<nixos-hardware/lenovo/thinkpad/x13/yoga>`             | `lenovo-thinkpad-x13-yoga`             |
+| [Lenovo ThinkPad X13 Yoga (3th Gen)](lenovo/thinkpad/x13/yoga/3th-gen)            | `<nixos-hardware/lenovo/thinkpad/x13/yoga/3th-gen>`     | `lenovo-thinkpad-x13-yoga-3th-gen`     |
+| [Lenovo ThinkPad X13 (Intel)](lenovo/thinkpad/x13/intel)                          | `<nixos-hardware/lenovo/thinkpad/x13/intel>`            | `lenovo-thinkpad-x13-intel`            |
+| [Lenovo ThinkPad X13 (AMD)](lenovo/thinkpad/x13/amd)                              | `<nixos-hardware/lenovo/thinkpad/x13/amd>`              | `lenovo-thinkpad-x13-amd`              |
+| [Lenovo ThinkPad X140e](lenovo/thinkpad/x140e)                                    | `<nixos-hardware/lenovo/thinkpad/x140e>`                | `lenovo-thinkpad-x140e`                |
+| [Lenovo ThinkPad X200s](lenovo/thinkpad/x200s)                                    | `<nixos-hardware/lenovo/thinkpad/x200s>`                | `lenovo-thinkpad-x200s`                |
+| [Lenovo ThinkPad X220](lenovo/thinkpad/x220)                                      | `<nixos-hardware/lenovo/thinkpad/x220>`                 | `lenovo-thinkpad-x220`                 |
+| [Lenovo ThinkPad X230](lenovo/thinkpad/x230)                                      | `<nixos-hardware/lenovo/thinkpad/x230>`                 | `lenovo-thinkpad-x230`                 |
+| [Lenovo ThinkPad X250](lenovo/thinkpad/x250)                                      | `<nixos-hardware/lenovo/thinkpad/x250>`                 | `lenovo-thinkpad-x250`                 |
+| [Lenovo ThinkPad X260](lenovo/thinkpad/x260)                                      | `<nixos-hardware/lenovo/thinkpad/x260>`                 | `lenovo-thinkpad-x260`                 |
+| [Lenovo ThinkPad X270](lenovo/thinkpad/x270)                                      | `<nixos-hardware/lenovo/thinkpad/x270>`                 | `lenovo-thinkpad-x270`                 |
+| [Lenovo ThinkPad X280](lenovo/thinkpad/x280)                                      | `<nixos-hardware/lenovo/thinkpad/x280>`                 | `lenovo-thinkpad-x280`                 |
+| [Lenovo ThinkPad X390](lenovo/thinkpad/x390)                                      | `<nixos-hardware/lenovo/thinkpad/x390>`                 | `lenovo-thinkpad-x390`                 |
+| [Lenovo ThinkPad Z Series](lenovo/thinkpad/z)                                     | `<nixos-hardware/lenovo/thinkpad/z>`                    | `lenovo-thinkpad-z`                    |
+| [Lenovo ThinkPad Z13 Gen 1](lenovo/thinkpad/z/gen1/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/gen1/z13>`           | `lenovo-thinkpad-z13-gen1`             |
+| [Lenovo ThinkPad Z13 Gen 2](lenovo/thinkpad/z/gen2/z13)                           | `<nixos-hardware/lenovo/thinkpad/z/gen2/z13>`           | `lenovo-thinkpad-z13-gen2`             |
+| [Lenovo XiaoXin Pro 14imh9 2024](lenovo/ideapad/14imh9)                           | `<nixos-hardware/lenovo/ideapad/14imh9>`                | `lenovo-ideapad-14imh9`                |
+| [LENOVO Yoga 6 13ALC6 82ND](lenovo/yoga/6/13ALC6)                                 | `<nixos-hardware/lenovo/yoga/6/13ALC6>`                 | `lenovo-yoga-6-13ALC6`                 |
+| [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/amdgpu)               | `<nixos-hardware/lenovo/yoga/7/14ARH7/amdgpu>`          | `lenovo-yoga-7-14ARH7-amdgpu`          |
+| [LENOVO Yoga Slim 7 Pro-X 14ARH7 82ND](lenovo/yoga/7/14ARH7/nvidia)               | `<nixos-hardware/lenovo/yoga/7/14ARH7/nvidia>`          | `lenovo-yoga-7-14ARH7-nvidia`          |
+| [Lenovo Yoga Slim 7i Pro X 14IAH7 (Integrated)](lenovo/yoga/7/14IAH7/integrated)  | `<nixos-hardware/lenovo/yoga/7/14IAH7/integrated>`      | `lenovo-yoga-7-14IAH7-integrated`      |
+| [Lenovo Yoga Slim 7i Pro X 14IAH7 (Hybrid)](lenovo/yoga/7/14IAH7/hybrid)          | `<nixos-hardware/lenovo/yoga/7/14IAH7/hybrid>`          | `lenovo-yoga-7-14IAH7-hybrid`          |
+| [Lenovo Yoga Slim 7 14ILL10](lenovo/yoga/7/14ILL10)                               | `<nixos-hardware/lenovo/yoga/7/14ILL10>`                | `lenovo-yoga-7-14ILL10`                |
+| [LENOVO Yoga 7 Slim Gen8](lenovo/yoga/7/slim/gen8)                                | `<nixos-hardware/lenovo/yoga/7/slim/gen8>`              | `lenovo-yoga-7-slim-gen8`              |
+| [Linglong Nova Studio](linglong/nova-studio)                                      | `<nixos-hardware/linglong/nova-studio>`                 | `linglong-nova-studio`                 |
+| [MSI B550-A PRO](msi/b550-a-pro)                                                  | `<nixos-hardware/msi/b550-a-pro>`                       | `msi-b550-a-pro`                       |
+| [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                            | `<nixos-hardware/msi/b350-tomahawk>`                    | `msi-b350-tomahawk`                    |
+| [MSI B550 TOMAHAWK](msi/b550-tomahawk)                                            | `<nixos-hardware/msi/b550-tomahawk>`                    | `msi-b550-tomahawk`                    |
+| [MSI GS60 2QE](msi/gs60)                                                          | `<nixos-hardware/msi/gs60>`                             | `msi-gs60`                             |
+| [MSI GL62/CX62](msi/gl62)                                                         | `<nixos-hardware/msi/gl62>`                             | `msi-gl62`                             |
+| [MSI GL65 10SDR-492](msi/gl65/10SDR-492)                                          | `<nixos-hardware/msi/gl65/10SDR-492>`                   | `msi-gl65-10SDR-492`                   |
+| [Malibal Aon S1](malibal/aon/s1)         |                                        | `<nixos-hardware/malibal/aon/s1>`                       | `malibal-aon-s1`                       |
+| [Microchip Icicle Kit](microchip/icicle-kit)                                      | `<nixos-hardware/microchip/icicle-kit>`                 | `microchip-icicle-kit`                 |
+| [Microsoft Surface Go](microsoft/surface/surface-go)                              | `<nixos-hardware/microsoft/surface/surface-go>`         | `microsoft-surface-go`                 |
+| [Microsoft Surface Pro (Intel)](microsoft/surface/surface-pro-intel)              | `<nixos-hardware/microsoft/surface/surface-pro-intel>`  | `microsoft-surface-pro-intel`          |
+| [Microsoft Surface Laptop (AMD)](microsoft/surface/surface-laptop-amd)            | `<nixos-hardware/microsoft/surface/surface-laptop-amd>` | `microsoft-surface-laptop-amd`         |
+| [Microsoft Surface Range (Common Modules)](microsoft/surface/common)              | `<nixos-hardware/microsoft/surface/common>`             | `microsoft-surface-common`             |
+| [Microsoft Surface Pro 3](microsoft/surface-pro/3)                                | `<nixos-hardware/microsoft/surface-pro/3>`              | `microsoft-surface-pro-3`              |
+| [Microsoft Surface Pro 9](microsoft/surface-pro/9)                                | `<nixos-hardware/microsoft/surface-pro/9>`              | `microsoft-surface-pro-9`              |
+| [Milk-V Pioneer](milkv/pioneer)                                                   | `<nixos-hardware/milkv/pioneer>`                        | `milkv-pioneer`                        |
+| [Morefine M600](morefine/m600)                                                    | `<nixos-hardware/morefine/m600>`                        | `morefine-m600`                        |
+| [Minisforum V3](minisforum/v3)                                                    | `<nixos-hardware/minisforum/v3>`                        | `minisforum-v3`                        |
+| [MNT Reform with RK3588 module](mnt/reform/rk3588)                                | `<nixos-hardware/mnt/reform/rk3588`                     | `mnt-reform-rk3588`                    |
+| [MECHREVO Yilong15Pro](mechrevo/GM5HG0A)                                          | `<nixos-hardware/mechrevo/GM5HG0A>`                     | `mechrevo-gm5hg0a`                     |
+| [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                                   | `<nixos-hardware/nxp/imx8mp-evk>`                       | `nxp-imx8mp-evk`                       |
+| [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                                   | `<nixos-hardware/nxp/imx8mq-evk>`                       | `nxp-imx8mq-evk`                       |
+| [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)                        | `<nixos-hardware/hardkernel/odroid-hc4>`                | `hardkernel-odroid-hc4`                |
+| [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h3>`                 | `hardkernel-odroid-h3`                 |
+| [Hardkernel Odroid H4](hardkernel/odroid-h4/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h4>`                 | `hardkernel-odroid-h4`                 |
+| [Olimex TERES-I](olimex/teres_i)                                                  | `<nixos-hardware/olimex/teres_i>`                       | `olimex-teres_i`                       |
+| [Omen 14-fb0798ng](omen/14-fb0798ng)                                              | `<nixos-hardware/omen/14-fb0798ng>`                     | `omen-14-fb0798ng`                     |
+| [Omen 15-ce002ns](omen/15-ce002ns)                                                | `<nixos-hardware/omen/15-ce002ns>`                      | `omen-15-ce002ns`                      |
+| [Omen 15-en0010ca](omen/15-en0010ca)                                              | `<nixos-hardware/omen/15-en0010ca>`                     | `omen-15-en0010ca`                     |
+| [Omen 16-n0005ne](omen/16-n0005ne)                                                | `<nixos-hardware/omen/16-n0005ne>`                      | `omen-16-n0005ne`                      |
+| [Omen 16-n0280nd](/omen/16-n0280nd)                                               | `<nixos-hardware/omen/16-n0280nd>`                      | `omen-16-n0280nd`                      |
+| [Omen 15-en1007sa](omen/15-en1007sa)                                              | `<nixos-hardware/omen/15-en1007sa>`                     | `omen-15-en1007sa`                     |
+| [Omen 15-en0002np](omen/15-en0002np)                                              | `<nixos-hardware/omen/15-en0002np>`                     | `omen-15-en0002np`                     |
+| [One-Netbook OneNetbook 4](onenetbook/4)                                          | `<nixos-hardware/onenetbook/4>`                         | `onenetbook-4`                         |
+| [Panasonic Let's Note CF-LX3](panasonic/letsnote/cf-lx3)                          | `<nixos-hardware/panasonic/letsnote/cf-lx3>`            | `panasonic-letsnote-cf-lx3`            |
+| [Panasonic Let's Note CF-LX4](panasonic/letsnote/cf-lx4)                          | `<nixos-hardware/panasonic/letsnote/cf-lx4>`            | `letsnote-cf-lx4`                      |
+| [PC Engines APU](pcengines/apu)                                                   | `<nixos-hardware/pcengines/apu>`                        | `pcengines-apu`                        |
+| [PINE64 Pinebook Pro](pine64/pinebook-pro/)                                       | `<nixos-hardware/pine64/pinebook-pro>`                  | `pine64-pinebook-pro`                  |
+| [PINE64 RockPro64](pine64/rockpro64/)                                             | `<nixos-hardware/pine64/rockpro64>`                     | `pine64-rockpro64`                     |
+| [PINE64 STAR64](pine64/star64/)                                                   | `<nixos-hardware/pine64/star64>`                        | `pine64-star64`                        |
+| [Protectli VP4670](protectli/vp4670/)                                             | `<nixos-hardware/protectli/vp4670>`                     | `protectli-vp4670`                     |
+| [Purism Librem 13v3](purism/librem/13v3)                                          | `<nixos-hardware/purism/librem/13v3>`                   | `purism-librem-13v3`                   |
+| [Purism Librem 15v3](purism/librem/15v3)                                          | `<nixos-hardware/purism/librem/15v3>`                   | `purism-librem-15v3`                   |
+| [Purism Librem 5r4](purism/librem/5r4)                                            | `<nixos-hardware/purism/librem/5r4>`                    | `purism-librem-5r4`                    |
+| [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   | `rock-4c-plus`                         |
+| [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        | `rock-5b`                              |
+| [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      | `rock-pi-4`                            |
+| [Radxa ROCK Pi E](radxa/rock-pi-e)                                                | `<nixos-hardware/radxa/rock-pi-e>`                      | `rock-pi-e`                            |
+| [Raspberry Pi 2](raspberry-pi/2)                                                  | `<nixos-hardware/raspberry-pi/2>`                       | `raspberry-pi-2`                       |
+| [Raspberry Pi 3](raspberry-pi/3)                                                  | `<nixos-hardware/raspberry-pi/3>`                       | `raspberry-pi-3`                       |
+| [Raspberry Pi 4](raspberry-pi/4)                                                  | `<nixos-hardware/raspberry-pi/4>`                       | `raspberry-pi-4`                       |
+| [Raspberry Pi 5](raspberry-pi/5)                                                  | `<nixos-hardware/raspberry-pi/5>`                       | `raspberry-pi-5`                       |
+| [Samsung Series 9 NP900X3C](samsung/np900x3c)                                     | `<nixos-hardware/samsung/np900x3c>`                     | `samsung-np900x3c`                     |
+| [Slimbook Hero RPL-RTX](slimbook/hero/rpl-rtx)                                    | `<nixos-hardware/slimbook/hero/rpl-rtx>`                | `slimbook-hero-rpl-rtx`                |
+| [StarFive VisionFive v1](starfive/visionfive/v1)                                  | `<nixos-hardware/starfive/visionfive/v1>`               | `starfive-visionfive-v1`               |
+| [StarFive VisionFive 2](starfive/visionfive/v2)                                   | `<nixos-hardware/starfive/visionfive/v2>`               | `starfive-visionfive-2`                |
+| [StarLabs StarLite 5 (I5)](starlabs/starlite/i5)                                  | `<nixos-hardware/starlabs/starlite/i5>`                 | `starlabs-starlite-i5`                 |
+| [Supermicro A1SRi-2758F](supermicro/a1sri-2758f)                                  | `<nixos-hardware/supermicro/a1sri-2758f>`               | `supermicro-a1sri-2758f`               |
+| [Supermicro M11SDV-8C-LN4F](supermicro/m11sdv-8c-ln4f)                            | `<nixos-hardware/supermicro/m11sdv-8c-ln4f>`            | `supermicro-m11sdv-8c-ln4f`            |
+| [Supermicro X10SLL-F](supermicro/x10sll-f)                                        | `<nixos-hardware/supermicro/x10sll-f>`                  | `supermicro-x10sll-f`                  |
+| [Supermicro X12SCZ-TLN4F](supermicro/x12scz-tln4f)                                | `<nixos-hardware/supermicro/x12scz-tln4f>`              | `supermicro-x12scz-tln4f`              |
+| [System76 (generic)](system76)                                                    | `<nixos-hardware/system76>`                             | `system76`                             |
+| [System76 Darter Pro 6](system76/darp6)                                           | `<nixos-hardware/system76/darp6>`                       | `system76-darp6`                       |
+| [System76 Gazelle 18](system76/gaze18)                                            | `<nixos-hardware/system76/gaze18>`                      | `system76-gaze18`                      |
+| [System76 Galago Pro 5](system76/galp5-1650)                                      | `<nixos-hardware/system76/galp5-1650>`                  | `system76-galp5-1650`                  |
+| [System76 Thelio Mega](system76/thelio-mega)                                      | `<nixos-hardware/system76/thelio-mega>`                 | `system76-thelio-mega`                 |
+| [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                                   | `<nixos-hardware/toshiba/swanky>`                       | `toshiba-swanky`                       |
+| [Tuxedo InfinityBook v4](tuxedo/infinitybook/v4)                                  | `<nixos-hardware/tuxedo/infinitybook/v4>`               | `tuxedo-infinitybook-v4`               |
+| [TUXEDO Aura 15 - Gen1](tuxedo/aura/15/gen1)                                      | `<nixos-hardware/tuxedo/aura/15/gen1>`                  | `tuxedo-aura-15-gen1`                  |
+| [TUXEDO InfinityBook Pro 14 - Gen7](tuxedo/infinitybook/pro14/gen7)               | `<nixos-hardware/tuxedo/infinitybook/pro14/gen7>`       | `tuxedo-infinitybook-pro14-gen7`       |
+| [TUXEDO InfinityBook Pro 14 - Gen9 - AMD](tuxedo/infinitybook/pro14/gen9/amd)     | `<nixos-hardware/tuxedo/infinitybook/pro14/gen9/amd>`   | `tuxedo-infinitybook-pro14-gen9-amd`   |
+| [TUXEDO InfinityBook Pro 14 - Gen9 - INTEL](tuxedo/infinitybook/pro14/gen9/intel) | `<nixos-hardware/tuxedo/infinitybook/pro14/gen9/intel>` | `tuxedo-infinitybook-pro14-gen9-intel` |
+| [TUXEDO Pulse 14 - Gen3](tuxedo/pulse/14/gen3)                                    | `<nixos-hardware/tuxedo/pulse/14/gen3>`                 | `tuxedo-pulse-14-gen3`                 |
+| [TUXEDO Pulse 15 - Gen2](tuxedo/pulse/15/gen2)                                    | `<nixos-hardware/tuxedo/pulse/15/gen2>`                 | `tuxedo-pulse-15-gen2`                 |
+| [Xiaomi Redmibook 15 Pro 2021](xiaomi/redmibook/15-pro-2021)                      | `<nixos-hardware/xiaomi/redmibook/15-pro-2021>`         | `xiaomi-redmibook-15-pro-2021`         |
+| [Xiaomi Redmibook 16 Pro 2024](xiaomi/redmibook/16-pro-2024)                      | `<nixos-hardware/xiaomi/redmibook/16-pro-2024>`         | `xiaomi-redmibook-16-pro-2024`         |
+


### PR DESCRIPTION
###### Description of changes

While working on https://github.com/NixOS/nixos-hardware/pull/1535 I noticed there was a missing Dell entry, which got me looking for other missing entries. This adds all the other ones I found, as well as fixing up a couple typos in existing entries, and some table reformatting. 

This was done by just manually going through results from `for FILE in $(fd default.nix); do if \! rg $(dirname ${FILE}) README.md >/dev/null; then echo ${FILE} missing; fi; done | rg -v common` and seeing which results were legitimately missing

I think I caught all of the real missing ones. While reviewing the raw table I decided to properly align most columns so that it's easier to edit/read.

Can do `git diff -w` to see the real non-alignment changes, which to summarize are:

Added:
 - Kobol Helios 4
 - Lenovo Legion Slim 5
 - Malibal Aon S1
 - Milk-V Pioneer
 - Olimex TERES-I

Fixed:
 - Framework 12th Gen Intel Core
 - HP Probook 440G5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

