### PR TITLE
Update thermal-config.xml surface-pro-intel

### DIFF
--- a/microsoft/surface/surface-pro-intel/thermal-conf.xml
+++ b/microsoft/surface/surface-pro-intel/thermal-conf.xml
@@ -1,27 +1,39 @@
 <?xml version="1.0"?>
 <ThermalConfiguration>
-<Platform>
-	<Name>Surface Pro Intel Thermal Workaround</Name>
-	<ProductName>*</ProductName>
-	<Preference>QUIET</Preference>
-	<ThermalZones>
-		<ThermalZone>
-			<Type>cpu</Type>
-			<TripPoints>
-				<TripPoint>
-					<SensorType>x86_pkg_temp</SensorType>
-					<Temperature>65000</Temperature>
-					<type>passive</type>
-					<ControlType>SEQUENTIAL</ControlType>
-					<CoolingDevice>
-						<index>1</index>
-						<type>rapl_controller</type>
-						<influence>100</influence>
-						<SamplingPeriod>10</SamplingPeriod>
-					</CoolingDevice>
-				</TripPoint>
-			</TripPoints>
-		</ThermalZone>
-	</ThermalZones>
-</Platform>
+  <Platform>
+    <Name>Surface Pro Intel Thermal Workaround</Name>
+    <ProductName>*</ProductName>
+    <Preference>QUIET</Preference>
+    <ThermalZones>
+      <ThermalZone>
+        <Type>cpu</Type>
+        <TripPoints>
+          <TripPoint>
+            <SensorType>x86_pkg_temp</SensorType>
+            <Temperature>63769</Temperature>
+            <type>passive</type>
+            <ControlType>PARALLEL</ControlType>
+            <CoolingDevice>
+              <index>1</index>
+              <type>rapl_controller</type>
+              <influence> 100 </influence>
+              <SamplingPeriod> 10 </SamplingPeriod>
+            </CoolingDevice>
+            <CoolingDevice>
+              <index>2</index>
+              <type>intel_pstate</type>
+              <influence> 90 </influence>
+              <SamplingPeriod> 10 </SamplingPeriod>
+            </CoolingDevice>
+            <CoolingDevice>
+              <index>3</index>
+              <type>intel_powerclamp</type>
+              <influence> 80 </influence>
+              <SamplingPeriod> 10 </SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+        </TripPoints>
+      </ThermalZone>
+    </ThermalZones>
+  </Platform>
 </ThermalConfiguration>


### PR DESCRIPTION
###### Description of changes

This changes the current thermald configuration for surface-pro-intel, here is the original comment with the explanation of where these changes come from.
https://github.com/linux-surface/linux-surface/issues/221#issuecomment-1732658939

I can confirm it seems to work very well with the surface pro 7 model. I think we could use this PR to see if it could potentially be also used or other intel models

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

