### PR TITLE
Remove deprecations until there's a migration path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -381,16 +381,10 @@
           common-cpu-amd-zenpower = import ./common/cpu/amd/zenpower.nix;
           common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
           common-cpu-intel = import ./common/cpu/intel;
-          common-gpu-intel-comet-lake =
-            deprecated "992" "common-gpu-intel-comet-lake"
-              (import ./common/gpu/intel/comet-lake);
+          common-gpu-intel-comet-lake = import ./common/gpu/intel/comet-lake;
           common-cpu-intel-cpu-only = import ./common/cpu/intel/cpu-only.nix;
-          common-gpu-intel-kaby-lake =
-            deprecated "992" "common-gpu-intel-kaby-lake"
-              (import ./common/gpu/intel/kaby-lake);
-          common-gpu-intel-sandy-bridge =
-            deprecated "992" "common-gpu-intel-sandy-bridge"
-              (import ./common/gpu/intel/sandy-bridge);
+          common-gpu-intel-kaby-lake = import ./common/gpu/intel/kaby-lake;
+          common-gpu-intel-sandy-bridge = import ./common/gpu/intel/sandy-bridge;
           common-gpu-amd = import ./common/gpu/amd;
           common-gpu-amd-sea-islands = import ./common/gpu/amd/sea-islands;
           common-gpu-amd-southern-islands = import ./common/gpu/amd/southern-islands;


### PR DESCRIPTION
###### Description of changes

Removes profile deprecations from flake. As discussed in #992 they shouldn't be deprecated until there's a suitable alternative.