### PR TITLE
feat: kernel params for x1 carbon

### DIFF
--- a/lenovo/thinkpad/x1/12th-gen/default.nix
+++ b/lenovo/thinkpad/x1/12th-gen/default.nix
@@ -2,6 +2,12 @@
   imports = [
     ../.
     ../../../../common/pc/ssd
+    ../../../../common/cpu/intel/meteor-lake
+  ];
+
+  boot.kernelParams = [
+    "i915.enable_guc=3"
+    "i915.force_probe=7d55"
   ];
 
   hardware.trackpoint.device = "TPPS/2 Synaptics TrackPoint";


### PR DESCRIPTION
###### Description of changes

This commit adds the necessary kernel parameters to enable graphics on laptops with Intel Meteor Lake CPUs. Specifically, it enables the GuC firmware for graphics acceleration and force-probes the i915 driver for the device ID 7d55, which corresponds to the integrated GPU on these processors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

