### PR TITLE
fix: add missing import of ideapad 16iah8

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,7 @@
           lenovo-ideapad-15ach6 = import ./lenovo/ideapad/15ach6;
           lenovo-ideapad-16ach6 = import ./lenovo/ideapad/16ach6;
           lenovo-ideapad-16ahp9 = import ./lenovo/ideapad/16ahp9;
+          lenovo-ideapad-s5-16iah8 = import ./lenovo/ideapad/16iah8;
           lenovo-ideapad-z510 = import ./lenovo/ideapad/z510;
           lenovo-ideapad-slim-5 = import ./lenovo/ideapad/slim-5;
           lenovo-ideapad-s145-15api = import ./lenovo/ideapad/s145-15api;


### PR DESCRIPTION
###### Description of changes
This PR simply adds an import of ideapad-s5-16iah8 which the dev probably forgot to add. Resolves #1588 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

