### PR TITLE
framework-amd-ai-300-series: bump kernel to latest for suspend support

### DIFF
--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -10,6 +10,11 @@
     ../common
     ../common/amd.nix
   ];
-  config.hardware.framework.laptop13.audioEnhancement.rawDeviceName =
-    lib.mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
+  config = {
+    hardware.framework.laptop13.audioEnhancement.rawDeviceName =
+      lib.mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
+
+    # suspend works with 6.15
+    boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") pkgs.linuxPackages_latest;
+  };
 }


### PR DESCRIPTION
###### Description of changes

Tested suspend and hibernate working with this config:

```nix
{
  disko.devices = {
    disk = {
      nvme0n1 = {
        device = "/dev/nvme0n1";
        type = "disk";
        content = {
          type = "gpt";
          partitions = {
            boot = {
              priority = 1;
              start = "34s";
              end = "2047s";
              type = "EF02"; # for grub MBR
            };
            ESP = {
              priority = 2;
              start = "2048s";
              end = "2099199s";
              type = "EF00";
              content = {
                type = "filesystem";
                format = "vfat";
                mountpoint = "/boot";
              };
            };
            luks = {
              priority = 3;
              start = "2099200s";
              type = "8309";
              content = {
                type = "luks";
                name = "crypted-nvme0n1";
                settings.allowDiscards = true;
                content = {
                  type = "lvm_pv";
                  vg = "nvme0n1";
                };
              };
            };
          };
        };
      };
    };
    lvm_vg = {
      nvme0n1 = {
        type = "lvm_vg";
        lvs = {
          # LVs are created in alphabetic order for some reason
          # Prefixing them with a letter like this ensures desired creation order
          a_swap = {
            size = "64GiB";
            content = {
              type = "swap";
            };
          };
          z_persist = {
            size = "100%FREE";
            content = {
              type = "zfs";
              pool = "root";
            };
          };
        };
      };
    };
    zpool = {
      root = {
        type = "zpool";
        rootFsOptions = {
          compression = "lz4";
          "com.sun:auto-snapshot" = "false";
          mountpoint = "none";
          reservation = "16G";
        };
        postCreateHook = ''
          zfs snapshot root@blank;
          zfs snapshot root/nixos@blank;
          zfs snapshot root/nix@blank;
          zfs snapshot root/home@blank;
          zfs snapshot root/persist@blank
        '';

        datasets = {
          nixos = {
            type = "zfs_fs";
            mountpoint = "/";
            options.mountpoint = "legacy";
            options."com.sun:auto-snapshot" = "true";
          };
          nix = {
            type = "zfs_fs";
            mountpoint = "/nix";
            options.mountpoint = "legacy";
            options."com.sun:auto-snapshot" = "false";
          };
          home = {
            type = "zfs_fs";
            mountpoint = "/home";
            options.mountpoint = "legacy";
            options."com.sun:auto-snapshot" = "true";
          };
          persist = {
            type = "zfs_fs";
            mountpoint = "/persist";
            options.mountpoint = "legacy";
            options."com.sun:auto-snapshot" = "true";
          };
        };
      };
    };
  };
}
```

```nix
{
  # Partition swapfile is on (after LUKS decryption)
  boot = {
    resumeDevice = "/dev/disk/by-id/dm-name-nvme0n1-a_swap";
    kernelParams = [
      "mem_sleep_default=deep"
    ];
    zfs.allowHibernation = true;
  };

  # Suspend-then-hibernate everywhere
  services.logind = {
    lidSwitch = "suspend-then-hibernate";
    extraConfig = ''
      HandlePowerKey=suspend-then-hibernate
      IdleAction=suspend-then-hibernate
      IdleActionSec=2m
    '';
  };
  systemd.sleep.extraConfig = "HibernateDelaySec=15m";
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

