### PR TITLE
broadcom-wl: enable WiFi/Bluetooth driver as discussed in PR #1580

### DIFF
--- a/apple/imac/14-2/README.md
+++ b/apple/imac/14-2/README.md
@@ -20,6 +20,12 @@
 
 ## Wifi
 - [x] ok
+> **Note:** Enabling WiFi and Bluetooth functionality on this hardware requires the proprietary Broadcom driver. Due to outstanding security issues, you need to explicitly opt-in by setting:
+>
+> ```nix
+> hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+> ```
+
 
 ## Graphics
 - [x] Latest unsupported Nvidia drivers available are 390.157, working with Kernel 6.10.6.

--- a/apple/imac/14-2/default.nix
+++ b/apple/imac/14-2/default.nix
@@ -13,25 +13,55 @@
     ../../../common/hidpi.nix
   ];
 
-  boot = {
-    initrd.kernelModules = [
-      "applesmc"
-      "applespi"
-      "intel_lpss_pci"
-      "spi_pxa2xx_platform"
-      "kvm-intel"
-    ];
-    blacklistedKernelModules = [
-      "b43"
-      "ssb"
-      "brcmfmac"
-      "brcmsmac"
-      "bcma"
-    ];
-    kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.0") pkgs.linuxPackages_latest;
+  options = {
+    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
+
+        This driver is vulnerable to heap buffer overflows:
+        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
+        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
+
+        Attackers within WiFi range can exploit this vulnerability by sending crafted
+        WiFi packets, even without being connected to the same network. Simply having
+        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
+        Only enable if no alternative WiFi solution is available.
+      '';
+    };
   };
 
-  hardware = {
-    bluetooth.enable = lib.mkDefault true;
+  config = {
+    boot = {
+      initrd.kernelModules = [
+        "applesmc"
+        "applespi"
+        "intel_lpss_pci"
+        "spi_pxa2xx_platform"
+        "kvm-intel"
+      ];
+      blacklistedKernelModules = [
+        "b43"
+        "ssb"
+        "brcmfmac"
+        "brcmsmac"
+        "bcma"
+      ];
+      kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.0") pkgs.linuxPackages_latest;
+      extraModulePackages =
+        lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+          [
+            (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
+              meta = oldAttrs.meta // {
+                knownVulnerabilities = [ ];
+              };
+            }))
+          ];
+    };
+
+    hardware = {
+      bluetooth.enable = lib.mkDefault true;
+    };
   };
 }

--- a/apple/imac/14-2/default.nix
+++ b/apple/imac/14-2/default.nix
@@ -13,7 +13,15 @@
     ../../../common/hidpi.nix
     ../../../common/broadcom-wifi.nix
   ];
-
+  # ##############################################################################
+  # ATTENTION / IMPORTANT NOTE:
+  #
+  # Note: Enabling WiFi and Bluetooth functionality on this hardware requires
+  # the proprietary Broadcom driver. Due to outstanding security issues, you
+  # need to explicitly opt-in by setting:
+  #
+  # hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+  # ##############################################################################
   config = {
     boot = {
       initrd.kernelModules = [

--- a/apple/imac/14-2/default.nix
+++ b/apple/imac/14-2/default.nix
@@ -11,26 +11,8 @@
     ../../../common/gpu/nvidia
     ../../../common/gpu/nvidia/kepler
     ../../../common/hidpi.nix
+    ../../../common/broadcom-wifi.nix
   ];
-
-  options = {
-    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
-
-        This driver is vulnerable to heap buffer overflows:
-        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
-        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
-
-        Attackers within WiFi range can exploit this vulnerability by sending crafted
-        WiFi packets, even without being connected to the same network. Simply having
-        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
-        Only enable if no alternative WiFi solution is available.
-      '';
-    };
-  };
 
   config = {
     boot = {
@@ -49,15 +31,6 @@
         "bcma"
       ];
       kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.0") pkgs.linuxPackages_latest;
-      extraModulePackages =
-        lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-          [
-            (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
-              meta = oldAttrs.meta // {
-                knownVulnerabilities = [ ];
-              };
-            }))
-          ];
     };
 
     hardware = {

--- a/apple/macbook-air/6/README.md
+++ b/apple/macbook-air/6/README.md
@@ -1,0 +1,9 @@
+# Apple MacBook Air 6,x
+
+## Wireless / Bluetooth
+
+> **Note:** Enabling WiFi and Bluetooth functionality on this hardware requires the proprietary Broadcom driver. Due to outstanding security issues, you need to explicitly opt-in by setting:
+>
+> ```nix
+> hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+> ```

--- a/apple/macbook-air/6/default.nix
+++ b/apple/macbook-air/6/default.nix
@@ -5,7 +5,15 @@
     ../.
     ../../../common/broadcom-wifi.nix
   ];
-
+  # ##############################################################################
+  # ATTENTION / IMPORTANT NOTE:
+  #
+  # Note: Enabling WiFi and Bluetooth functionality on this hardware requires
+  # the proprietary Broadcom driver. Due to outstanding security issues, you
+  # need to explicitly opt-in by setting:
+  #
+  # hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+  # ##############################################################################
   config = {
     boot = {
       # Divides power consumption by two.

--- a/apple/macbook-air/6/default.nix
+++ b/apple/macbook-air/6/default.nix
@@ -1,26 +1,10 @@
 { config, lib, ... }:
 
 {
-  imports = [ ../. ];
-
-  options = {
-    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
-
-        This driver is vulnerable to heap buffer overflows:
-        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
-        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
-
-        Attackers within WiFi range can exploit this vulnerability by sending crafted
-        WiFi packets, even without being connected to the same network. Simply having
-        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
-        Only enable if no alternative WiFi solution is available.
-      '';
-    };
-  };
+  imports = [
+    ../.
+    ../../../common/broadcom-wifi.nix
+  ];
 
   config = {
     boot = {
@@ -28,18 +12,6 @@
       kernelParams = [ "acpi_osi=" ];
 
       blacklistedKernelModules = [ "bcma" ];
-      kernelModules = lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities [
-        "wl"
-      ];
-      extraModulePackages =
-        lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-          [
-            (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
-              meta = oldAttrs.meta // {
-                knownVulnerabilities = [ ];
-              };
-            }))
-          ];
     };
 
     services.xserver.deviceSection = lib.mkDefault ''

--- a/apple/macbook-air/6/default.nix
+++ b/apple/macbook-air/6/default.nix
@@ -3,14 +3,47 @@
 {
   imports = [ ../. ];
 
-  boot.blacklistedKernelModules = [ "bcma" ];
+  options = {
+    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
 
-  boot = {
-    # Divides power consumption by two.
-    kernelParams = [ "acpi_osi=" ];
+        This driver is vulnerable to heap buffer overflows:
+        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
+        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
+
+        Attackers within WiFi range can exploit this vulnerability by sending crafted
+        WiFi packets, even without being connected to the same network. Simply having
+        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
+        Only enable if no alternative WiFi solution is available.
+      '';
+    };
   };
 
-  services.xserver.deviceSection = lib.mkDefault ''
-    Option "TearFree" "true"
-  '';
+  config = {
+    boot = {
+      # Divides power consumption by two.
+      kernelParams = [ "acpi_osi=" ];
+
+      blacklistedKernelModules = [ "bcma" ];
+      kernelModules = lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities [
+        "wl"
+      ];
+      extraModulePackages =
+        lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+          [
+            (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
+              meta = oldAttrs.meta // {
+                knownVulnerabilities = [ ];
+              };
+            }))
+          ];
+    };
+
+    services.xserver.deviceSection = lib.mkDefault ''
+      Option "TearFree" "true"
+    '';
+  };
 }

--- a/apple/macbook-pro/11-1/README.md
+++ b/apple/macbook-pro/11-1/README.md
@@ -4,6 +4,13 @@ This configuration is tested on my 13" *MacBook Pro (Retina, 13-inch, Late 2013)
 
 The 6.11.5 kernel appears to work well with only minor adjustments on this notebook. Note that my machine has a BCM4360 wireless card (PCI-ID `14e4:43a0`) which appears to only work with the nonfree `wl` driver.
 
+> **Note:** Enabling WiFi and Bluetooth functionality on this hardware requires the proprietary Broadcom driver. Due to outstanding security issues, you need to explicitly opt-in by setting:
+>
+> ```nix
+> hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+> ```
+
+
 ## Additional resources
 
 * Linux Wireless Documentation: [List of hardware](https://wireless.docs.kernel.org/en/latest/en/users/drivers/b43.html#list-of-hardware)

--- a/apple/macbook-pro/11-1/default.nix
+++ b/apple/macbook-pro/11-1/default.nix
@@ -6,5 +6,38 @@
     ../../../common/cpu/intel/haswell
   ];
 
-  hardware.enableRedistributableFirmware = lib.mkDefault true;
+  options = {
+    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
+
+        This driver is vulnerable to heap buffer overflows:
+        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
+        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
+
+        Attackers within WiFi range can exploit this vulnerability by sending crafted
+        WiFi packets, even without being connected to the same network. Simply having
+        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
+        Only enable if no alternative WiFi solution is available.
+      '';
+    };
+  };
+
+  config = {
+    hardware.enableRedistributableFirmware = lib.mkDefault true; # broadcom-wl
+    boot.kernelModules =
+      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+        [ "wl" ];
+    boot.extraModulePackages =
+      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+        [
+          (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
+            meta = oldAttrs.meta // {
+              knownVulnerabilities = [ ];
+            };
+          }))
+        ];
+  };
 }

--- a/apple/macbook-pro/11-1/default.nix
+++ b/apple/macbook-pro/11-1/default.nix
@@ -6,7 +6,15 @@
     ../../../common/cpu/intel/haswell
     ../../../common/broadcom-wifi.nix
   ];
-
+  # ##############################################################################
+  # ATTENTION / IMPORTANT NOTE:
+  #
+  # Note: Enabling WiFi and Bluetooth functionality on this hardware requires
+  # the proprietary Broadcom driver. Due to outstanding security issues, you
+  # need to explicitly opt-in by setting:
+  #
+  # hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+  # ##############################################################################
   config = {
     hardware.enableRedistributableFirmware = lib.mkDefault true; # broadcom-wl
   };

--- a/apple/macbook-pro/11-1/default.nix
+++ b/apple/macbook-pro/11-1/default.nix
@@ -4,40 +4,10 @@
     ../.
     ../../../common/pc/ssd
     ../../../common/cpu/intel/haswell
+    ../../../common/broadcom-wifi.nix
   ];
-
-  options = {
-    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
-
-        This driver is vulnerable to heap buffer overflows:
-        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
-        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
-
-        Attackers within WiFi range can exploit this vulnerability by sending crafted
-        WiFi packets, even without being connected to the same network. Simply having
-        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
-        Only enable if no alternative WiFi solution is available.
-      '';
-    };
-  };
 
   config = {
     hardware.enableRedistributableFirmware = lib.mkDefault true; # broadcom-wl
-    boot.kernelModules =
-      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-        [ "wl" ];
-    boot.extraModulePackages =
-      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-        [
-          (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
-            meta = oldAttrs.meta // {
-              knownVulnerabilities = [ ];
-            };
-          }))
-        ];
   };
 }

--- a/common/broadcom-wifi.nix
+++ b/common/broadcom-wifi.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options = {
+    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
+
+        This driver is vulnerable to heap buffer overflows:
+        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
+        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
+
+        Attackers within WiFi range can exploit this vulnerability by sending crafted
+        WiFi packets, even without being connected to the same network. Simply having
+        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
+        Only enable if no alternative WiFi solution is available.
+      '';
+    };
+  };
+
+  config = lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities {
+    boot.kernelModules = [ "wl" ];
+    boot.extraModulePackages = [
+      (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
+        meta = oldAttrs.meta // {
+          knownVulnerabilities = [ ];
+        };
+      }))
+    ];
+  };
+}

--- a/dell/inspiron/3442/README.md
+++ b/dell/inspiron/3442/README.md
@@ -25,6 +25,14 @@ $ lspci -nn
 
 ### Extra Configuration
 
+#### Broadcom WiFi/Bluetooth
+
+> **Note:** Enabling WiFi and Bluetooth functionality on this hardware requires the proprietary Broadcom driver. Due to outstanding security issues, you need to explicitly opt-in by setting:
+>
+> ```nix
+> hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+> ```
+
 #### Bluetooth
 
 To enable bluetooth support, set `hardware.bluetooth.enable = true;`.

--- a/dell/inspiron/3442/default.nix
+++ b/dell/inspiron/3442/default.nix
@@ -6,8 +6,42 @@
     ../../../common/pc/laptop
   ];
 
-  services = {
-    fwupd.enable = lib.mkDefault true;
-    thermald.enable = lib.mkDefault true;
+  options = {
+    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
+
+        This driver is vulnerable to heap buffer overflows:
+        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
+        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
+
+        Attackers within WiFi range can exploit this vulnerability by sending crafted
+        WiFi packets, even without being connected to the same network. Simply having
+        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
+        Only enable if no alternative WiFi solution is available.
+      '';
+    };
+  };
+
+  config = {
+    boot.kernelModules =
+      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+        [ "wl" ];
+    boot.extraModulePackages =
+      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+        [
+          (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
+            meta = oldAttrs.meta // {
+              knownVulnerabilities = [ ];
+            };
+          }))
+        ];
+
+    services = {
+      fwupd.enable = lib.mkDefault true;
+      thermald.enable = lib.mkDefault true;
+    };
   };
 }

--- a/dell/inspiron/3442/default.nix
+++ b/dell/inspiron/3442/default.nix
@@ -4,41 +4,10 @@
   imports = [
     ../../../common/cpu/intel/haswell
     ../../../common/pc/laptop
+    ../../../common/broadcom-wifi.nix
   ];
 
-  options = {
-    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
-
-        This driver is vulnerable to heap buffer overflows:
-        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
-        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
-
-        Attackers within WiFi range can exploit this vulnerability by sending crafted
-        WiFi packets, even without being connected to the same network. Simply having
-        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
-        Only enable if no alternative WiFi solution is available.
-      '';
-    };
-  };
-
   config = {
-    boot.kernelModules =
-      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-        [ "wl" ];
-    boot.extraModulePackages =
-      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-        [
-          (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
-            meta = oldAttrs.meta // {
-              knownVulnerabilities = [ ];
-            };
-          }))
-        ];
-
     services = {
       fwupd.enable = lib.mkDefault true;
       thermald.enable = lib.mkDefault true;

--- a/dell/inspiron/3442/default.nix
+++ b/dell/inspiron/3442/default.nix
@@ -6,7 +6,15 @@
     ../../../common/pc/laptop
     ../../../common/broadcom-wifi.nix
   ];
-
+  # ##############################################################################
+  # ATTENTION / IMPORTANT NOTE:
+  #
+  # Note: Enabling WiFi and Bluetooth functionality on this hardware requires
+  # the proprietary Broadcom driver. Due to outstanding security issues, you
+  # need to explicitly opt-in by setting:
+  #
+  # hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+  # ##############################################################################
   config = {
     services = {
       fwupd.enable = lib.mkDefault true;

--- a/dell/xps/13-9343/README.md
+++ b/dell/xps/13-9343/README.md
@@ -1,0 +1,9 @@
+# Dell XPS 13 (9343)
+
+## Wireless / Bluetooth
+
+> **Note:** Enabling WiFi and Bluetooth functionality on this hardware requires the proprietary Broadcom driver. Due to outstanding security issues, you need to explicitly opt-in by setting:
+>
+> ```nix
+> hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+> ```

--- a/dell/xps/13-9343/default.nix
+++ b/dell/xps/13-9343/default.nix
@@ -7,14 +7,43 @@
     ../../../common/pc/ssd
   ];
 
-  services = {
-    fwupd.enable = lib.mkDefault true;
-    thermald.enable = lib.mkDefault true;
+  options = {
+    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
+
+        This driver is vulnerable to heap buffer overflows:
+        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
+        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
+
+        Attackers within WiFi range can exploit this vulnerability by sending crafted
+        WiFi packets, even without being connected to the same network. Simply having
+        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
+        Only enable if no alternative WiFi solution is available.
+      '';
+    };
   };
 
-  boot = {
-    kernelModules = [
+  config = {
+    boot.kernelModules = [
       "kvm-intel"
-    ];
+    ]
+    ++ lib.optionals config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities [ "wl" ];
+    boot.extraModulePackages =
+      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
+        [
+          (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
+            meta = oldAttrs.meta // {
+              knownVulnerabilities = [ ];
+            };
+          }))
+        ];
+
+    services = {
+      fwupd.enable = lib.mkDefault true;
+      thermald.enable = lib.mkDefault true;
+    };
   };
 }

--- a/dell/xps/13-9343/default.nix
+++ b/dell/xps/13-9343/default.nix
@@ -7,7 +7,15 @@
     ../../../common/pc/ssd
     ../../../common/broadcom-wifi.nix
   ];
-
+  # ##############################################################################
+  # ATTENTION / IMPORTANT NOTE:
+  #
+  # Note: Enabling WiFi and Bluetooth functionality on this hardware requires
+  # the proprietary Broadcom driver. Due to outstanding security issues, you
+  # need to explicitly opt-in by setting:
+  #
+  # hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = true;
+  # ##############################################################################
   config = {
     boot.kernelModules = [
       "kvm-intel"

--- a/dell/xps/13-9343/default.nix
+++ b/dell/xps/13-9343/default.nix
@@ -5,41 +5,13 @@
     ../../../common/cpu/intel
     ../../../common/pc/laptop
     ../../../common/pc/ssd
+    ../../../common/broadcom-wifi.nix
   ];
-
-  options = {
-    hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Enable the legacy Broadcom WiFi driver (wl) with known security vulnerabilities.
-
-        This driver is vulnerable to heap buffer overflows:
-        - CVE-2019-9501 (https://github.com/advisories/GHSA-vjw8-c937-7hwp)
-        - CVE-2019-9502 (https://github.com/advisories/GHSA-4rfg-8q34-prmp)
-
-        Attackers within WiFi range can exploit this vulnerability by sending crafted
-        WiFi packets, even without being connected to the same network. Simply having
-        WiFi enabled makes the system vulnerable to arbitrary code execution or denial-of-service.
-        Only enable if no alternative WiFi solution is available.
-      '';
-    };
-  };
 
   config = {
     boot.kernelModules = [
       "kvm-intel"
-    ]
-    ++ lib.optionals config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities [ "wl" ];
-    boot.extraModulePackages =
-      lib.mkIf config.hardware.broadcom.wifi.enableLegacyDriverWithKnownVulnerabilities
-        [
-          (config.boot.kernelPackages.broadcom_sta.overrideAttrs (oldAttrs: {
-            meta = oldAttrs.meta // {
-              knownVulnerabilities = [ ];
-            };
-          }))
-        ];
+    ];
 
     services = {
       fwupd.enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes
Re-enable the Broadcom `wl` (broadcom-sta) WiFi/Bluetooth driver that was removed in PR #1580, and add an option to disable it for users who prefer not to use the vulnerable driver (for example because they replaced it with a USB Wi-Fi adapter due to the security issue).
By default, the Broadcom driver is enabled, so that affected devices regain working Wi-Fi.
The driver is included via an overridden `broadcom_sta` package with cleared `meta.knownVulnerabilities`, which avoids evaluation failures while keeping the module functional.
Tested on a MacBook Air 6,2.

###### Things done

- [X] Tested the changes in my own NixOS Configuration on a MacBook Air 6.2
- [x] Tested the changes end-to-end on a MacBook Air 6.2 by using my fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

