### PR TITLE
lenovo/thinkpad/t480: replaced cpu/intel with cpu/intel/kaby-lake

### DIFF
--- a/lenovo/thinkpad/t480/default.nix
+++ b/lenovo/thinkpad/t480/default.nix
@@ -2,7 +2,7 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
+    ../../../common/cpu/intel/kaby-lake
     ../../../common/pc/ssd
     ../.
   ];


### PR DESCRIPTION
###### Description of changes

Replaced the common Intel CPU import with the Kaby Lake profile for Lenovo ThinkPad T480. 
This prevents installation of the unused "intel-vaapi-driver" and also enables Kaby Lake-specific optimizations 
(i915 boot parameters) and fixes, including the legacy OpenCL runtime (computeRuntime="legacy").

This import is already used by other platforms, such as ThinkPad X1 Carbon 6th and Surface Go.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

