### PR TITLE
raspberry-pi/3: load usbhid and usb_storage

### DIFF
--- a/raspberry-pi/3/default.nix
+++ b/raspberry-pi/3/default.nix
@@ -5,7 +5,13 @@
 }:
 
 {
-  boot.kernelPackages = lib.mkDefault pkgs.linuxKernel.packages.linux_rpi3;
+  boot = {
+    kernelPackages = lib.mkDefault pkgs.linuxKernel.packages.linux_rpi3;
+    initrd.availableKernelModules = [
+      "usbhid"
+      "usb_storage"
+    ];
+  };
 
   # fix the following error :
   # modprobe: FATAL: Module ahci not found in directory


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

