### PR TITLE
framework 16: Remove headset quirk

### DIFF
--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -8,12 +8,6 @@
     ../../framework-tool.nix
   ];
 
-  # Fix TRRS headphones missing a mic
-  # https://community.frame.work/t/headset-microphone-on-linux/12387/3
-  boot.extraModprobeConfig = lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.6.8") ''
-    options snd-hda-intel model=dell-headset-multi
-  '';
-
   # For fingerprint support
   services.fprintd.enable = lib.mkDefault true;
 


### PR DESCRIPTION
###### Description of changes
Framework 16 does not have a built-in headphone jack, this is not needed.
The kernel has also reverted the quick, so matching on a kernel version does nothing useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

