### PR TITLE
asus/battery: fix battery threshold not being set after hibernation

### DIFF
--- a/asus/battery.nix
+++ b/asus/battery.nix
@@ -31,10 +31,14 @@ in
       wantedBy = [
         "local-fs.target"
         "suspend.target"
+        "suspend-then-hibernate.target"
+        "hibernate.target"
       ];
       after = [
         "local-fs.target"
         "suspend.target"
+        "suspend-then-hibernate.target"
+        "hibernate.target"
       ];
       description = "Set the battery charge threshold to ${toString cfg.chargeUpto}%";
       startLimitBurst = 5;


### PR DESCRIPTION
###### Description of changes

Adds `suspend-then-hibernate` and `hibernate` targets to the `battery-charge-threshold` service, so the threshold gets correctly set after hibernation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
