### PR TITLE
msi/b550-tomahawk: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ See code for all available configurations.
 | [LENOVO Yoga 7 Slim Gen8](lenovo/yoga/7/slim/gen8)                                | `<nixos-hardware/lenovo/yoga/7/slim/gen8>`              | `lenovo-yoga-7-slim-gen8`         |
 | [MSI B550-A PRO](msi/b550-a-pro)                                                  | `<nixos-hardware/msi/b550-a-pro>`                       | `msi-b550-a-pro`                  |
 | [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                            | `<nixos-hardware/msi/b350-tomahawk>`                    | `msi-b350-tomahawk`               |
+| [MSI B550 TOMAHAWK](msi/b550-tomahawk)                                            | `<nixos-hardware/msi/b550-tomahawk>`                    | `msi-b550-tomahawk`               |
 | [MSI GS60 2QE](msi/gs60)                                                          | `<nixos-hardware/msi/gs60>`                             | `msi-gs60`                        |
 | [MSI GL62/CX62](msi/gl62)                                                         | `<nixos-hardware/msi/gl62>`                             | `msi-gl62`                        |
 | [MSI GL65 10SDR-492](msi/gl65/10SDR-492)                                          | `<nixos-hardware/msi/gl65/10SDR-492>`                   | `msi-gl65-10SDR-492`              |

--- a/flake.nix
+++ b/flake.nix
@@ -315,6 +315,7 @@
           morefine-m600 = import ./morefine/m600;
           msi-b350-tomahawk = import ./msi/b350-tomahawk;
           msi-b550-a-pro = import ./msi/b550-a-pro;
+          msi-b550-tomahawk = import ./msi/b550-tomahawk;
           msi-gs60 = import ./msi/gs60;
           msi-gl62 = import ./msi/gl62;
           msi-gl65-10SDR-492 = import ./msi/gl65/10SDR-492;

--- a/msi/b550-tomahawk/default.nix
+++ b/msi/b550-tomahawk/default.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+{
+  imports = [
+    ../../common/cpu/amd
+    ../../common/pc/ssd
+    ../../common/pc
+  ];
+
+  boot.extraModulePackages = with config.boot.kernelPackages; [
+    nct6687d
+  ];
+
+  boot.kernelModules = [ "nct6687d" ];
+}


### PR DESCRIPTION
###### Description of changes
Very similar to other msi motherboards but it uses semi-supported esio chip nuvoton nct6687d.
Refer to https://github.com/Fred78290/nct6687d. As you can see it exists in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

