### PR TITLE
MacBookAir6,x: fix wireless

### DIFF
--- a/apple/macbook-air/6/default.nix
+++ b/apple/macbook-air/6/default.nix
@@ -1,7 +1,11 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
   imports = [ ../. ];
+
+  boot.kernelModules = [ "wl" ];
+  boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
+  boot.blacklistedKernelModules = [ "bcma" ];
 
   boot = {
     # Divides power consumption by two.


### PR DESCRIPTION
###### Description of changes

The BCM4360 wireless chipset is only supported in `broadcom-wl` (`broadcom_sta`) not in the `b43`/`bcma` kernel modules

https://wireless.docs.kernel.org/en/latest/en/users/drivers/b43/devices.html
https://wiki.debian.org/wl#Supported_Devices

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

