### PR TITLE
framework/13-inch/intel-core-ultra-series1: revert #1358 (fix intel_vpu firmware error -2)

### DIFF
--- a/framework/13-inch/intel-core-ultra-series1/default.nix
+++ b/framework/13-inch/intel-core-ultra-series1/default.nix
@@ -17,30 +17,6 @@
     lib.mkDefault pkgs.linuxPackages_latest
   );
 
-  # Intel NPU Driver
-  # https://discourse.nixos.org/t/new-installation-on-asus-zenbook-ux5406-intel-vpu-firmware-error-2/58732/2
-  hardware.firmware = lib.optionals (config.hardware.enableRedistributableFirmware) [
-    (
-      let
-        model = "37xx";
-        version = "0.0";
-
-        firmware = pkgs.fetchurl {
-          url = "https://github.com/intel/linux-npu-driver/raw/v1.13.0/firmware/bin/vpu_${model}_v${version}.bin";
-          hash = "sha256-Mpoeq8HrwChjtHALsss/7QsFtDYAoFNsnhllU0xp3os=";
-        };
-      in
-      pkgs.runCommand "intel-vpu-firmware-${model}-${version}" { } ''
-        mkdir -p "$out/lib/firmware/intel/vpu"
-        cp '${firmware}' "$out/lib/firmware/intel/vpu/vpu_${model}_v${version}.bin"
-      ''
-    )
-  ];
-
-  warnings = lib.mkIf (!config.hardware.enableRedistributableFirmware) [
-    ''For Intel NPU support, set the option: hardware.enableRedistributableFirmware = true;''
-  ];
-
   hardware.framework.laptop13.audioEnhancement.rawDeviceName =
     lib.mkDefault "alsa_output.pci-0000_00_1f.3.analog-stereo";
 }


### PR DESCRIPTION
###### Description of changes

This reverts #1358 (framework/13-inch/intel-core-ultra-series1: fix intel_vpu firmware error -2).

The firmware is now upstreamed to linux-firmware (https://web.git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=9b870dde196d030a6c8872e8965dd28a0146c990), so #1358 is no longer needed.

Right now, there is no impact to my proposed change (all this does is avoid downloading a file twice). However, it is better to use the upstreamed version in case the firmware gets updated in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

