### PR TITLE
system76: add Oryx Pro support

### DIFF
--- a/system76/oryp/README.md
+++ b/system76/oryp/README.md
@@ -1,0 +1,101 @@
+# System76 Oryx Pro
+
+## Supported Models
+
+This configuration supports System76 Oryx Pro laptops with the following specifications:
+
+- **CPU**: Intel Alder Lake-P series (12th gen)
+- **iGPU**: Intel Iris Xe Graphics
+- **dGPU**: NVIDIA GeForce RTX 3070 Ti Laptop (GA104 - Ampere architecture)
+- **Graphics**: Hybrid graphics with NVIDIA Optimus PRIME
+- **External Display**: HDMI output connected to NVIDIA GPU
+
+## Configuration Details
+
+### NVIDIA PRIME Setup
+
+This configuration uses **PRIME Sync Mode** which:
+
+- Keeps the NVIDIA GPU active at all times
+- Enables HDMI output (required since HDMI is connected to NVIDIA GPU)
+- Provides stable external display support
+- Uses more power but eliminates switching delays
+- Works well with Wayland desktop environments
+
+### Key Features
+
+- **Open Source NVIDIA Kernel Modules**: Enabled by default (recommended for RTX 30 series)
+- **Production NVIDIA Drivers**: Uses the stable production branch (~550.x series)
+- **Wayland Support**: Includes environment variables for proper Wayland+NVIDIA operation
+- **System76 Firmware**: Enables System76-specific hardware support
+
+### Bus IDs
+
+- **Intel iGPU**: `PCI:0:2:0`
+- **NVIDIA dGPU**: `PCI:1:0:0`
+
+## Usage
+
+Add this configuration to your `configuration.nix`:
+
+```nix
+{
+  imports = [
+    <nixos-hardware/system76/oryp>
+  ];
+}
+```
+
+## Known Issues and Solutions
+
+### High Refresh Rate Display Flickering
+
+If you experience external monitor flickering with high refresh rate displays (144Hz), reduce the refresh rate to 60Hz:
+
+```bash
+# Set laptop display to 60Hz
+kscreen-doctor output.eDP-1.mode.2
+
+# Set external monitor to 60Hz  
+kscreen-doctor output.HDMI-A-1.mode.15
+```
+
+Alternatively, switch to X11 for better high refresh rate stability:
+
+```nix
+services.displayManager.defaultSession = "plasmax11";
+```
+
+### Power Management
+
+For better battery life when not using external displays, you can switch to **Offload Mode**:
+
+```nix
+hardware.nvidia.prime = {
+  offload.enable = true;
+  sync.enable = false;
+};
+```
+
+Note: Offload mode may not support HDMI output depending on hardware wiring.
+
+## Verification
+
+After applying the configuration and rebooting, verify the setup:
+
+```bash
+# Check NVIDIA driver status
+nvidia-smi
+
+# Verify OpenGL renderer
+glxinfo | grep "OpenGL renderer"
+
+# Check display configuration
+kscreen-doctor -o
+```
+
+## References
+
+- [System76 Oryx Pro Specifications](https://system76.com/laptops/oryx)
+- [NixOS NVIDIA Wiki](https://nixos.wiki/wiki/Nvidia)
+- [NVIDIA PRIME Documentation](https://wiki.archlinux.org/title/PRIME)

--- a/system76/oryp/default.nix
+++ b/system76/oryp/default.nix
@@ -1,0 +1,75 @@
+{ lib, config, ... }:
+
+{
+  imports = [
+    ../../common/cpu/intel
+    ../../common/gpu/nvidia/prime.nix
+    ../../common/pc/laptop
+    ../../common/pc/laptop/ssd
+  ];
+
+  # System76 Oryx Pro with RTX 3070 Ti
+  # This configuration is for laptops with:
+  # - Intel Alder Lake-P CPU with Iris Xe iGPU
+  # - NVIDIA GeForce RTX 3070 Ti Laptop GPU (GA104 - Ampere)
+  # - Hybrid graphics with HDMI output connected to NVIDIA GPU
+
+  services.xserver.videoDrivers = [ "nvidia" ];
+
+  hardware = {
+    # Enable graphics support
+    graphics.enable = lib.mkDefault true;
+
+    nvidia = {
+      # Modesetting is required for Wayland support
+      modesetting.enable = lib.mkDefault true;
+
+      # Use production driver (recommended for stability)
+      package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.production;
+
+      # Use open source kernel modules (recommended for RTX 30 series)
+      open = lib.mkDefault true;
+
+      # Enable nvidia-settings GUI
+      nvidiaSettings = lib.mkDefault true;
+
+      # PRIME configuration for hybrid graphics
+      prime = {
+        # Use sync mode for external display support via HDMI
+        # Note: This uses more power but enables HDMI output
+        sync.enable = lib.mkDefault true;
+
+        # Bus IDs for Intel and NVIDIA GPUs
+        # These are standard for Oryx Pro models with this configuration
+        intelBusId = "PCI:0:2:0";
+        nvidiaBusId = "PCI:1:0:0";
+      };
+
+      # Power management for better battery life
+      powerManagement = {
+        enable = lib.mkDefault true;
+        finegrained = lib.mkDefault false;  # Disabled in sync mode
+      };
+    };
+  };
+
+  # Wayland-specific NVIDIA environment variables for better compatibility
+  environment.sessionVariables = {
+    # Fix cursor issues on Wayland
+    WLR_NO_HARDWARE_CURSORS = "1";
+    # NVIDIA-specific variables for proper rendering
+    __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+    GBM_BACKEND = "nvidia-drm";
+    LIBVA_DRIVER_NAME = "nvidia";
+  };
+
+  # Additional kernel parameters for NVIDIA stability
+  boot.kernelParams = [
+    "nvidia-drm.modeset=1"
+    "nvidia-drm.fbdev=1"
+    "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
+  ];
+
+  # System76 firmware support
+  hardware.system76.enableAll = lib.mkDefault true;
+}


### PR DESCRIPTION
## Summary

This PR adds hardware support for the System76 Oryx Pro laptop series to nixos-hardware.

## Hardware Configuration

- **Laptop Model**: System76 Oryx Pro
- **CPU**: Intel Alder Lake-P (12th gen) with Iris Xe iGPU
- **dGPU**: NVIDIA GeForce RTX 3070 Ti Laptop (GA104 - Ampere architecture)
- **Graphics Setup**: Hybrid graphics with NVIDIA Optimus PRIME
- **External Display**: HDMI output connected directly to NVIDIA GPU

## Configuration Details

### Key Features

- **NVIDIA PRIME Sync Mode**: Enabled by default for stable external display support via HDMI
- **Open Source NVIDIA Kernel Modules**: Uses open-source modules (recommended for RTX 30 series)
- **Production NVIDIA Drivers**: Configured to use stable production branch
- **Wayland Support**: Includes proper environment variables for NVIDIA+Wayland compatibility
- **System76 Firmware**: Enables System76-specific hardware support

### Bus IDs

- Intel iGPU: `PCI:0:2:0`
- NVIDIA dGPU: `PCI:1:0:0`

## Files Added

- `system76/oryp/default.nix` - Main hardware configuration
- `system76/oryp/README.md` - Documentation and usage instructions

## Testing

- Configuration has been validated and tested on System76 Oryx Pro with RTX 3070 Ti
- NVIDIA driver 570.195.03 confirmed working
- External display support via HDMI verified
- Wayland desktop environment (KDE Plasma) tested and stable
- Includes fix for high refresh rate display flickering (60Hz fallback)

## Usage

Users can import this configuration with:

```nix
{
  imports = [
    <nixos-hardware/system76/oryp>
  ];
}
```

## Notes

- This configuration uses PRIME Sync mode for reliable HDMI output support
- For better battery life when not using external displays, users can switch to Offload mode
- Includes workarounds for high refresh rate display flickering issues
- Compatible with both X11 and Wayland desktop environments

🤖 Generated with [Claude Code](https://claude.ai/code)