### PR TITLE
Lenovo Legion 5 15ach6h add option for hybrid only or nvidia only modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ See code for all available configurations.
 | [Lenovo IdeaPad 2-in-1 16ahp9](lenovo/ideapad/16ahp9)                             | `<nixos-hardware/lenovo/ideapad/16ahp9>`                | `lenovo-ideapad-16ahp9`           |
 | [Lenovo IdeaPad S145 15api](lenovo/ideapad/s145-15api)                            | `<nixos-hardware/lenovo/ideapad/s145-15api>`            | `lenovo-ideapad-s145-15api`       |
 | [Lenovo Legion 5 15ach6h](lenovo/legion/15ach6h)                                  | `<nixos-hardware/lenovo/legion/15ach6h>`                | `lenovo-legion-15ach6h`           |
+| [Lenovo Legion 5 15ach6h (Hybrid)](lenovo/legion/15ach6h/hybrid)                  | `<nixos-hardware/lenovo/legion/15ach6h/hybrid>`         | `lenovo-legion-15ach6h-hybrid`    |
+| [Lenovo Legion 5 15ach6h (Nvidia)](lenovo/legion/15ach6h/hybrid)                  | `<nixos-hardware/lenovo/legion/15ach6h/nvidia>`         | `lenovo-legion-15ach6h-nvidia`    |
 | [Lenovo Legion 5 15arh05h](lenovo/legion/15arh05h)                                | `<nixos-hardware/lenovo/legion/15arh05h>`               | `lenovo-legion-15arh05h`          |
 | [Lenovo Legion 7 Slim 15ach6](lenovo/legion/15ach6)                               | `<nixos-hardware/lenovo/legion/15ach6>`                 | `lenovo-legion-15ach6`            |
 | [Lenovo Legion 5 Pro 16ach6h](lenovo/legion/16ach6h)                              | `<nixos-hardware/lenovo/legion/16ach6h>`                | `lenovo-legion-16ach6h`           |

--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,8 @@
           lenovo-ideapad-s145-15api = import ./lenovo/ideapad/s145-15api;
           lenovo-legion-15ach6 = import ./lenovo/legion/15ach6;
           lenovo-legion-15ach6h = import ./lenovo/legion/15ach6h;
+          lenovo-legion-15ach6h-hybrid = import ./lenovo/legion/15ach6h/hybrid;
+          lenovo-legion-15ach6h-nvidia = import ./lenovo/legion/15ach6h/nvidia;
           lenovo-legion-15arh05h = import ./lenovo/legion/15arh05h;
           lenovo-legion-16ach6h = import ./lenovo/legion/16ach6h;
           lenovo-legion-16ach6h-hybrid = import ./lenovo/legion/16ach6h/hybrid;


### PR DESCRIPTION
###### Description of changes

Lenovo Legion 15ACH6H only had the option to choose both hybrid and nvidia modules (by building a specialization). Added two more options to the `flake.nix` so the specialization can be opted out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

