### PR TITLE
Fix sg_display.enable option description in ASUS modules

### DIFF
--- a/asus/flow/gv302x/amdgpu/default.nix
+++ b/asus/flow/gv302x/amdgpu/default.nix
@@ -18,7 +18,7 @@ in
     recovery.enable = (mkEnableOption "Enable amdgpu.gpu_recovery kernel boot param") // {
       default = false;
     };
-    sg_display.enable = (mkEnableOption "Enable amdgpu.gpu_recovery kernel boot param") // {
+    sg_display.enable = (mkEnableOption "Enable amdgpu.sg_display kernel boot param") // {
       default = true;
     };
     psr.enable = (mkEnableOption "Enable amdgpu.dcdebugmask=0x10 kernel boot param") // {

--- a/asus/zephyrus/ga402x/amdgpu/default.nix
+++ b/asus/zephyrus/ga402x/amdgpu/default.nix
@@ -18,7 +18,7 @@ in
     recovery.enable = (mkEnableOption "Enable amdgpu.gpu_recovery kernel boot param") // {
       default = false;
     };
-    sg_display.enable = (mkEnableOption "Enable amdgpu.gpu_recovery kernel boot param") // {
+    sg_display.enable = (mkEnableOption "Enable amdgpu.sg_display kernel boot param") // {
       default = true;
     };
     psr.enable = (mkEnableOption "Enable amdgpu.dcdebugmask=0x10 kernel boot param") // {


### PR DESCRIPTION
###### Description of changes

Fix sg_display.enable option description in ASUS modules

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

