### PR TITLE
init dell-latitude-5320

### DIFF
--- a/dell/latitude/5320/README.md
+++ b/dell/latitude/5320/README.md
@@ -1,0 +1,43 @@
+# Dell Latitude 5320
+
+CPU: 11th Gen Intel(R) Core(TM) i5-1145G7 @ 2.60GHz
+GPU: Intel UHD Graphics 620
+
+Ports:
+
+- HDMI
+- 2 x USB-C (compatible thunderbolt)
+- MicroSD-card reader
+- Combo Audio jack
+- 2 x USB-A
+- SIM card tray
+
+Notable Feature:
+
+- fingerprint scanner
+
+```shell
+$ lspci -nn
+00:00.0 Host bridge [0600]: Intel Corporation Tiger Lake-UP3/H35 4 cores Host Bridge/DRAM Registers [8086:9a14] (rev 01)
+00:02.0 VGA compatible controller [0300]: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] [8086:9a49] (rev 01)
+00:04.0 Signal processing controller [1180]: Intel Corporation TigerLake-LP Dynamic Tuning Processor Participant [8086:9a03] (rev 01)
+00:07.0 PCI bridge [0604]: Intel Corporation Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #0 [8086:9a23] (rev 01)
+00:07.1 PCI bridge [0604]: Intel Corporation Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #1 [8086:9a25] (rev 01)
+00:0d.0 USB controller [0c03]: Intel Corporation Tiger Lake-LP Thunderbolt 4 USB Controller [8086:9a13] (rev 01)
+00:0d.2 USB controller [0c03]: Intel Corporation Tiger Lake-LP Thunderbolt 4 NHI #0 [8086:9a1b] (rev 01)
+00:12.0 Serial controller [0700]: Intel Corporation Tiger Lake-LP Integrated Sensor Hub [8086:a0fc] (rev 20)
+00:14.0 USB controller [0c03]: Intel Corporation Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller [8086:a0ed] (rev 20)
+00:14.2 RAM memory [0500]: Intel Corporation Tiger Lake-LP Shared SRAM [8086:a0ef] (rev 20)
+00:14.3 Network controller [0280]: Intel Corporation Wi-Fi 6 AX201 [8086:a0f0] (rev 20)
+00:15.0 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #0 [8086:a0e8] (rev 20)
+00:15.1 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #1 [8086:a0e9] (rev 20)
+00:16.0 Communication controller [0780]: Intel Corporation Tiger Lake-LP Management Engine Interface [8086:a0e0] (rev 20)
+00:1c.0 PCI bridge [0604]: Intel Corporation Tiger Lake-LP PCI Express Root Port #7 [8086:a0be] (rev 20)
+00:1d.0 PCI bridge [0604]: Intel Corporation Tiger Lake-LP PCI Express Root Port #9 [8086:a0b0] (rev 20)
+00:1f.0 ISA bridge [0601]: Intel Corporation Tiger Lake-LP LPC Controller [8086:a082] (rev 20)
+00:1f.3 Audio device [0403]: Intel Corporation Tiger Lake-LP Smart Sound Technology Audio Controller [8086:a0c8] (rev 20)
+00:1f.4 SMBus [0c05]: Intel Corporation Tiger Lake-LP SMBus Controller [8086:a0a3] (rev 20)
+00:1f.5 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP SPI Controller [8086:a0a4] (rev 20)
+71:00.0 Unassigned class [ff00]: Realtek Semiconductor Co., Ltd. RTS525A PCI Express Card Reader [10ec:525a] (rev 01)
+72:00.0 Non-Volatile memory controller [0108]: Samsung Electronics Co Ltd NVMe SSD Controller 980 (DRAM-less) [144d:a809
+```

--- a/dell/latitude/5320/default.nix
+++ b/dell/latitude/5320/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ../../../common/cpu/intel/tiger-lake
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  # Important Firmware
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  # Start the driver at boot
+  systemd.services.fprintd = {
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig.Type = "simple";
+  };
+
+  # this enable the fingerprint sensor
+  services.fprintd.enable = lib.mkDefault true;
+  # fprintd is not enough we need the fork with the supported devices https://gitlab.freedesktop.org/3v1n0/libfprint/-/blob/tod/README.tod.md
+  services.fprintd.tod.enable = lib.mkDefault true;
+  # for my device, I need this driver
+  # https://discussion.fedoraproject.org/t/broadcom-58200-fingerprint-driver-open-source-driver-released-can-we-add-to-fedora-repos/139332
+  services.fprintd.tod.driver = lib.mkDefault true pkgs.libfprint-2-tod1-broadcom;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,6 @@
         );
     in
     {
-
       nixosModules =
         let
           deprecated =
@@ -112,6 +111,7 @@
           dell-inspiron-7559 = import ./dell/inspiron/7559;
           dell-latitude-3340 = import ./dell/latitude/3340;
           dell-latitude-3480 = import ./dell/latitude/3480;
+          dell-latitude-5320 = import ./dell/latitude/5320;
           dell-latitude-5490 = import ./dell/latitude/5490;
           dell-latitude-5520 = import ./dell/latitude/5520;
           dell-latitude-7280 = import ./dell/latitude/7280;


### PR DESCRIPTION
###### Description of changes

added a profile for the dell-latitude-5320.
Notable feature of the profile: 
- the fingerprint reader works and can be used instead of the user password if a fingerprint is enrolled (both in the shell and in plasma DE).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Testing is ongoing
- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

