### PR TITLE
System76/gaze18: minor fixes

### DIFF
--- a/system76/gaze18/default.nix
+++ b/system76/gaze18/default.nix
@@ -9,6 +9,7 @@
     ../.
     ../../common/gpu/nvidia/prime.nix
     ../../common/gpu/nvidia/ampere
+    ../../common/cpu/intel/raptor-lake
   ];
 
   boot.initrd.kernelModules = [ "nvidia" ];

--- a/system76/gaze18/default.nix
+++ b/system76/gaze18/default.nix
@@ -10,6 +10,8 @@
     ../../common/gpu/nvidia/prime.nix
     ../../common/gpu/nvidia/ampere
     ../../common/cpu/intel/raptor-lake
+    ../../common/pc/laptop
+    ../../common/pc/ssd
   ];
 
   # For offloading, `modesetting` is needed

--- a/system76/gaze18/default.nix
+++ b/system76/gaze18/default.nix
@@ -12,7 +12,11 @@
     ../../common/cpu/intel/raptor-lake
   ];
 
-  boot.initrd.kernelModules = [ "nvidia" ];
+  # For offloading, `modesetting` is needed
+  services.xserver.videoDrivers = [
+    "modesetting"
+    "nvidia"
+  ];
 
   hardware.graphics = {
     enable = lib.mkDefault true;
@@ -20,8 +24,6 @@
   };
 
   hardware.nvidia = {
-
-    # modesetting.enable = lib.mkDefault true;
 
     powerManagement.finegrained = lib.mkDefault true;
 


### PR DESCRIPTION
###### Description of changes

- Add CPU module
- use services.xserver.videoDrivers instead initrd.kernelModules for Nvidia graphics


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

