### PR TITLE
tuxedo/pulse/15/gen2: load more modules and defer warning

### DIFF
--- a/tuxedo/pulse/15/gen2/default.nix
+++ b/tuxedo/pulse/15/gen2/default.nix
@@ -2,7 +2,12 @@
 {
   imports = [
     ../../../../common/cpu/amd
+    ../../../../common/cpu/amd/pstate.nix
+    ../../../../common/cpu/amd/zenpower.nix
     ../../../../common/gpu/amd
+    ../../../../common/hidpi.nix
+    ../../../../common/pc
+    ../../../../common/pc/laptop
     ../../../../common/pc/ssd
   ];
 

--- a/tuxedo/pulse/15/gen2/default.nix
+++ b/tuxedo/pulse/15/gen2/default.nix
@@ -11,6 +11,13 @@
     ../../../../common/pc/ssd
   ];
 
+  # Defer the following Stage 1 warning to Stage 2:
+  #
+  #     loading module amdgpu...
+  #     [...] amdgpu 0000:05:00.0: amdgpu: Secure display: Generic Failure.
+  #     [...] amdgpu 0000:05:00.0: amdgpu: SECUREDISPLAY: query securedisplay TA failed. ret 0x0
+  hardware.amdgpu.initrd.enable = false;
+
   services.udev.extraRules = builtins.concatStringsSep "\n" (
     [ "# Properly suspend the system." ]
     ++ (map


### PR DESCRIPTION
###### Description of changes

```
commit 0c55f0f776577c45cc9d05d2e0a38013b965d70b
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-07 01:15:31 +0200

    tuxedo/pulse/15/gen2: load more internal modules

 tuxedo/pulse/15/gen2/default.nix | 5 +++++
 1 file changed, 5 insertions(+)

commit 40dffd02e3fe00ad1a27fd1b8b0d059c253776da
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-07 21:38:07 +0000

    tuxedo/pulse/15/gen2: defer amdgpu secure display warning to Stage 2

    Defer the amdgpu secure display warning from Stage 1 to Stage 2, despite
    the initial decision [1] of reverting commit dd18dc771432
    ("fix(tuxedo/pulse/15/gen2): prevent 'Secure display: Generic Failure'
    warning") with commit 80d98a7d55c6 ("feat(tuxedo/pulse/15/gen2): use
    default 'hardware.amdgpu.loadInInitrd'").

    Since this noisy warning is an inherit property of this hardware,
    deferring it is the desired behavior.

    [1]: https://github.com/NixOS/nixos-hardware/pull/755#discussion_r1359669448

 tuxedo/pulse/15/gen2/default.nix | 7 +++++++
 1 file changed, 7 insertions(+)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
