### PR TITLE
framework-16-amd-ai-300-series: add nvidia submodule

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,7 @@
           framework-amd-ai-300-series = import ./framework/13-inch/amd-ai-300-series;
           framework-16-7040-amd = import ./framework/16-inch/7040-amd;
           framework-16-amd-ai-300-series = import ./framework/16-inch/amd-ai-300-series;
+          framework-16-amd-ai-300-series-nvidia = import ./framework/16-inch/amd-ai-300-series/nvidia;
           framework-desktop-amd-ai-max-300-series = import ./framework/desktop/amd-ai-max-300-series;
           friendlyarm-nanopc-t4 = import ./friendlyarm/nanopc-t4;
           friendlyarm-nanopi-r5s = import ./friendlyarm/nanopi-r5s;

--- a/framework/16-inch/amd-ai-300-series/README.md
+++ b/framework/16-inch/amd-ai-300-series/README.md
@@ -1,13 +1,39 @@
 # [Framework Laptop 16 AMD AI 300 Series](https://frame.work/)
 
-## nvidia
+## NVIDIA dGPU Module
 
-If you have an nvidia dGPU module, you can enable it via the nvidia open drivers:
+If you have an NVIDIA dGPU module (GeForce RTX 5070 or similar), use the nvidia submodule:
 
+```nix
+{
+  imports = [
+    nixos-hardware.nixosModules.framework-16-amd-ai-300-series-nvidia
+  ];
+}
 ```
-services.xserver.videoDrivers = [ "nvidia" ];
-hardware.nvidia.open = true;  # see the note above
+
+This enables hybrid graphics with PRIME offload: the AMD iGPU runs by default for better battery life, and the NVIDIA dGPU can be used on demand with `nvidia-offload <command>`.
+
+**IMPORTANT:** You MUST override the PCI bus IDs for your specific system. The default values are examples only and will likely not match your hardware. Due to Framework 16's modular design, bus IDs vary depending on installed expansion cards and NVMe drives:
+
+```nix
+{
+  hardware.nvidia.prime = {
+    amdgpuBusId = "PCI:195:0:0";   # Adjust to your system
+    nvidiaBusId = "PCI:194:0:0";   # Adjust to your system
+  };
+}
 ```
+
+Find your bus IDs with:
+
+```sh
+$ lspci | grep -E "VGA|3D|Display"
+c2:00.0 VGA compatible controller: NVIDIA Corporation ...
+c3:00.0 Display controller: Advanced Micro Devices ...
+```
+
+Convert the hex bus ID to decimal (e.g., `c2:00.0` → `PCI:194:0:0`, `c3:00.0` → `PCI:195:0:0`).
 
 See also [NVIDIA](https://wiki.nixos.org/wiki/NVIDIA) on the NixOS Wiki.
 

--- a/framework/16-inch/amd-ai-300-series/nvidia/default.nix
+++ b/framework/16-inch/amd-ai-300-series/nvidia/default.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../common/gpu/nvidia/blackwell
+    ../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  # Explicitly set nvidia as video driver to override modesetting from AMD module
+  services.xserver.videoDrivers = [ "nvidia" ];
+
+  hardware.nvidia = {
+    # Hybrid graphics with PRIME offload for better battery life
+    # AMD iGPU by default, NVIDIA dGPU on demand via nvidia-offload command
+    prime = {
+      # WARNING: These defaults may not match your system!
+      # Bus IDs vary depending on installed expansion cards and NVMe drives.
+      # You MUST override these values - see README.md for instructions.
+      # Bus IDs can be found with `lspci | grep -E "VGA|3D|Display"`
+      amdgpuBusId = lib.mkDefault "PCI:195:0:0";
+      nvidiaBusId = lib.mkDefault "PCI:194:0:0";
+    };
+
+    # Power management for hybrid graphics
+    powerManagement.enable = lib.mkDefault true;
+  };
+}


### PR DESCRIPTION
Add a dedicated submodule for Framework Laptop 16 AMD AI 300 Series with NVIDIA dGPU (RTX 5070). This provides hybrid graphics configuration with PRIME offload, allowing the AMD iGPU to run by default for better battery life while making the NVIDIA dGPU available on demand via nvidia-offload.

Exposed as nixosModules.framework-16-amd-ai-300-series-nvidia

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

