### PR TITLE
audio(framework-13-amd-ai-300): update default rawDeviceName

### DIFF
--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -16,7 +16,7 @@
     services.fwupd.enable = true;
 
     hardware.framework.laptop13.audioEnhancement.rawDeviceName =
-      lib.mkDefault "alsa_output.pci-0000_c1_00.6.analog-stereo";
+      lib.mkDefault "alsa_output.pci-0000_c1_00.6.HiFi__Speaker__sink";
 
     # suspend works with 6.15
     boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") (


### PR DESCRIPTION
###### Description of changes

Update the default `rawDeviceName` for the Framework 13 AMD AI 300 series. Recent UCM profile updates (or kernel driver changes) now cause the device to expose a HiFi profile sink name (`HiFi__Speaker__sink`) instead of the generic `analog-stereo` name.

This ensures the audio enhancement effects correctly attach to the speaker sink out of the box.

Device name changed from:
`alsa_output.pci-0000_c1_00.6.analog-stereo`
to:
`alsa_output.pci-0000_c1_00.6.HiFi__Speaker__sink`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

