### PR TITLE
'runCommandNoCC' has been renamed to/replaced by 'runCommand'

### DIFF
--- a/lenovo/legion/16ach6h/edid/default.nix
+++ b/lenovo/legion/16ach6h/edid/default.nix
@@ -7,7 +7,7 @@
 
 let
   # This file was obtained from the display while "DDG" mode was enabled.
-  chip_edid = pkgs.runCommandNoCC "chip_edid" { } ''
+  chip_edid = pkgs.runCommand "chip_edid" { } ''
     mkdir -p $out/lib/firmware/edid
     cp ${./16ach6h.bin} $out/lib/firmware/edid/16ach6h.bin
   '';


### PR DESCRIPTION
###### Description of changes
runCommandNoCC dont work anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

