### PR TITLE
raspberry-pi/4: support enabling/disabling media-controller api on tc358743

### DIFF
--- a/raspberry-pi/4/tc358743.nix
+++ b/raspberry-pi/4/tc358743.nix
@@ -13,6 +13,11 @@ in
         running ustreamer (which starts webservice providing a camera stream):
         ''${pkgs.ustreamer}/bin/ustreamer --persistent --dv-timings
       '';
+      media-controller = lib.mkEnableOption ''
+        Enable support for the Media Controller API.
+
+        See https://forums.raspberrypi.com/viewtopic.php?t=322076 for details
+      '';
     };
   };
 
@@ -60,6 +65,15 @@ in
 
               __overlay__ {
                 status = "okay";
+
+                ${
+                  if cfg.media-controller then
+                    ""
+                  else
+                    ''
+                      compatible = "brcm,bcm2835-unicam-legacy";
+                    ''
+                }
 
                 port {
 


### PR DESCRIPTION
###### Description of changes

Newer kernels seem to enable the Media Controller API by default on tc358743, which breaks some apps relying on the legacy API. See https://github.com/raspberrypi/linux/issues/4670#issuecomment-961850934 for details.

This change adds an option to choose whether Media Controller is enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

