### PR TITLE
fydetab/duo: fix hardware.firmware being applied

### DIFF
--- a/fydetab/duo/README.md
+++ b/fydetab/duo/README.md
@@ -5,6 +5,8 @@ The Fydetab Duo is an open source and hackable tablet by FydeOS.
 ## Features
 
 - Display: **works**
+  - X11: **untested**
+  - Wayland: **not working** (niri, sway, COSMIC)
 - GPU driver: **not working**
 - WiFi: **working**
 - Cellular: **untested**

--- a/fydetab/duo/config
+++ b/fydetab/duo/config
@@ -6540,7 +6540,7 @@ CONFIG_HID_WIIMOTE=m
 # CONFIG_HID_XINMO is not set
 # CONFIG_HID_ZEROPLUS is not set
 # CONFIG_HID_ZYDACRON is not set
-# CONFIG_HID_SENSOR_HUB is not set
+CONFIG_HID_SENSOR_HUB=m
 # CONFIG_HID_ALPS is not set
 # CONFIG_HID_MCP2221 is not set
 # end of Special HID drivers

--- a/fydetab/duo/himax.nix
+++ b/fydetab/duo/himax.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation (_finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/Linux-for-Fydetab-Duo/pkgbuilds/raw/f4c012bd42d87f677370f987f703982d53cd233d/fydetabduo-post-install/Himax_firmware.bin";
+    hash = "sha256-z0p/zXcNTBdhKCV6GmM2C8C02lu4Wkb2HP+Ir/nQJTc=";
   };
 
   compressFirmware = false;


### PR DESCRIPTION
###### Description of changes

Fixes this error:
```
       error: A definition for option `hardware.firmware' is not of type `list of package'. TypeError: Definition values:
       - In `/nix/store/1jcq7nbm2bj68bpa85fblak3c87a917r-source/fydetab/duo': <derivation ap6275p-firmware-2023-11-05>
       - In `/nix/store/1jcq7nbm2bj68bpa85fblak3c87a917r-source/fydetab/duo': <derivation mali-g610-firmware-2024-08-23>
       - In `/nix/store/1jcq7nbm2bj68bpa85fblak3c87a917r-source/fydetab/duo': <derivation himax-firmware-2024-11-09>
```

Also fixes the himax firmware, forgot to get a hash. I've also changed the graphics section of the README to clarify things more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

