### PR TITLE
microsoft/surface: fix invalid hash

### DIFF
--- a/microsoft/surface/common/default.nix
+++ b/microsoft/surface/common/default.nix
@@ -37,7 +37,7 @@ let
     owner = "linux-surface";
     repo = "linux-surface";
     rev = "50d0ed6be462a5fdb643cfe8469bf69158afae42";
-    hash = "sha256-ozvYrZDiVtMkdCcVnNEdlF2Kdw4jivW0aMJrDynN3Hk=";
+    hash = "sha256-VEoZH3dFsLn9GnUyjnbOoJeTRM3KEQ9fhlMk03NXoXs=";
   };
 
   # Fetch and build the kernel


### PR DESCRIPTION
###### Description of changes

Fix the hash when downloading the patches from linux-surface. Fixes #1687 

###### Things done

I tested to make sure the patches were downloaded and applied without errors, but I didn't wait for the full kernel build to finish

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

