### PR TITLE
imx8-evk: fix cross-compiled builds

### DIFF
--- a/nxp/common/bsp/imx-mkimage.nix
+++ b/nxp/common/bsp/imx-mkimage.nix
@@ -16,12 +16,12 @@ pkgs.stdenv.mkDerivation rec {
         --replace 'CC = gcc' 'CC = clang'
   '';
 
-  nativeBuildInputs = [
-    clang
-    git
+  depsBuildBuild = [
+    pkgs.buildPackages.stdenv.cc
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
+    clang
     git
     glibc.static
   ];

--- a/nxp/common/bsp/imx-optee-builder.nix
+++ b/nxp/common/bsp/imx-optee-builder.nix
@@ -15,7 +15,7 @@ let
   inherit (pkgs.buildPackages) python3;
   toolchain = pkgs.stdenv.cc;
   binutils = pkgs.stdenv.cc.bintools.bintools_bin;
-  cpp = pkgs.stdenv.gcc;
+  cpp = pkgs.stdenv.cc;
 
   # Determine PLATFORM and PLATFORM_FLAVOR from platformFlavor
   # Format can be either "imx-mx93evk" (full platform string) or "mx8mpevk" (just flavor, platform is "imx")
@@ -58,7 +58,7 @@ pkgs.stdenv.mkDerivation {
     substituteInPlace mk/gcc.mk \
       --replace-fail "\$(CROSS_COMPILE_\$(sm))ar" ${binutils}/bin/${toolchain.targetPrefix}ar
     substituteInPlace mk/gcc.mk \
-      --replace-fail "\$(CROSS_COMPILE_\$(sm))cpp"${cpp}/bin/${toolchain.targetPrefix}cpp
+      --replace-fail "\$(CROSS_COMPILE_\$(sm))cpp" ${cpp}/bin/${toolchain.targetPrefix}cpp
   '';
 
   makeFlags = [

--- a/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-boot.nix
@@ -2,7 +2,6 @@
   pkgs,
   enable-tee ? true,
 }:
-with pkgs;
 let
   fw-ver = "202006";
   cp-tee = if enable-tee then "install -m 0644 ${imx8mp-optee-os}/tee.bin ./iMX8M/tee.bin" else "";
@@ -22,7 +21,7 @@ let
   shortRev = builtins.substring 0 8 src.rev;
 in
 {
-  imx8m-boot = pkgs.stdenv.mkDerivation rec {
+  imx8m-boot = pkgs.buildPackages.stdenv.mkDerivation {
     inherit src;
     name = "imx8mp-mkimage";
     version = "lf-6.1.55-2.2.0";
@@ -30,22 +29,16 @@ in
     postPatch = ''
       substituteInPlace Makefile \
           --replace 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
-      substituteInPlace Makefile \
-          --replace 'CC = gcc' 'CC = clang'
       patchShebangs scripts
     '';
 
     nativeBuildInputs = [
-      clang
-      git
-      dtc
-    ];
-
-    buildInputs = [
-      git
-      glibc.static
-      zlib
-      zlib.static
+      pkgs.buildPackages.stdenv.cc
+      pkgs.buildPackages.git
+      pkgs.buildPackages.dtc
+      pkgs.buildPackages.glibc.static
+      pkgs.buildPackages.zlib
+      pkgs.buildPackages.zlib.static
     ];
 
     buildPhase = ''
@@ -54,7 +47,7 @@ in
       make bin
       make SOC=iMX8MP mkimage_imx8
 
-      cp -v ${pkgs.ubootTools}/bin/mkimage ./iMX8M/mkimage_uboot
+      cp -v ${pkgs.buildPackages.ubootTools}/bin/mkimage ./iMX8M/mkimage_uboot
 
       install -m 0644 ${imx8mp-uboot}/u-boot-spl.bin ./iMX8M/u-boot-spl.bin
       install -m 0644 ${imx8mp-uboot}/u-boot-nodtb.bin ./iMX8M/u-boot-nodtb.bin

--- a/nxp/imx8mp-evk/bsp/imx8mp-firmware.nix
+++ b/nxp/imx8mp-evk/bsp/imx8mp-firmware.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   installPhase = ''
-    ${pkgs.bash}/bin/bash $src --auto-accept --force
+    ${pkgs.buildPackages.bash}/bin/bash $src --auto-accept --force
     mv firmware-imx-${version} $out
   '';
 }


### PR DESCRIPTION
update just to fix the cross compilation.

###### Description of changes

fixing some issues that have recently become apparent. Tested against the Ghaf target. `.#nxp-imx8mp-evk-debug-from-x86_64`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

