### PR TITLE
added hardware config for galaxybook 2 pro

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -351,6 +351,7 @@
           rock-pi-e = import ./radxa/rock-pi-e;
           kobol-helios4 = import ./kobol/helios4;
           samsung-np900x3c = import ./samsung/np900x3c;
+          samsung-galaxybook-2-pro= import ./samsung/galaxybook-2-pro;
           slimbook-hero-rpl-rtx = import ./slimbook/hero/rpl-rtx;
           starfive-visionfive-v1 = import ./starfive/visionfive/v1;
           starfive-visionfive-2 = import ./starfive/visionfive/v2;

--- a/samsung/galaxybook-2-pro/default.nix
+++ b/samsung/galaxybook-2-pro/default.nix
@@ -1,0 +1,48 @@
+###
+# Kernel module by Joshua Grisham, added features in readme
+# https://github.com/joshuagrisham/samsung-galaxybook-extras
+# only use it for kernel versions <6.14 default is disabled but you can deactivate with:
+# hardware.samsung-galaxybook.enableKmod =  false;
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  kernel_version_compatible = lib.versionOlder config.boot.kernelPackages.kernel.version "6.14";
+in {
+  imports = [
+    ../../common/cpu/intel/alder-lake
+    ../../common/gpu/intel/alder-lake
+    ../../common/pc/ssd
+    ../../common/pc/laptop
+  ];
+
+  options.hardware.samsung-galaxybook.enableKmod =
+    (
+      lib.mkEnableOption
+      "Enable the community created Samsung Galaxy Book kernel module that allows for additional features and functionality"
+    )
+    // {
+      default = kernel_version_compatible;
+      defaultText = "enabled by default on kernel < 6.14";
+    };
+
+  config = lib.mkMerge [
+    (
+      lib.mkIf config.hardware.samsung-galaxybook.enableKmod {
+        boot.extraModulePackages = [
+          (pkgs.callPackage ./kernel-module.nix {
+            kernel = config.boot.kernelPackages.kernel;
+          })
+        ];
+      }
+    )
+    {
+      boot.kernelModules = ["kvm-intel"];
+      boot.kernelParams = ["i915.enable_dpcd_backlight=3"];
+      boot.initrd.availableKernelModules = ["xhci_pci" "thunderbolt" "nvme" "usb_storage" "sd_mod"];
+      services.fprintd.enable = lib.mkDefault true;
+    }
+  ];
+}

--- a/samsung/galaxybook-2-pro/kernel-module.nix
+++ b/samsung/galaxybook-2-pro/kernel-module.nix
@@ -1,0 +1,39 @@
+{ stdenv, kernel, fetchFromGitHub, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "samsung-galaxybook-module";
+  version = "unstable-2025-01-29";
+
+  src = fetchFromGitHub {
+    owner = "joshuagrisham";
+    repo = "samsung-galaxybook-extras";
+    rev = "pre-6.14"; # or specific commit hash
+    hash = "sha256-srCGcmUI5ZKjndIWhSptG3hVkAo0dvDjJ4NoUkutaIA=";
+  };
+
+  nativeBuildInputs = [ kernel.dev ];
+  buildInputs = [ kernel ];
+
+  KERNEL_VERSION = kernel.modDirVersion;
+  KERNEL_SRC = "${kernel.dev}/lib/modules/${KERNEL_VERSION}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  buildPhase = ''
+    runHook preBuild
+    make -C $KERNEL_SRC M=$PWD modules
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    make -C $KERNEL_SRC M=$PWD modules_install
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Kernel module for Samsung Galaxybook devices";
+    homepage = "https://github.com/joshuagrisham/samsung-galaxybook-extras";
+    platforms = platforms.linux;
+    broken = lib.versionAtLeast kernel.version "6.14";
+  };
+}


### PR DESCRIPTION
###### Description of changes
added config for samsung galaxybook pro 2. The kernel module is unnessesary for kernels <6.14 so it is available but is off by default on newer kernels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

