### PR TITLE
apple/t2: kernel latest 6.16 -> 6.18; sync patches

### DIFF
--- a/apple/t2/pkgs/linux-t2/latest.json
+++ b/apple/t2/pkgs/linux-t2/latest.json
@@ -1,49 +1,25 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/6b41c3fd65913e0fa3592ad16ff4a3a5b01efc7a/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/f32e738d74e3b72a944227386ded334452b2fe42/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-00K3LmId2Ag6s5K76p7mB2a0oEXp815yRd+U5wxWPMc="
+      "hash": "sha256-Wo95/UfIPIScDhrhDkIYUZrETPJCEeVbG5mSNJ8Dufc="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
       "hash": "sha256-wkveNo1qwAwXWDGTFed4ZDbuBnJbwKgWLmTHK9qq0oM="
     },
     {
-      "name": "1003-Fix-sparse-errors.patch",
-      "hash": "sha256-nuCOPWa4Hp+HCCBe6Y++M4g1k4plOWzy2hqHXlJbp9g="
-    },
-    {
-      "name": "1004-Fix-freezing-on-turning-off-camera.patch",
+      "name": "1003-Fix-freezing-on-turning-off-camera.patch",
       "hash": "sha256-rFrSUhiNXgQbfgKjryJktYxYcchXE1PI49Q1gW001+0="
     },
     {
-      "name": "1007-HID-multitouch-Get-the-contact-ID-from-HID_DG_TRANSD.patch",
-      "hash": "sha256-JF5PjByo4S1Rd/B5luAzOXDv+iakCnJfmujIQuUiT1A="
-    },
-    {
-      "name": "1008-HID-multitouch-support-getting-the-tip-state-from-HI.patch",
-      "hash": "sha256-m/NAKoHRC/HwxG5fFZxFl6DtY4Xv8kPBWvdKdtadrrk="
-    },
-    {
-      "name": "1009-HID-multitouch-take-cls-maxcontacts-into-account-for.patch",
-      "hash": "sha256-h6jk9yw/4txd8PATpMxB9mIzik9+X1zP6p4K35AqdXw="
-    },
-    {
-      "name": "1010-HID-multitouch-specify-that-Apple-Touch-Bar-is-direc.patch",
-      "hash": "sha256-5PbLynVnQqlJKPTWhcmwXCkYDEopLBQWnxWvZUt0EN4="
-    },
-    {
-      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bar.patch",
-      "hash": "sha256-dIzEOj89D2rIEc2/mjq3TkIfI3ZHzu0VRDQQOzp+Snc="
-    },
-    {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
-      "hash": "sha256-PjMVt4u505PXnKFpojov0Uwhj0KxZas1E4NYJGI6lQ4="
+      "hash": "sha256-oOlpybSIaEPVZ7FqdsVSljYe++0synyCqEdMXb23Jnk="
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
-      "hash": "sha256-aE+MEu/jRrZBa+3Q03quOHUsIseRED6A7N/K9kEVtbM="
+      "hash": "sha256-6i+fh/Ifle0di5/tMOdMm0NMkEmeUb17hYM/g2j2dfI="
     },
     {
       "name": "3001-applesmc-convert-static-structures-to-drvdata.patch",
@@ -83,27 +59,19 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-nOpQ3t+QQXco6p7C03fM5EZ3ZfnzwC6UCFwHQd1EnGE="
-    },
-    {
-      "name": "4002-HID-quirks-remove-T2-devices-from-hid_mouse_ignore_l.patch",
-      "hash": "sha256-0PMCE3IWHekir5YV1BD6Jakc7dOV6Fj2HfIGWZnXZV0="
+      "hash": "sha256-+YXyIjtlVrLo8allTO3M1A+xold5FUXaZ8dwD2j5HDc="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
-      "hash": "sha256-JTeYtaBqMyTu5IdGb8x7wbP9ZE1rXT4lpEjudR1ySFI="
+      "hash": "sha256-T2tYcFLeWUdx6QawANe3ZNVSRxmo1IdPiSpGLQk4IDY="
     },
     {
       "name": "4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch",
-      "hash": "sha256-dNrpDlIE9SaQUOntVQHMOyj7T/dsuRemN56yskKWue0="
+      "hash": "sha256-ubchCEv1BZ7t/zkI9DpHA4gUln9cdu4yHzVJI2TNlS0="
     },
     {
-      "name": "4005-HID-apple-Add-necessary-IDs-and-support-for-replacem.patch",
-      "hash": "sha256-SRKESCbpxSYm7U0VyCmvkmT/er6/GEHhwo8tgJDO6mQ="
-    },
-    {
-      "name": "4006-HID-magicmouse-Add-MacBookPro15-1-replacement-trackp.patch",
-      "hash": "sha256-mMqHhxig+Z9eVPaa1qfcNVCRX16B6/KuEd1KnSZMLLk="
+      "name": "4005-HID-magicmouse-fix-regression-breaking-support-for-M.patch",
+      "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
     },
     {
       "name": "7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch",
@@ -111,7 +79,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-uR5hg75SFFWzfrKyU5UnzPL4U7LkjqGs44rkxM7ur8o="
+      "hash": "sha256-s7lJRWWgbhgchffwtajp4nNVjgma0ghCHZ8Xeyy7RAU="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",

--- a/apple/t2/pkgs/linux-t2/latest.nix
+++ b/apple/t2/pkgs/linux-t2/latest.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_6_16, ... }@args:
+{ callPackage, linux_6_18, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_6_16;
+  kernel = linux_6_18;
   patchesFile = ./latest.json;
 }

--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/5eaf1261d069bbc67aba7fe2737a5fe981e05a9e/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/804c76852d22ea09551192e8a2ddbd4489e5ba56/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
@@ -127,7 +127,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-QpIPsMjWNPOkw6rSKn7rW0Fmx9HUwJaiGy3pZeT5Fd0="
+      "hash": "sha256-ZHY9oJls14//CFewiO3OK+ZYKd/sXUCDy5RMx3//fLQ="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",


### PR DESCRIPTION
###### Description of changes

bumped kernel from 6.16 to 6.18 for the latest kernel, and update patches for both. apologies for the long overdue update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

