### PR TITLE
radxa/dragon-q6a: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ See code for all available configurations.
 | [Purism Librem 13v3](purism/librem/13v3)                                          | `<nixos-hardware/purism/librem/13v3>`                   | `purism-librem-13v3`                   |
 | [Purism Librem 15v3](purism/librem/15v3)                                          | `<nixos-hardware/purism/librem/15v3>`                   | `purism-librem-15v3`                   |
 | [Purism Librem 5r4](purism/librem/5r4)                                            | `<nixos-hardware/purism/librem/5r4>`                    | `purism-librem-5r4`                    |
+| [Radxa Dragon Q6A](radxa/dragon-q6a)                                              | `<nixos-hardware/radxa/dragon-q6a>`                     | `dragon-q6a`                           |
 | [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   | `rock-4c-plus`                         |
 | [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        | `rock-5b`                              |
 | [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      | `rock-pi-4`                            |

--- a/flake.nix
+++ b/flake.nix
@@ -391,6 +391,7 @@
           purism-librem-13v3 = import ./purism/librem/13v3;
           purism-librem-15v3 = import ./purism/librem/15v3;
           purism-librem-5r4 = import ./purism/librem/5r4;
+          radxa-dragon-q6a = import ./radxa/dragon-q6a;
           razer-blade-14-RZ09-0530 = import ./razer/blade/14/RZ09-0530;
           raspberry-pi-2 = import ./raspberry-pi/2;
           raspberry-pi-3 = import ./raspberry-pi/3;

--- a/radxa/dragon-q6a/README.md
+++ b/radxa/dragon-q6a/README.md
@@ -1,0 +1,9 @@
+# Radxa Dragon Q6A
+
+This SBC still needs a vendor kernel until 6.19 released, otherwise some important hardware like NVME won't work.
+
+## edl-ng
+
+[edl-ng](https://github.com/strongtz/edl-ng) is a modern, user-friendly tool for interacting with Qualcomm devices in Emergency Download (EDL) mode. It can be used to flash the SPI firmware or UFS image for Radxa Dragon Q6A.
+
+The upstream repo supports nix flake to run easily by `github:strongtz/edl-ng#edl-ng` .

--- a/radxa/dragon-q6a/default.nix
+++ b/radxa/dragon-q6a/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  alsa-ucm-conf-patches = pkgs.fetchFromGitHub {
+    owner = "radxa-pkg";
+    repo = "alsa-ucm-conf";
+    tag = "1.2.14-1radxa2";
+    hash = "sha256-9y+0GxJ/CCA9J0gnRPl+EHxNnQNuKiNceB0dfilPeT4=";
+  };
+  alsa-ucm-conf-patched = pkgs.alsa-ucm-conf.overrideAttrs (oldAttrs: {
+    # https://github.com/radxa-pkg/alsa-ucm-conf/blob/main/debian/patches/series
+    patches = (oldAttrs.patches or [ ]) ++ [
+      "${alsa-ucm-conf-patches}/debian/patches/radxa/0001-add-radxa-dragon-q6a-support.patch"
+      "${alsa-ucm-conf-patches}/debian/patches/radxa/0002-fix-radxa-dragon-q6a-config.patch"
+      "${alsa-ucm-conf-patches}/debian/patches/radxa/0003-ucm2-Qualcomm-qcs6490-Add-DMI-match-for-Radxa-Dragon.patch"
+    ];
+  });
+in
+{
+  imports = [
+    ../.
+  ];
+
+  config = {
+    hardware = {
+      radxa.enable = true;
+    };
+
+    boot = {
+      # We need a out-of-tree kernel for Dragon Q6A, otherwise important hardware such as NVME won't work.
+      kernelPackages = lib.mkDefault (pkgs.linuxPackagesFor (import ./kernel.nix { inherit lib pkgs; }));
+      loader = {
+        systemd-boot = {
+          enable = lib.mkDefault true;
+          installDeviceTree = true;
+        };
+        efi.canTouchEfiVariables = false;
+      };
+      kernelParams = [
+        "console=ttyMSM0,115200n8"
+        "earlycon"
+        "keep_bootcon"
+      ];
+
+      initrd = {
+        availableKernelModules = [
+          "usb_storage"
+          "nvme"
+          "xhci_hcd"
+        ];
+      };
+    };
+
+    console.earlySetup = lib.mkDefault true;
+
+    hardware = {
+      firmware = with pkgs; [
+        linux-firmware
+      ];
+      deviceTree = {
+        enable = true;
+        name = "qcom/qcs6490-radxa-dragon-q6a.dtb";
+      };
+    };
+
+    systemd.tpm2.enable = false;
+    environment.variables.ALSA_CONFIG_UCM2 = "${alsa-ucm-conf-patched}/share/alsa/ucm2";
+  };
+}

--- a/radxa/dragon-q6a/kernel.nix
+++ b/radxa/dragon-q6a/kernel.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+pkgs.buildLinux {
+  defconfig = "qcom_module_defconfig";
+  version = "6.18.2-1-q6a-radxa";
+  modDirVersion = "6.18.2";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "radxa";
+    repo = "kernel";
+    # Use the same kernel commit ID as
+    # https://github.com/radxa-pkg/linux-qcom/tree/6.18.2-1
+    rev = "ca7680ac08f031ed0a952dbc6174ced3d513bef9";
+    hash = "sha256-xCgW/2iaWu9JWz3LLeV/xwzvtx5JComcPZpgH7rnOgw=";
+  };
+
+  structuredExtraConfig = with lib.kernel; {
+    EFI_ZBOOT = lib.mkForce no;
+    NVME_AUTH = lib.mkForce yes;
+  };
+
+  extraConfig = ''
+    COMPRESSED_INSTALL n
+    DRM_NOVA n
+    NOVA_CORE n
+    WLAN_VENDOR_AIC8800 n
+  '';
+
+  ignoreConfigErrors = true;
+}


### PR DESCRIPTION
###### Description of changes

Initialize the support of Radxa Dragon Q6A

https://docs.radxa.com/dragon/q6a

---

A major challenge is how we handle the onboard AIC8800 WiFi module.

The downstream vendor released their driver at: https://github.com/radxa-pkg/aic8800

Due to its extremely poor code quality, this module is virtually impossible to integrate into nixpkgs as is, let alone the mainline kernel. Here are some attempts:

- https://github.com/NixOS/nixpkgs/pull/443520
- https://lore.kernel.org/all/20251020092144.25259-1-he.zhenang@bedmex.com/

To make matters worse, due to the creators' extremely poor understanding of Linux kernel firmware loading, the original code for this driver was completely unusable on Nixos.

I modified a version on the Deepin community that looks usable, but I can't guarantee its long-term maintenance： https://github.com/deepin-community/aic8800

---

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

CC @RadxaYuntian 