### PR TITLE
framework/amd: disable Panel Replay in addition to PSR (0x10 → 0x410)

### DIFF
--- a/framework/13-inch/common/amd.nix
+++ b/framework/13-inch/common/amd.nix
@@ -7,12 +7,14 @@
   ];
 
   boot.kernelParams = [
-    # There seems to be an issue with panel self-refresh (PSR) that
-    # causes hangs for users.
+    # Disable PSR, PSR-SU, and Panel Replay to fix display hangs and corruption.
+    # Panel Replay requires PSR/PSR-SU to also be disabled to avoid issues.
     #
     # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
     # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
-    "amdgpu.dcdebugmask=0x10"
+    # https://community.frame.work/t/workaround-graphical-corruption-with-780m-igpu/61750
+    # https://gist.github.com/lbrame/f9034b1a9fe4fc2d2835c5542acb170a
+    "amdgpu.dcdebugmask=0x410"
   ]
   # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
   ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [

--- a/framework/16-inch/common/amd.nix
+++ b/framework/16-inch/common/amd.nix
@@ -7,12 +7,14 @@
   ];
 
   boot.kernelParams = [
-    # There seems to be an issue with panel self-refresh (PSR) that
-    # causes hangs for users.
+    # Disable PSR, PSR-SU, and Panel Replay to fix display hangs and corruption.
+    # Panel Replay requires PSR/PSR-SU to also be disabled to avoid issues.
     #
     # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
     # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
-    "amdgpu.dcdebugmask=0x10"
+    # https://community.frame.work/t/workaround-graphical-corruption-with-780m-igpu/61750
+    # https://gist.github.com/lbrame/f9034b1a9fe4fc2d2835c5542acb170a
+    "amdgpu.dcdebugmask=0x410"
   ]
   # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
   ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [


### PR DESCRIPTION
###### Description of changes

Disable Panel Replay in addition to PSR on Framework AMD laptops (0x10 → 0x410).

The previous value `0x10` only disabled PSR (Panel Self Refresh), but users report that
Panel Replay must also be disabled to avoid graphical corruption and flickering.
When disabling Panel Replay, PSR and PSR-SU must also be disabled to avoid issues.

`0x410` disables all three: PSR, PSR-SU, and Panel Replay.

References:
- https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
- https://gitlab.freedesktop.org/drm/amd/-/issues/3647
- https://community.frame.work/t/workaround-graphical-corruption-with-780m-igpu/61750
- https://gist.github.com/lbrame/f9034b1a9fe4fc2d2835c5542acb170a

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

---
*This PR was created with assistance from Claude (Anthropic).*