### PR TITLE
Revert "apple: add hid_apple.iso_layout=0 kernel param"

### DIFF
--- a/apple/default.nix
+++ b/apple/default.nix
@@ -1,10 +1,6 @@
 { config, lib, ... }:
 
 {
-  boot.kernelParams = [
-    "hid_apple.iso_layout=0"
-  ];
-
   hardware.facetimehd.enable = lib.mkDefault (config.nixpkgs.config.allowUnfree or false);
 
   services.mbpfan.enable = lib.mkDefault true;


### PR DESCRIPTION
This reverts commit e228c7827b5ac2b08f07433aa8fbc8f2c41e85a5.

###### Description of changes

This seems to be out of date. It causes issues on apple-macbook-pro-12-1 with ISO layout.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

