### PR TITLE
lenovo/t14-intel-gen1(-nvidia): init

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,9 @@ See code for all available configurations.
 | [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         | `lenovo-thinkpad-t14-amd-gen4`    |
 | [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         | `lenovo-thinkpad-t14-amd-gen5`    |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                                        | `<nixos-hardware/lenovo/thinkpad/t14>`                  | `lenovo-thinkpad-t14`              |
-| [Lenovo ThinkPad T14 Intel Gen 6](lenovo/thinkpad/t14/intel/gen6)                | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen6>`       | `lenovo-thinkpad-t14-intel-gen6`   |
+| [Lenovo ThinkPad T14 Intel Gen 1](lenovo/thinkpad/t14/intel/gen1)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1>`       | `lenovo-thinkpad-t14-intel-gen1`              |
+| [Lenovo ThinkPad T14 Intel Gen 1 (Nvidia)](lenovo/thinkpad/t14/intel/gen1/nvidia) | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1/nvidia>`| `lenovo-thinkpad-t14-intel-gen1-nvidia` |
+| [Lenovo ThinkPad T14 Intel Gen 6](lenovo/thinkpad/t14/intel/gen6)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen6>`       | `lenovo-thinkpad-t14-intel-gen6`   |
 | [Lenovo ThinkPad T14s AMD Gen 1](lenovo/thinkpad/t14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen1>`        | `lenovo-thinkpad-t14s-amd-gen1`    |
 | [Lenovo ThinkPad T14s AMD Gen 4](lenovo/thinkpad/t14s/amd/gen4)                   | `<nixos-hardware/lenovo/thinkpad/t14s/amd/gen4>`        | `lenovo-thinkpad-t14s-amd-gen4`    |
 | [Lenovo ThinkPad T14s](lenovo/thinkpad/t14s)                                      | `<nixos-hardware/lenovo/thinkpad/t14s>`                 | `lenovo-thinkpad-t14s`             |

--- a/flake.nix
+++ b/flake.nix
@@ -234,6 +234,8 @@
           lenovo-thinkpad-t14-amd-gen3 = import ./lenovo/thinkpad/t14/amd/gen3;
           lenovo-thinkpad-t14-amd-gen4 = import ./lenovo/thinkpad/t14/amd/gen4;
           lenovo-thinkpad-t14-amd-gen5 = import ./lenovo/thinkpad/t14/amd/gen5;
+          lenovo-thinkpad-t14-intel-gen1 = import ./lenovo/thinkpad/t14/intel/gen1;
+          lenovo-thinkpad-t14-intel-gen1-nvidia = import ./lenovo/thinkpad/t14/intel/gen1/nvidia;
           lenovo-thinkpad-t14-intel-gen6 = import ./lenovo/thinkpad/t14/intel/gen6;
           lenovo-thinkpad-t14s = import ./lenovo/thinkpad/t14s;
           lenovo-thinkpad-t14s-amd-gen1 = import ./lenovo/thinkpad/t14s/amd/gen1;

--- a/lenovo/thinkpad/t14/intel/gen1/default.nix
+++ b/lenovo/thinkpad/t14/intel/gen1/default.nix
@@ -1,0 +1,8 @@
+{ lib, config, ... }:
+{
+  imports = [
+    ../../../../../common/cpu/intel/comet-lake
+
+    ../.
+  ];
+}

--- a/lenovo/thinkpad/t14/intel/gen1/nvidia/default.nix
+++ b/lenovo/thinkpad/t14/intel/gen1/nvidia/default.nix
@@ -1,0 +1,28 @@
+{ lib, config, ... }:
+{
+  imports = [
+    ../../../../../../common/gpu/nvidia/pascal
+    ../../../../../../common/gpu/nvidia/prime-sync.nix
+
+    ../.
+  ];
+  hardware = {
+    graphics = {
+      enable = lib.mkDefault true;
+      enable32Bit = lib.mkDefault true;
+    };
+    nvidia = {
+      powerManagement.enable = lib.mkDefault true;
+      modesetting.enable = lib.mkDefault true;
+
+      dynamicBoost.enable = lib.mkForce false; # Dynamic boost is not supported on Pascal architeture
+      prime = {
+        # 00:02.0 VGA compatible controller: Intel Corporation CometLake-U GT2 [UHD Graphics] (rev 02)
+        intelBusId = lib.mkDefault "PCI:0:2:0";
+        # 2d:00.0 3D controller: NVIDIA Corporation GP108M [GeForce MX330] (rev a1)
+        nvidiaBusId = lib.mkDefault "PCI:45:0:0";
+      };
+    };
+  };
+  services.thermald.enable = lib.mkDefault true;
+}


### PR DESCRIPTION

###### Description of changes
init configuration for t14 intel gen1 with and without nvidia dedicated graphics card

ref: https://thinkwiki.de/T14_Gen_1_(Intel)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

