### PR TITLE
apple/macbook-pro: Correct typos in 12-1 and 8-1 READMEs

### DIFF
--- a/apple/macbook-pro/12-1/README.md
+++ b/apple/macbook-pro/12-1/README.md
@@ -9,7 +9,6 @@ This means it might be required to restart your wifi deamon i.e. wpa_supplicant:
 powerManagement.powerUpCommands = ''
   ${pkgs.systemd}/bin/systemctl restart wpa_supplicant.service
 '';
-};
 ```
 
 You can apply this to your network management software of choice.

--- a/apple/macbook-pro/8-1/README.md
+++ b/apple/macbook-pro/8-1/README.md
@@ -12,7 +12,6 @@
     "b43-firmware"
   ];
 }
-
 ```
 
 ### For all packages


### PR DESCRIPTION
###### Description of changes
Fixed minor typos

###### Things done
- Removed a misplaced bracket in apple/macbook-pro/12-1/README.md
- Removed and unnecessary empty line in apple/macbook-pro/8-1/README.md

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input