### PR TITLE
Disable UCM globally on FW16

### DIFF
--- a/framework/16-inch/amd-ai-300-series/default.nix
+++ b/framework/16-inch/amd-ai-300-series/default.nix
@@ -26,4 +26,15 @@
     "amdgpu.sg_display=0"
     "amdgpu.abmlevel=0"
   ];
+
+  # Work around broken ALSA UCM profiles. Symptoms include incorrect default routing
+  # (e.g. “Headphones” with nothing plugged in) and broken internal mic/speaker routes.
+  # Disabling UCM makes WirePlumber fall back to ACP profiles (e.g. analog-stereo),
+  # which restores sane defaults.
+  # Reference: https://github.com/NixOS/nixos-hardware/issues/1603#issue-3383477120
+  services.pipewire.wireplumber.extraConfig."10-no-ucm" = {
+    "monitor.alsa.properties" = {
+      "alsa.use-ucm" = false;
+    };
+  };
 }


### PR DESCRIPTION
For Framework Laptop 16 *only*, this works around https://github.com/NixOS/nixos-hardware/issues/1603. The extra snippet is taken from the the first comment in the issue (with the `10-` prefix added to the rule name for ordering stability).

For FW13, https://github.com/NixOS/nixos-hardware/pull/1709 was merged a few days ago. I'm not sure if it resolves the same issue, and I would appreciate a comment from @alirezamirsepassi on whether disabling UCM is the correct solution for FW16, since its `default.nix` looks a bit different compared to FW13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

