### PR TITLE
lenovo/yoga/7/14ILL10: update kernel version requirement

### DIFF
--- a/lenovo/yoga/7/14ILL10/default.nix
+++ b/lenovo/yoga/7/14ILL10/default.nix
@@ -6,8 +6,8 @@
     ../../../../common/pc/ssd
   ];
 
-  # touchpad, wifi, and bluetooth do not work before 6.12
-  config.boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.12") (
+  # device will not boot in kernel versions older than 6.15
+  config.boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") (
     lib.mkDefault pkgs.linuxPackages_latest
   );
 }


### PR DESCRIPTION
###### Description of changes
Newer sub-versions of Linux 6.12 do not boot. This increases the version requirement to 6.15.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

