### PR TITLE
Update flake.lock, dropping unused `nixpkgs` input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1751290770,
-        "narHash": "sha256-u4s8yKAqTzPGY3vTcDyAIet11uXaNCM//93/0O0NlbA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0620a50e9a847851bf802c59a4202552ed79b821",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7


### PR DESCRIPTION
###### Description of changes

On a7600cef40e350c6f3fcb6eefb6f0d6b09c7d05e all the inputs on `flake.nix` were moved to `tests/flake.nix`, but `flake.lock` was not updated correctly, and a reference to `nixpkgs` still remains, producing this error upon evaluation when used as an input to my flake:

```
evaluating file '<nix/derivation-internal.nix>'
copying "/nix/store/xjzjf1f6nyg6yqxb6v5awf9hs14606yp-source" to the store...
evaluating file '/nix/store/xjzjf1f6nyg6yqxb6v5awf9hs14606yp-source/flake.nix'
evaluating file '/nix/store/xjzjf1f6nyg6yqxb6v5awf9hs14606yp-source/flake.nix'
warning: updating lock file '"/nix/store/xjzjf1f6nyg6yqxb6v5awf9hs14606yp-source/flake.lock"':
• Removed input 'nixpkgs'
error:… while updating the lock file of flake 'path:/nix/store/xjzjf1f6nyg6yqxb6v5awf9hs14606yp-source?lastModified=0&narHash=sha256-dz303vGuzWjzOPOaYkS9xSW%2BB93PSAJxvBd6CambXVA%3D'
error: opening file '/nix/store/xjzjf1f6nyg6yqxb6v5awf9hs14606yp-source/flake.lock': Read-only file system
```

I’ve thus updated `flake.lock` with the standard procedure:

```console
❯ nix flake lock --verbose
warning: updating lock file '"/home/pancho/sandbox/NixOS/nixos-hardware/flake.lock"':
• Removed input 'nixpkgs'
```

which fixes the issue.

Hope that it helps. Cheers!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

