### PR TITLE
Allow boot.kernelPackages to be configurable for AMD 300 series

### DIFF
--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -4,7 +4,6 @@
   pkgs,
   ...
 }:
-
 {
   imports = [
     ../common
@@ -15,6 +14,8 @@
       lib.mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
 
     # suspend works with 6.15
-    boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") pkgs.linuxPackages_latest;
+    boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") (
+      lib.mkDefault pkgs.linuxPackages_latest
+    );
   };
 }


### PR DESCRIPTION
###### Description of changes
The last change which introduced a check for 6.15 kernel version removed the lib.mkDefault parameter causing customization of the paramter on the user side to fail. This change reintroduces that functionality.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

