### PR TITLE
fydetab/duo: fix typo with enable option

### DIFF
--- a/fydetab/duo/default.nix
+++ b/fydetab/duo/default.nix
@@ -13,7 +13,7 @@ in
   ];
 
   options.hardware.fydetab.duo = {
-    enablePanthor = lib.mkEnable "Panthor GPU driver";
+    enablePanthor = lib.mkEnableOption "Panthor GPU driver";
   };
 
   config = {


### PR DESCRIPTION
###### Description of changes

Fixes a typo from #1583

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

