### PR TITLE
fix: enableRedistributableFirmware on Framework 13 Intel Core Ultra Series1

### DIFF
--- a/framework/13-inch/intel-core-ultra-series1/default.nix
+++ b/framework/13-inch/intel-core-ultra-series1/default.nix
@@ -20,6 +20,9 @@
     lib.mkDefault pkgs.linuxPackages_latest
   );
 
+  # NPU, GPU
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
   # Intel NPU Driver
   # https://discourse.nixos.org/t/new-installation-on-asus-zenbook-ux5406-intel-vpu-firmware-error-2/58732/2
   hardware.firmware = lib.optionals (config.hardware.enableRedistributableFirmware) [
@@ -38,10 +41,6 @@
         cp '${firmware}' "$out/lib/firmware/intel/vpu/vpu_${model}_v${version}.bin"
       ''
     )
-  ];
-
-  warnings = lib.mkIf (!config.hardware.enableRedistributableFirmware) [
-    ''For Intel NPU support, set the option: hardware.enableRedistributableFirmware = true;''
   ];
 
   hardware.framework.laptop13.audioEnhancement.rawDeviceName =


### PR DESCRIPTION
###### Description of changes

Setting up a Framework 13 `intel-core-ultra-series1` using `nixos-hardware` I had to additionally `hardware.enableRedistributableFirmware = true;` in order to get the GPU working. I think this should be the default. This PR fixes this.

Let me know what you think.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

