### PR TITLE
acer/aspire/one/756: init

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
+acer/aspire/one/756 @trueNAHO
 beagleboard/pocketbeagle @yegortimoshenko
 dell/xps/13-9370 @moredread
 dell/xps/13-9380 @kalbasit

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See code for all available configurations.
 | Model                                                                             | Path                                                    | Flake Module                           |
 | --------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------- |
 | [Acer Aspire 4810T](acer/aspire/4810t)                                            | `<nixos-hardware/acer/aspire/4810t>`                    | `acer-aspire-4810t`                    |
+| [Acer Aspire One 756](acer/aspire/one/756)                                        | `<nixos-hardware/acer/aspire/one/756>`                  | `acer-aspire-one-756`                  |
 | [Airis N990](airis/n990)                                                          | `<nixos-hardware/airis/n990>`                           | `airis-n990`                           |
 | [Apple iMac 14.2](apple/imac/14-2)                                                | `<nixos-hardware/apple/imac/14-2>`                      | `apple-imac-14-2`                      |
 | [Apple iMac 18.2](apple/imac/18-2)                                                | `<nixos-hardware/apple/imac/18-2>`                      | `apple-imac-18-2`                      |

--- a/acer/aspire/one/756/README.md
+++ b/acer/aspire/one/756/README.md
@@ -1,0 +1,6 @@
+# Acer Aspire One 756
+
+## About
+
+[NixOS hardware configuration](https://github.com/NixOS/nixos-hardware) for
+[Acer Aspire One 756](https://www.acer.com/us-en/support/product-support/AO756).

--- a/acer/aspire/one/756/default.nix
+++ b/acer/aspire/one/756/default.nix
@@ -1,0 +1,8 @@
+{
+  imports = [
+    ../../../../common/cpu/intel/sandy-bridge
+    ../../../../common/gpu/intel/sandy-bridge
+    ../../../../common/pc
+    ../../../../common/pc/laptop
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
         in
         {
           acer-aspire-4810t = import ./acer/aspire/4810t;
+          acer-aspire-one-756 = import ./acer/aspire/one/756;
           airis-n990 = import ./airis/n990;
           aoostar-r1-n100 = import ./aoostar/r1/n100;
           apple-imac-14-2 = import ./apple/imac/14-2;


### PR DESCRIPTION
###### Description of changes

Add NixOS hardware configuration for [Acer Aspire One 756](https://www.acer.com/us-en/support/product-support/AO756).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input