### PR TITLE
apple/t2 - update latest kernel to 6.19 (from 6.16)

### DIFF
--- a/apple/t2/pkgs/brcm-firmware/fetchmacos.nix
+++ b/apple/t2/pkgs/brcm-firmware/fetchmacos.nix
@@ -1,7 +1,5 @@
 {
-  lib,
   stdenvNoCC,
-  fetchFromGitHub,
   callPackage,
   dmg2img,
 }:

--- a/apple/t2/pkgs/linux-t2/latest.json
+++ b/apple/t2/pkgs/linux-t2/latest.json
@@ -1,49 +1,21 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/6b41c3fd65913e0fa3592ad16ff4a3a5b01efc7a/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/5051ebba61fe8765ba452f46db9b944f33f07a86/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-00K3LmId2Ag6s5K76p7mB2a0oEXp815yRd+U5wxWPMc="
+      "hash": "sha256-oZgaj1ujKSjn5PEJ8khrqFnoAkXbC+TInlKfdX0X82Y="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-wkveNo1qwAwXWDGTFed4ZDbuBnJbwKgWLmTHK9qq0oM="
-    },
-    {
-      "name": "1003-Fix-sparse-errors.patch",
-      "hash": "sha256-nuCOPWa4Hp+HCCBe6Y++M4g1k4plOWzy2hqHXlJbp9g="
-    },
-    {
-      "name": "1004-Fix-freezing-on-turning-off-camera.patch",
-      "hash": "sha256-rFrSUhiNXgQbfgKjryJktYxYcchXE1PI49Q1gW001+0="
-    },
-    {
-      "name": "1007-HID-multitouch-Get-the-contact-ID-from-HID_DG_TRANSD.patch",
-      "hash": "sha256-JF5PjByo4S1Rd/B5luAzOXDv+iakCnJfmujIQuUiT1A="
-    },
-    {
-      "name": "1008-HID-multitouch-support-getting-the-tip-state-from-HI.patch",
-      "hash": "sha256-m/NAKoHRC/HwxG5fFZxFl6DtY4Xv8kPBWvdKdtadrrk="
-    },
-    {
-      "name": "1009-HID-multitouch-take-cls-maxcontacts-into-account-for.patch",
-      "hash": "sha256-h6jk9yw/4txd8PATpMxB9mIzik9+X1zP6p4K35AqdXw="
-    },
-    {
-      "name": "1010-HID-multitouch-specify-that-Apple-Touch-Bar-is-direc.patch",
-      "hash": "sha256-5PbLynVnQqlJKPTWhcmwXCkYDEopLBQWnxWvZUt0EN4="
-    },
-    {
-      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bar.patch",
-      "hash": "sha256-dIzEOj89D2rIEc2/mjq3TkIfI3ZHzu0VRDQQOzp+Snc="
+      "hash": "sha256-JHWLmSJ158Qs24cjnzolR4JKuNhzzf9e9hRR8T96Dp4="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
-      "hash": "sha256-PjMVt4u505PXnKFpojov0Uwhj0KxZas1E4NYJGI6lQ4="
+      "hash": "sha256-S2osR1aSjqJiO7rNZP1sKt2+Uxyitwse/6BXMJvE9as="
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
-      "hash": "sha256-aE+MEu/jRrZBa+3Q03quOHUsIseRED6A7N/K9kEVtbM="
+      "hash": "sha256-6i+fh/Ifle0di5/tMOdMm0NMkEmeUb17hYM/g2j2dfI="
     },
     {
       "name": "3001-applesmc-convert-static-structures-to-drvdata.patch",
@@ -83,27 +55,19 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-nOpQ3t+QQXco6p7C03fM5EZ3ZfnzwC6UCFwHQd1EnGE="
-    },
-    {
-      "name": "4002-HID-quirks-remove-T2-devices-from-hid_mouse_ignore_l.patch",
-      "hash": "sha256-0PMCE3IWHekir5YV1BD6Jakc7dOV6Fj2HfIGWZnXZV0="
+      "hash": "sha256-+YXyIjtlVrLo8allTO3M1A+xold5FUXaZ8dwD2j5HDc="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
-      "hash": "sha256-JTeYtaBqMyTu5IdGb8x7wbP9ZE1rXT4lpEjudR1ySFI="
+      "hash": "sha256-T2tYcFLeWUdx6QawANe3ZNVSRxmo1IdPiSpGLQk4IDY="
     },
     {
       "name": "4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch",
-      "hash": "sha256-dNrpDlIE9SaQUOntVQHMOyj7T/dsuRemN56yskKWue0="
+      "hash": "sha256-ubchCEv1BZ7t/zkI9DpHA4gUln9cdu4yHzVJI2TNlS0="
     },
     {
-      "name": "4005-HID-apple-Add-necessary-IDs-and-support-for-replacem.patch",
-      "hash": "sha256-SRKESCbpxSYm7U0VyCmvkmT/er6/GEHhwo8tgJDO6mQ="
-    },
-    {
-      "name": "4006-HID-magicmouse-Add-MacBookPro15-1-replacement-trackp.patch",
-      "hash": "sha256-mMqHhxig+Z9eVPaa1qfcNVCRX16B6/KuEd1KnSZMLLk="
+      "name": "4005-HID-magicmouse-fix-regression-breaking-support-for-M.patch",
+      "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
     },
     {
       "name": "7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch",
@@ -111,11 +75,11 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-uR5hg75SFFWzfrKyU5UnzPL4U7LkjqGs44rkxM7ur8o="
+      "hash": "sha256-ozOkXGFfsT2iVjAZDoWya8tBY8yiChgLKkBnGACzyrY="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",
-      "hash": "sha256-n1SH5vC//LRJdWOavH9/BHqBTjkUj5f+dFGitSeHksw="
+      "hash": "sha256-gh1z49QeKgTmGJ92KFNDvqn9gCW0dtrI7DMzaD2ZHGU="
     }
   ]
 }

--- a/apple/t2/pkgs/linux-t2/latest.nix
+++ b/apple/t2/pkgs/linux-t2/latest.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_6_16, ... }@args:
+{ callPackage, linux_6_19, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_6_16;
+  kernel = linux_6_19;
   patchesFile = ./latest.json;
 }

--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,65 +1,21 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/1f514a15e2b20ce2e1f99018493c71de9784fcf0/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/5051ebba61fe8765ba452f46db9b944f33f07a86/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-e3RPvWPj2QASGOS4kieO8YFekrXsBCJtfF82OPlOn2E="
+      "hash": "sha256-oZgaj1ujKSjn5PEJ8khrqFnoAkXbC+TInlKfdX0X82Y="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-DXj4CmE7TKMGrAhQDOR5RVw9YHmyQMiXZsmxYfkKAEA="
-    },
-    {
-      "name": "1003-Fix-sparse-errors.patch",
-      "hash": "sha256-nuCOPWa4Hp+HCCBe6Y++M4g1k4plOWzy2hqHXlJbp9g="
-    },
-    {
-      "name": "1004-Fix-freezing-on-turning-off-camera.patch",
-      "hash": "sha256-rFrSUhiNXgQbfgKjryJktYxYcchXE1PI49Q1gW001+0="
-    },
-    {
-      "name": "1005-HID-hid-appletb-bl-add-driver-for-the-backlight-of-A.patch",
-      "hash": "sha256-kEscS1FAyDxLZPOPInYTXFEf4fouBEa4zGctX14hSu8="
-    },
-    {
-      "name": "1006-HID-hid-appletb-kbd-add-driver-for-the-keyboard-mode.patch",
-      "hash": "sha256-eVEuvnoRItaDjwWu41nn9bTkgHgY+1SL/hFAvUR2IlY="
-    },
-    {
-      "name": "1007-HID-multitouch-Get-the-contact-ID-from-HID_DG_TRANSD.patch",
-      "hash": "sha256-JF5PjByo4S1Rd/B5luAzOXDv+iakCnJfmujIQuUiT1A="
-    },
-    {
-      "name": "1008-HID-multitouch-support-getting-the-tip-state-from-HI.patch",
-      "hash": "sha256-m/NAKoHRC/HwxG5fFZxFl6DtY4Xv8kPBWvdKdtadrrk="
-    },
-    {
-      "name": "1009-HID-multitouch-take-cls-maxcontacts-into-account-for.patch",
-      "hash": "sha256-h6jk9yw/4txd8PATpMxB9mIzik9+X1zP6p4K35AqdXw="
-    },
-    {
-      "name": "1010-HID-multitouch-specify-that-Apple-Touch-Bar-is-direc.patch",
-      "hash": "sha256-5PbLynVnQqlJKPTWhcmwXCkYDEopLBQWnxWvZUt0EN4="
-    },
-    {
-      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bar.patch",
-      "hash": "sha256-dIzEOj89D2rIEc2/mjq3TkIfI3ZHzu0VRDQQOzp+Snc="
-    },
-    {
-      "name": "1013-lib-vsprintf-Add-support-for-generic-FourCCs-by-exte.patch",
-      "hash": "sha256-h3gxaKtvdm/GSd+AP1sPC9avWHOsceUxTmoua/3rIf4="
-    },
-    {
-      "name": "1015-drm-tiny-add-driver-for-Apple-Touch-Bars-in-x86-Macs.patch",
-      "hash": "sha256-tDjK/VipVQbuNOURW38gssqeRLy3s8I+DVq0+4zGnHs="
+      "hash": "sha256-JHWLmSJ158Qs24cjnzolR4JKuNhzzf9e9hRR8T96Dp4="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
-      "hash": "sha256-lZ7MWXZubmAlJCqBmuzueg7agENJbikxP1SE46SmwNw="
+      "hash": "sha256-S2osR1aSjqJiO7rNZP1sKt2+Uxyitwse/6BXMJvE9as="
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
-      "hash": "sha256-XKwlyJZjJLQz39mc0/S7sPnRnwrqMsq9OKy+QCO+oho="
+      "hash": "sha256-6i+fh/Ifle0di5/tMOdMm0NMkEmeUb17hYM/g2j2dfI="
     },
     {
       "name": "3001-applesmc-convert-static-structures-to-drvdata.patch",
@@ -99,39 +55,31 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-kfAYVovukZLD5ocHQxhoHJSa9c5XAJ1GhH1RlzGkS+k="
-    },
-    {
-      "name": "4002-HID-quirks-remove-T2-devices-from-hid_mouse_ignore_l.patch",
-      "hash": "sha256-0PMCE3IWHekir5YV1BD6Jakc7dOV6Fj2HfIGWZnXZV0="
+      "hash": "sha256-+YXyIjtlVrLo8allTO3M1A+xold5FUXaZ8dwD2j5HDc="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
-      "hash": "sha256-JTeYtaBqMyTu5IdGb8x7wbP9ZE1rXT4lpEjudR1ySFI="
+      "hash": "sha256-T2tYcFLeWUdx6QawANe3ZNVSRxmo1IdPiSpGLQk4IDY="
     },
     {
       "name": "4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch",
-      "hash": "sha256-HcPX7gY3hnlwM/tY06pbtXnch04AqwHgC596E8ZqGY8="
+      "hash": "sha256-ubchCEv1BZ7t/zkI9DpHA4gUln9cdu4yHzVJI2TNlS0="
     },
     {
-      "name": "4005-HID-apple-Add-necessary-IDs-and-support-for-replacem.patch",
-      "hash": "sha256-SRKESCbpxSYm7U0VyCmvkmT/er6/GEHhwo8tgJDO6mQ="
-    },
-    {
-      "name": "4006-HID-magicmouse-Add-MacBookPro15-1-replacement-trackp.patch",
-      "hash": "sha256-uAlT/4ADwYyKvbuPQaGwqCjZ2/myruC63etVV6cfFLk="
+      "name": "4005-HID-magicmouse-fix-regression-breaking-support-for-M.patch",
+      "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
     },
     {
       "name": "7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch",
-      "hash": "sha256-O6RHFxmKZn7aCq1D+r5z2T3jLt0r5+01EABD9rs0E5M="
+      "hash": "sha256-/EKN7JsAxcpAgfJFtPp2NLYaGqQ0kl8wjJEXifSzJpY="
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-rTdmORTT2oeBTh6R8LbXimgiaA7X6AgQO+lUuN5hJYI="
+      "hash": "sha256-ozOkXGFfsT2iVjAZDoWya8tBY8yiChgLKkBnGACzyrY="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",
-      "hash": "sha256-n1SH5vC//LRJdWOavH9/BHqBTjkUj5f+dFGitSeHksw="
+      "hash": "sha256-gh1z49QeKgTmGJ92KFNDvqn9gCW0dtrI7DMzaD2ZHGU="
     }
   ]
 }


### PR DESCRIPTION
###### Description of changes

`hardware.apple-t2.kernelChannel` can be `stable` or `latest`. When `latest` is selected, a T2 kernel based on `linux_6_16` is used.

Since NixOS 25.11 this fails to compile with:

> linux 6.16 was removed because it has reached its end of life upstream

The [`t2linux/linux-t2-patches`](https://github.com/t2linux/linux-t2-patches) project is using 6.18, so this PR aligns with that repo and also updates to the latest set of patches.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

