### PR TITLE
framework/kmod: remove compatibility with Linux version < 6.10

### DIFF
--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -1,56 +1,35 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
-let
-  kernel_version_compatible = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.10";
-in
 {
   options.hardware.framework.enableKmod =
-    (lib.mkEnableOption "Enable the community created Framework kernel module that allows interacting with the embedded controller from sysfs.")
+    (lib.mkEnableOption "the community-created Framework kernel module that allows interacting with the embedded controller from sysfs.")
     // {
       # enable by default on NixOS >= 24.05 and kernel >= 6.10
-      default = lib.and (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05") kernel_version_compatible;
-      defaultText = "enabled by default on NixOS >= 24.05 and kernel >= 6.10";
+      default = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.10";
+      defaultText = "enabled by default if kernel >= 6.10";
     };
 
-  config.boot = lib.mkIf config.hardware.framework.enableKmod {
-    extraModulePackages = with config.boot.kernelPackages; [
-      framework-laptop-kmod
-    ];
-
-    # https://github.com/DHowett/framework-laptop-kmod?tab=readme-ov-file#usage
-    kernelModules = [
-      "cros_ec"
-      "cros_ec_lpcs"
-    ];
-
-    # add required patch if enabled on kernel <6.10
-    kernelPatches = lib.mkIf (!kernel_version_compatible) [
-      rec {
-        name = "platform/chrome: cros_ec_lpc: add support for AMD Framework Laptops";
-        msgid = "20240403004713.130365-1-dustin@howett.net";
-        version = "3";
-        hash = "sha256-aQSyys8CMzlj9EdNhg8vtp76fg1qEwUVeJL0E+8w5HU=";
-        patch =
-          pkgs.runCommandLocal "patch-${msgid}"
-            {
-              nativeBuildInputs = with pkgs; [
-                b4
-                git
-                cacert
-              ];
-              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-
-              outputHash = hash;
-            }
-            ''
-              export HOME="$TMP"
-              PYTHONHASHSEED=0 ${pkgs.b4}/bin/b4 -n am -C -T -v ${version} -o- "${msgid}" > "$out"
-            '';
+  config = lib.mkIf config.hardware.framework.enableKmod {
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.10";
+        message = "The framework laptop kernel module requires Linux 6.10 or above";
       }
     ];
+
+    boot = {
+      extraModulePackages = with config.boot.kernelPackages; [
+        framework-laptop-kmod
+      ];
+
+      # https://github.com/DHowett/framework-laptop-kmod?tab=readme-ov-file#usage
+      kernelModules = [
+        "cros_ec"
+        "cros_ec_lpcs"
+      ];
+    };
   };
 }


### PR DESCRIPTION
###### Description of changes

Upstream changes broke the checks that we had in https://github.com/NixOS/nixpkgs/commit/845e340ed98ef6d8a5c5d7069663f2cd034e508a.

By now we have 6.12 as the LTS, and 24.05 went out of support, so I think we don't need to support this anymore.
Anyone still on such old kernel versions, can apply the patch manually if needed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
