### PR TITLE
rename option to new image.baseName

### DIFF
--- a/starfive/visionfive/v2/sd-image.nix
+++ b/starfive/visionfive/v2/sd-image.nix
@@ -11,8 +11,8 @@
     ./.
   ];
 
-  sdImage = {
-    imageName = "${config.sdImage.imageBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}-starfive-visionfive2.img";
+  image = {
+    baseName = "${config.image.baseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}-starfive-visionfive2.img";
 
     # Overridden by postBuildCommands
     populateFirmwareCommands = "";


### PR DESCRIPTION
###### Description of changes

When building riscv VisionFive2 image or cross-compiling to it, following warning appears: `evaluation warning: Obsolete option "sdImage.imageBaseName" is used. It was renamed to "image.baseName".`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

