### PR TITLE
common/gpu/intel/default: install setcap wrapper for intel gpu tools

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -91,6 +91,8 @@
         lib.optionals useIntelVaapiDriver [ intel-vaapi-driver-32 ]
         ++ lib.optionals useIntelMediaDriver [ intel-media-driver-32 ];
 
+      hardware.intel-gpu-tools.enable = true;
+
       assertions = [
         {
           assertion = (


### PR DESCRIPTION
###### Description of changes

If I am not mistaken, this adds support for reading GPU stats as non-root, which makes sense more often that not

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

