### PR TITLE
microsoft/surface: simplify patch pulling

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -33,27 +33,22 @@ let
       abort "Invalid kernel version: ${kernelVersion}";
 
   # Fetch the latest linux-surface patches
-  repos = pkgs.callPackage (
-    { fetchFromGitHub }:
-    {
-      linux-surface = fetchFromGitHub {
-        owner = "linux-surface";
-        repo = "linux-surface";
-        rev = "50d0ed6be462a5fdb643cfe8469bf69158afae42";
-        hash = "sha256-ozvYrZDiVtMkdCcVnNEdlF2Kdw4jivW0aMJrDynN3Hk=";
-      };
-    }
-  ) { };
+  linux-surface = pkgs.fetchFromGitHub {
+    owner = "linux-surface";
+    repo = "linux-surface";
+    rev = "50d0ed6be462a5fdb643cfe8469bf69158afae42";
+    hash = "sha256-ozvYrZDiVtMkdCcVnNEdlF2Kdw4jivW0aMJrDynN3Hk=";
+  };
 
   # Fetch and build the kernel
-  inherit (pkgs.callPackage ./kernel/linux-package.nix { inherit repos; })
+  inherit (pkgs.callPackage ./kernel/linux-package.nix { })
     linuxPackage
     surfacePatches
     ;
   kernelPatches = surfacePatches {
     version = srcVersion;
     patchFn = ./kernel/${versions.majorMinor srcVersion}/patches.nix;
-    patchSrc = (repos.linux-surface + "/patches/${versions.majorMinor srcVersion}");
+    patchSrc = (linux-surface + "/patches/${versions.majorMinor srcVersion}");
   };
   kernelPackages = linuxPackage {
     inherit kernelPatches;

--- a/microsoft/surface/common/kernel/linux-package.nix
+++ b/microsoft/surface/common/kernel/linux-package.nix
@@ -4,7 +4,6 @@
   fetchurl,
   buildLinux,
   linuxPackagesFor,
-  repos,
 }:
 
 let
@@ -74,7 +73,6 @@ in
 {
   inherit
     linuxPackage
-    repos
     surfacePatches
     versionsOf
     isVersionOf


### PR DESCRIPTION
###### Description of changes

This is a relatively minor tweak to the linux-surface kernel logic. Since the project retains all patch sets for recent kernels, we can just pull the latest commit (or release). 

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

