### PR TITLE
laptop: check for tuned service before enabling tlp

### DIFF
--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 {
   imports = [ ../. ];
@@ -7,7 +12,7 @@
   # However, these 2 services clash when enabled simultaneously.
   # https://github.com/NixOS/nixos-hardware/issues/260
   services.tlp.enable = lib.mkDefault (
-    (lib.versionOlder (lib.versions.majorMinor lib.version) "21.05")
-    || !config.services.power-profiles-daemon.enable
+    !(options.services ? power-profiles-daemon && config.services.power-profiles-daemon.enable)
+    && !(options.services ? tuned && config.services.tuned.enable)
   );
 }

--- a/gpd/win-2/default.nix
+++ b/gpd/win-2/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 {
   imports = [
     ../../common/cpu/intel
@@ -11,8 +16,8 @@
   ];
 
   services.tlp.enable = lib.mkDefault (
-    (lib.versionOlder (lib.versions.majorMinor lib.version) "21.05")
-    || !config.services.power-profiles-daemon.enable
+    !(options.services ? power-profiles-daemon && config.services.power-profiles-daemon.enable)
+    && !(options.services ? tuned && config.services.tuned.enable)
   );
 
   # Required for grub to properly display the boot menu.


### PR DESCRIPTION
###### Description of changes

This PR adds an extra check to the logic that conditionally enabled `tlp` on laptops by default. Before, it was enabled if `power-profiles-daemon`.

With this change, we also check for `services.tuned.enable`, which also conflicts with `tlp`. Enabling `tuned` and loading the default laptop module resulted in an evaluation error of the config.

I have a couple of questions regarding the changes:

- Looking at [the NixOS tuneD module](https://github.com/NixOS/nixpkgs/blob/d42ef9dc9820cd568ab9278b37ff121e9ae9a05d/nixos/modules/services/hardware/tuned.nix), `auto-cpufreq` also conflicts with the service. Should we add a check for it as well?
- The original logic used a `lib.version` check before accessing the `power-profiles-daemon` to avoid evaluation error in older NixOS releases (#270). I replaced that with an existence check for both options for consistency, but I can revert that part (`tuned` was released in 25.05 I believe).

In the end, this PR is superseded by #1474, but it is a nice QOL improvement while it doesn't land.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

