### PR TITLE
framework: Enable fwupd by default

### DIFF
--- a/framework/12-inch/13th-gen-intel/README.md
+++ b/framework/12-inch/13th-gen-intel/README.md
@@ -2,16 +2,13 @@
 
 ## Updating Firmware
 
-First put enable `fwupd`
+Everything is updateable through fwupd, so it's enabled by default.
 
-```nix
-services.fwupd.enable = true;
-```
-
-Then run
+To get the latest firmware, run:
 
 ```sh
- $ fwupdmgr update
+$ fwupdmgr refresh
+$ fwupdmgr update
 ```
 
 - [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop12.RPL.BIOS.firmware)

--- a/framework/12-inch/common/default.nix
+++ b/framework/12-inch/common/default.nix
@@ -16,4 +16,7 @@
 
   # Needed for desktop environments to detect display orientation
   hardware.sensor.iio.enable = lib.mkDefault true;
+
+  # Everything is updateable through fwupd
+  services.fwupd.enable = true;
 }

--- a/framework/13-inch/7040-amd/README.md
+++ b/framework/13-inch/7040-amd/README.md
@@ -2,16 +2,13 @@
 
 ## Updating Firmware
 
-First put enable `fwupd`
+Everything is updateable through fwupd, so it's enabled by default.
 
-```nix
-services.fwupd.enable = true;
-```
-
-Then run
+To get the latest firmware, run:
 
 ```sh
- $ fwupdmgr update
+$ fwupdmgr refresh
+$ fwupdmgr update
 ```
 
 - [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop.Ryzen7040.BIOS.firmware)

--- a/framework/13-inch/7040-amd/default.nix
+++ b/framework/13-inch/7040-amd/default.nix
@@ -14,7 +14,6 @@ in
     ../common/amd.nix
     ../../../common/cpu/amd/raphael/igpu.nix
   ];
-
   options = {
     hardware.framework.amd-7040.preventWakeOnAC = lib.mkOption {
       type = lib.types.bool;
@@ -30,6 +29,8 @@ in
   };
 
   config = {
+    services.fwupd.enable = true;
+
     # Workaround applied upstream in Linux >=6.7 (on BIOS 03.03)
     # https://github.com/torvalds/linux/commit/a55bdad5dfd1efd4ed9ffe518897a21ca8e4e193
     services.udev.extraRules =

--- a/framework/13-inch/amd-ai-300-series/README.md
+++ b/framework/13-inch/amd-ai-300-series/README.md
@@ -2,14 +2,13 @@
 
 ## Updating Firmware
 
-First put enable `fwupd`
+Everything is updateable through fwupd, so it's enabled by default.
 
-```nix
-services.fwupd.enable = true;
-```
-
-Then run
+To get the latest firmware, run:
 
 ```sh
- $ fwupdmgr update
+$ fwupdmgr refresh
+$ fwupdmgr update
 ```
+
+- [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop.RyzenAI300.BIOS.firmware)

--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -10,7 +10,11 @@
     ../common
     ../common/amd.nix
   ];
+
   config = {
+    # Everything is updateable through fwupd
+    services.fwupd.enable = true;
+
     hardware.framework.laptop13.audioEnhancement.rawDeviceName =
       lib.mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
 

--- a/framework/13-inch/intel-core-ultra-series1/README.md
+++ b/framework/13-inch/intel-core-ultra-series1/README.md
@@ -2,14 +2,13 @@
 
 ## Updating Firmware
 
-First put enable `fwupd`
+Everything is updateable through fwupd, so it's enabled by default.
 
-```nix
-services.fwupd.enable = true;
-```
-
-Then run
+To get the latest firmware, run:
 
 ```sh
- $ fwupdmgr update
+$ fwupdmgr refresh
+$ fwupdmgr update
 ```
+
+- [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop.MTL.BIOS.firmware)

--- a/framework/13-inch/intel-core-ultra-series1/default.nix
+++ b/framework/13-inch/intel-core-ultra-series1/default.nix
@@ -11,6 +11,9 @@
     ../common/intel.nix
   ];
 
+  # Everything is updateable through fwupd
+  services.fwupd.enable = true;
+
   # Need at least 6.9 to make suspend properly
   # Specifically this patch: https://github.com/torvalds/linux/commit/073237281a508ac80ec025872ad7de50cfb5a28a
   boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.9") (

--- a/framework/16-inch/7040-amd/README.md
+++ b/framework/16-inch/7040-amd/README.md
@@ -1,4 +1,14 @@
 # [Framework Laptop 16](https://frame.work/)
 
 ## Updating Firmware
-The Framework Laptop 16 uses LVFS, so it can be updated via fwupd; see https://wiki.nixos.org/wiki/Fwupd for details
+
+Everything is updateable through fwupd, so it's enabled by default.
+
+To get the latest firmware, run:
+
+```sh
+$ fwupdmgr refresh
+$ fwupdmgr update
+```
+
+- [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop16.Ryzen7040.BIOS.firmware)

--- a/framework/16-inch/7040-amd/default.nix
+++ b/framework/16-inch/7040-amd/default.nix
@@ -12,4 +12,6 @@
     ../../../common/cpu/amd/raphael/igpu.nix
   ];
 
+  # Everything is updateable through fwupd
+  services.fwupd.enable = true;
 }

--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -50,4 +50,7 @@
     MatchDMIModalias=dmi:*svnFramework:pnLaptop16*
     AttrKeyboardIntegration=internal
   '';
+
+  # Everything is updateable through fwupd
+  services.fwupd.enable = true;
 }


### PR DESCRIPTION
###### Description of changes
Users should keep their firmware (not just BIOS) up to date. Framework 13 Intel 11-13th Gen have some components that can't be updated with fwupd, so some BIOS versions are better to be installed through the EFI shell or Windows.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

