### PR TITLE
raspberry-pi/4: add genet module to initrd if netboot

### DIFF
--- a/raspberry-pi/4/default.nix
+++ b/raspberry-pi/4/default.nix
@@ -35,7 +35,8 @@
       "vc4"
       "pcie_brcmstb" # required for the pcie bus to work
       "reset-raspberrypi" # required for vl805 firmware to load
-    ];
+    ]
+    ++ lib.optional config.boot.initrd.network.enable "genet";
 
     # Allow building kernel
     initrd.systemd.tpm2.enable = false;


### PR DESCRIPTION
This module is required to have Ethernet in initial RAM disk.

It solves the issue encountered in this thread:
https://discourse.nixos.org/t/netboot-into-nfs-root-instead-of-the-fat-netboot-ramdisk/8556/2

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

