### PR TITLE
dell/precision/7520: use stable nvidia driver (not legacy)

### DIFF
--- a/dell/precision/7520/README.md
+++ b/dell/precision/7520/README.md
@@ -61,7 +61,10 @@ Then use `fwupdmgr` to perform updates
 
 ## Nvidia Driver
 
-The choice of the `legacy_390` driver is based on looking for PCI Device ID `10de:1436`. On the [nvidia driver site](https://www.nvidia.com/en-us/drivers/unix/legacy-gpu/) which should indicate the
-driver, the exact device isn't listed. However, we can see
-[here](https://linux-hardware.org/?id=pci:10de-1436-103c-1909) has nvidia driver "375.82 and newer" listed. Since the
-newest nvidia drivers don't support legacy devices, the closest version newer than 375.82 was chosen.
+The choice of the `stable` driver is based on looking at the family of the card on [nouveau wiki's code names page](https://nouveau.freedesktop.org/CodeNames.html) obtained with:
+
+```bash
+$ lspci -k -d ::03xx
+```
+
+Both `Quadro M2200 Mobile (GM206GLM)` and `Quadro M1200 Mobile (GM107GLM)` belong to the **Maxwell** family which is still supported by the stable driver.

--- a/dell/precision/7520/default.nix
+++ b/dell/precision/7520/default.nix
@@ -32,7 +32,7 @@
       enable32Bit = lib.mkDefault true;
     };
     nvidia = {
-      package = config.boot.kernelPackages.nvidiaPackages.legacy_390;
+      package = config.boot.kernelPackages.nvidiaPackages.stable;
       nvidiaSettings = lib.mkDefault true;
       modesetting.enable = lib.mkDefault true;
       open = lib.mkDefault false;


### PR DESCRIPTION
###### Description of changes

Maxwell family GPUs are still supported by the stable NVIDIA proprietary driver. This PR changes the package used for the driver to  `config.boot.kernelPackages.nvidiaPackages.stable`.
Also, it changes the `dell/precision/7520/README.md` file to reflect the changes and points to the nouveau relevant documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

