### PR TITLE
lenovo/thinkbook/16pg5irx: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ See code for all available configurations.
 | [Lenovo Legion Slim 7 Gen 7 (AMD)](lenovo/legion/16arha7/)                        | `<nixos-hardware/lenovo/legion/16arha7>`                | `lenovo-legion-16arha7`                |
 | [Lenovo Legion T5 AMR5](lenovo/legion/t526amr5)                                   | `<nixos-hardware/lenovo/legion/t526amr5>`               | `lenovo-legion-t526amr5`               |
 | [Lenovo Legion Y530 15ICH](lenovo/legion/15ich)                                   | `<nixos-hardware/lenovo/legion/15ich>`                  | `lenovo-legion-y530-15ich`             |
+| [Lenovo ThinkBook 16p Gen5 IRX](lenovo/thinkpad/16pg5irx)                         | `<nixos-hardware/lenovo/thinkbook/16pg5irx>`            | `lenovo-thinkbook-16pg5irx`            |
 | [Lenovo ThinkPad A475](lenovo/thinkpad/a475)                                      | `<nixos-hardware/lenovo/thinkpad/a475>`                 | `lenovo-thinkpad-a475`                 |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                              | `<nixos-hardware/lenovo/thinkpad/e14/amd>`              | `lenovo-thinkpad-e14-amd`              |
 | [Lenovo ThinkPad E14 (Intel - Gen 1)](lenovo/thinkpad/e14/intel)                  | `<nixos-hardware/lenovo/thinkpad/e14/intel>`            | `lenovo-thinkpad-e14-intel`            |

--- a/flake.nix
+++ b/flake.nix
@@ -233,6 +233,7 @@
           lenovo-legion-16iax10h = import ./lenovo/legion/16iax10h;
           lenovo-legion-t526amr5 = import ./lenovo/legion/t526amr5;
           lenovo-legion-y530-15ich = import ./lenovo/legion/15ich;
+          lenovo-thinkbook-16pg5irx = import ./lenovo/thinkbook/16pg5irx;
           lenovo-thinkpad = import ./lenovo/thinkpad;
           lenovo-thinkpad-a475 = import ./lenovo/thinkpad/a475;
           lenovo-thinkpad-e14-amd = import ./lenovo/thinkpad/e14/amd;

--- a/lenovo/thinkbook/16pg5irx/default.nix
+++ b/lenovo/thinkbook/16pg5irx/default.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ../../../common/cpu/intel/raptor-lake
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ada-lovelace
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../../common/hidpi.nix
+  ];
+
+  # Requires at least 6.13 for correct audio behaviour.
+  # https://github.com/torvalds/linux/commit/34c8e74cd6667ef5da90d448a1af702c4b873bd3
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.13") (
+    lib.mkDefault pkgs.linuxPackages_latest
+  );
+
+  # Ambient light sensor
+  hardware.sensor.iio.enable = lib.mkDefault true;
+  # Fingerprint reader
+  services.fprintd.enable = lib.mkDefault true;
+
+  hardware = {
+    nvidia = {
+      powerManagement = {
+        enable = lib.mkDefault true;
+        finegrained = lib.mkDefault true;
+      };
+      dynamicBoost.enable = lib.mkDefault true;
+
+      prime = {
+        intelBusId = lib.mkDefault "PCI:00:02:0";
+        nvidiaBusId = lib.mkDefault "PCI:01:00:0";
+      };
+    };
+  };
+
+  # Cooling management
+  services.thermald.enable = lib.mkDefault true;
+
+  # round(sqrt(3200^2 + 2000^2) px / 16 in) = 236 dpi
+  services.xserver.dpi = 236;
+}


### PR DESCRIPTION
###### Description of changes
Add configuration for Lenovo ThinkBook 16p Gen5 IRX.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

