### PR TITLE
CODEOWNERS: remove trueNAHO from tuxedo-pulse-14-gen3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@ purism/librem/13v3 @yegortimoshenko
 system76/darp6 @khumba
 framework @emiller88
 tuxedo/pulse/15/gen2 @trueNAHO
-tuxedo/pulse/14/gen3 @gabyx @britter @trueNAHO
+tuxedo/pulse/14/gen3 @gabyx @britter


### PR DESCRIPTION
###### Description of changes

```
Remove trueNAHO from tuxedo-pulse-14-gen3 because I never owned this
hardware.

Fixes: caabc425565b ("feat: Update CODEOWNERS for Tuxedo Pulse Laptops")
```

CC: @gabyx

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

