### PR TITLE
Fix Typo Preventing Microsoft Surface Kernels from Building

### DIFF
--- a/microsoft/surface/common/kernel/6.12/patches.nix
+++ b/microsoft/surface/common/kernel/6.12/patches.nix
@@ -3,7 +3,9 @@
   kernel ? lib.kernel,
   patchSrc,
   version,
-}: [
+}:
+
+[
   {
     name = "microsoft-surface-patches-linux-${version}";
     patch = null;

--- a/microsoft/surface/common/kernel/6.12/patches.nix
+++ b/microsoft/surface/common/kernel/6.12/patches.nix
@@ -3,13 +3,11 @@
   kernel ? lib.kernel,
   patchSrc,
   version,
-}:
-
-[
+}: [
   {
     name = "microsoft-surface-patches-linux-${version}";
     patch = null;
-    extraStructuredConfig = with kernel; {
+    structuredExtraConfig = with kernel; {
       STAGING_MEDIA = yes;
 
       ##

--- a/microsoft/surface/common/kernel/6.15/patches.nix
+++ b/microsoft/surface/common/kernel/6.15/patches.nix
@@ -3,7 +3,9 @@
   kernel ? lib.kernel,
   patchSrc,
   version,
-}: [
+}:
+
+[
   {
     name = "microsoft-surface-patches-linux-${version}";
     patch = null;

--- a/microsoft/surface/common/kernel/6.15/patches.nix
+++ b/microsoft/surface/common/kernel/6.15/patches.nix
@@ -3,13 +3,11 @@
   kernel ? lib.kernel,
   patchSrc,
   version,
-}:
-
-[
+}: [
   {
     name = "microsoft-surface-patches-linux-${version}";
     patch = null;
-    extraStructuredConfig = with kernel; {
+    structuredExtraConfig = with kernel; {
       STAGING_MEDIA = yes;
       ##
       ## Surface Aggregator Module


### PR DESCRIPTION
###### Description of changes

Due to [nixpkgs #431115](https://github.com/NixOS/nixpkgs/pull/431115) and [nixpkgs #432497](https://github.com/NixOS/nixpkgs/pull/432497), using `extraStructuredConfig` now throws an error rather then being silently ignored. This PR updates the kernel patches for the Microsoft surface kernels to use `structuredExtraConfig` instead, to correctly configure the kernel without any errors.

I'm currently running the fixed branch of my fork on my Surface 5.

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via Flake input

