### PR TITLE
raspberry-pi/4: add only wireless firmwares

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -55,6 +55,5 @@
     }
   ];
 
-  # Required for the Wireless firmware
-  hardware.enableRedistributableFirmware = true;
+  hardware.firmware = [ pkgs.raspberrypiWirelessFirmware ];
 }


### PR DESCRIPTION
###### Description of changes

Instead of pulling all redistributable firmwares, we should only depend on Raspberry Pi's firmwares.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

