### PR TITLE
add lenovo loq 15ahp10 configuration

### DIFF
--- a/common/gpu/nvidia/blackwell/default.nix
+++ b/common/gpu/nvidia/blackwell/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  nvidiaPackage = config.hardware.nvidia.package;
+in
+{
+  imports = [ ../. ];
+
+  # enable the open source drivers if the package supports it
+  hardware.nvidia.open = lib.mkOverride 990 (nvidiaPackage ? open && nvidiaPackage ? firmware);
+}

--- a/lenovo/loq/15ahp10/README.md
+++ b/lenovo/loq/15ahp10/README.md
@@ -1,0 +1,19 @@
+# system information
+
+```
+$ nix-info -m
+ - system: `"x86_64-linux"`
+ - host os: `Linux 6.12.49, NixOS, 25.11 (Xantusia), 25.11.20250928.e9f00bd`
+ - multi-user?: `yes`
+ - sandbox: `yes`
+ - version: `nix-env (Nix) 2.28.5`
+```
+
+# lspci output
+```
+$ lspci
+
+01:00.0 VGA compatible controller: NVIDIA Corporation GB206M [GeForce RTX 5060 Max-Q / Mobile] (rev a1)
+
+06:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] HawkPoint1 (rev b5)
+```

--- a/lenovo/loq/15ahp10/hybrid/default.nix
+++ b/lenovo/loq/15ahp10/hybrid/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ../../../../common/cpu/amd
+    ../../../../common/gpu/amd
+    ../../../../common/gpu/nvidia
+    ../../../../common/gpu/nvidia/blackwell
+    ../../../../common/gpu/nvidia/prime.nix
+    ../../../../common/pc/laptop
+    ../../../../common/pc/ssd
+  ];
+
+  hardware.nvidia = {
+    modesetting.enable = lib.mkDefault true;
+    open = lib.mkDefault true;
+    powerManagement = {
+      enable = lib.mkDefault true;
+      finegrained = lib.mkDefault true;
+    };
+    prime = {
+      amdgpuBusId = "PCI:6:0:0"; # 06:00.0 in hexadecimal -> 6:0:0 in decimal
+      nvidiaBusId = "PCI:1:0:0"; # 01:00.0 in hexadecimal -> 1:0:0 in decimal
+    };
+  };
+
+  # AMD has better battery life with PPD over TLP:
+  # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13
+  services.power-profiles-daemon.enable = lib.mkDefault true;
+}


### PR DESCRIPTION
###### Description of changes

Added nixos system configuration for lenovo loq 15ahp10 laptop.

###### Things done

Added a generic nix module for nvidia blackwell architecture gpu support.

Added a nix module for hybrid(igpu+dgpu) gpu mode support.

Added a minimal `README.md` file for system information at the time of testing. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

