### PR TITLE
Fix phantom Headphones + silent HDA capture devices on Framework 16 (AMD AI 300) by guarding generic HDA UCM devices

### DIFF
--- a/framework/16-inch/amd-ai-300-series/README.md
+++ b/framework/16-inch/amd-ai-300-series/README.md
@@ -96,6 +96,10 @@ This creates an additional boot entry tagged `battery-saver`.
 
 * If suspend/resume fails after heavy GPU/VRAM usage, see the NixOS NVIDIA wiki for power management / VRAM save notes: https://wiki.nixos.org/wiki/NVIDIA
 
+## Audio
+
+FW16 has no 3.5mm jack, but `pkgs.alsa-ucm-conf` creates the corresponding microphone source and headphones sink unconditionally with high priority, resulting in audio being routed to non-existent devices by default. This profile ships temporary patches to override this behavior until the fix is upstreamed into [`alsa-ucm-conf`](https://github.com/alsa-project/alsa-ucm-conf). See https://github.com/NixOS/nixos-hardware/pull/1718 for context.
+
 ## Firmware updates (fwupd)
 
 Firmware is updatable via `fwupd` (enabled by default). To get the latest firmware:

--- a/framework/16-inch/amd-ai-300-series/audio.nix
+++ b/framework/16-inch/amd-ai-300-series/audio.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  # Patch the upstream UCM definitions until the fixes land in alsa-ucm-conf.
+  # Use a mostly-symlinked tree and only materialize patched files to keep
+  # closure size down.
+  ucm2Patched =
+    pkgs.runCommand "alsa-ucm2-patched-fw16-ai300"
+      {
+        nativeBuildInputs = [ pkgs.patch ];
+      }
+      ''
+        set -euo pipefail
+
+        ucmSrc="${pkgs.alsa-ucm-conf}/share/alsa/ucm2"
+        ucmOut="$out/share/alsa/ucm2"
+        patchDir=${./ucm-patches}
+
+        mkdir -p "$out/share/alsa"
+        cp -as "$ucmSrc" "$out/share/alsa/"
+
+        # Make editable, materialize, patch, and sanity-check the targets.
+        for f in HDA/HiFi-analog.conf HDA/HiFi-mic.conf; do
+          chmod u+w "$ucmOut/$f"
+          cp --remove-destination "$ucmSrc/$f" "$ucmOut/$f"
+          patch -p1 -d "$out/share/alsa" < "$patchDir/$f.patch"
+          test -f "$ucmOut/$f"
+        done
+      '';
+
+  ucm2Path = "${ucm2Patched}/share/alsa/ucm2";
+in
+{
+  # Point ALSA / PipeWire / WirePlumber at the patched UCM profiles so the
+  # Headphones and HDA capture devices are only created when the relevant
+  # controls are present. Without this, FW16, which has no physical 3.5mm
+  # jack, exposes silent devices.
+  systemd.user.services = lib.mkIf config.services.pipewire.enable {
+    pipewire.environment.ALSA_CONFIG_UCM2 = lib.mkDefault ucm2Path;
+    pipewire-pulse.environment.ALSA_CONFIG_UCM2 = lib.mkDefault ucm2Path;
+    wireplumber.environment.ALSA_CONFIG_UCM2 = lib.mkDefault ucm2Path;
+  };
+}

--- a/framework/16-inch/amd-ai-300-series/default.nix
+++ b/framework/16-inch/amd-ai-300-series/default.nix
@@ -9,6 +9,7 @@
   imports = [
     ../common
     ../common/amd.nix
+    ./audio.nix
   ];
 
   # 6.14 is the minimum recommended kernel, 6.15 has many useful changes, too

--- a/framework/16-inch/amd-ai-300-series/ucm-patches/HDA/HiFi-analog.conf.patch
+++ b/framework/16-inch/amd-ai-300-series/ucm-patches/HDA/HiFi-analog.conf.patch
@@ -1,0 +1,92 @@
+diff --git a/ucm2/HDA/HiFi-analog.conf b/ucm2/HDA/HiFi-analog.conf
+index 673c74e..6d4aaed 100644
+--- a/ucm2/HDA/HiFi-analog.conf
++++ b/ucm2/HDA/HiFi-analog.conf
+@@ -53,32 +53,64 @@ If.hplo {
+ 	}
+ }
+ 
+-SectionDevice."Headphones" {
+-	Comment "Headphones"
++Define.HeadphonesPresent ""
+ 
+-	If.headphone_switch {
+-		Condition {
+-			Type ControlExists
+-			Control "name='Headphone Playback Switch'"
+-		}
+-		True {
+-			EnableSequence [
+-				cset "name='Headphone Playback Switch' on"
+-			]
+-			DisableSequence [
+-				cset "name='Headphone Playback Switch' off"
+-			]
+-		}
++If.hpvol_ctl {
++	Condition {
++		Type ControlExists
++		Control "name='${var:hpvol} Playback Volume'"
+ 	}
++	True.Define.HeadphonesPresent y
++}
++
++If.hpsw_ctl {
++	Condition {
++		Type ControlExists
++		Control "name='Headphone Playback Switch'"
++	}
++	True.Define.HeadphonesPresent y
++}
++
++If.hpjack_ctl {
++	Condition {
++		Type ControlExists
++		Control "iface=CARD,name='${var:hpjack}'"
++	}
++	True.Define.HeadphonesPresent y
++}
+ 
+-	Value {
+-		PlaybackPriority 200
+-		PlaybackPCM "hw:${CardId}"
+-		PlaybackMixerElem "${var:hpvol}"
+-		PlaybackMasterElem "Master"
+-		PlaybackVolume "${var:hpvol} Playback Volume"
+-		PlaybackSwitch "Headphone Playback Switch"
+-		JackControl "${var:hpjack}"
++If.headphones_dev {
++	Condition {
++		Type String
++		Empty "${var:HeadphonesPresent}"
++	}
++	False.SectionDevice."Headphones" {
++		Comment "Headphones"
++
++		If.headphone_switch {
++			Condition {
++				Type ControlExists
++				Control "name='Headphone Playback Switch'"
++			}
++			True {
++				EnableSequence [
++					cset "name='Headphone Playback Switch' on"
++				]
++				DisableSequence [
++					cset "name='Headphone Playback Switch' off"
++				]
++			}
++		}
++
++		Value {
++			PlaybackPriority 200
++			PlaybackPCM "hw:${CardId}"
++			PlaybackMixerElem "${var:hpvol}"
++			PlaybackMasterElem "Master"
++			PlaybackVolume "${var:hpvol} Playback Volume"
++			PlaybackSwitch "Headphone Playback Switch"
++			JackControl "${var:hpjack}"
++		}
+ 	}
+ }
+ 

--- a/framework/16-inch/amd-ai-300-series/ucm-patches/HDA/HiFi-mic.conf.patch
+++ b/framework/16-inch/amd-ai-300-series/ucm-patches/HDA/HiFi-mic.conf.patch
@@ -1,0 +1,144 @@
+diff --git a/ucm2/HDA/HiFi-mic.conf b/ucm2/HDA/HiFi-mic.conf
+index 68ecc13..bc79e00 100644
+--- a/ucm2/HDA/HiFi-mic.conf
++++ b/ucm2/HDA/HiFi-mic.conf
+@@ -316,6 +316,28 @@ If.micsetup {
+ 	}
+ }
+ 
++# Guard: only create HDA analog capture devices when the expected capture
++# kcontrols exist. Some platforms (e.g. jackless designs) expose no HDA capture
++# controls, but the generic profile would still create Mic/Mic2 devices that
++# record silence and may become the default source.
++Define.HDACaptureControlsPresent ""
++
++If.hda_capvol {
++	Condition {
++		Type ControlExists
++		Control "name='Capture Volume'"
++	}
++	True.Define.HDACaptureControlsPresent y
++}
++
++If.hda_capsw {
++	Condition {
++		Type ControlExists
++		Control "name='Capture Switch'"
++	}
++	True.Define.HDACaptureControlsPresent y
++}
++
+ # Macro HDACaptureDevice - Create the SectionDevice for HDA inputs
+ #
+ # Arguments:
+@@ -393,15 +415,21 @@ If.mic1 {
+ 		Type String
+ 		Empty "${var:DeviceMicName}"
+ 	}
+-	False.Macro.0.HDACaptureDevice {
+-		DevName "${var:DeviceMic}"
+-		MicName "${var:DeviceMicName}"
+-		DevComment "${var:DeviceMicComment}"
+-		JackName "${var:DeviceMicJack}"
+-		Priority "${var:DeviceMicPriority}"
+-		ConflictCondition1 "${var:DeviceMic2Name}" ConflictDev1 "${var:DeviceMic2}"
+-		ConflictCondition2 "${var:DeviceMic3Name}" ConflictDev2 "${var:DeviceMic3}"
+-		ConflictCondition3 "${var:DeviceMic4Name}" ConflictDev3 "${var:DeviceMic4}"
++	False.If.hda_cap_present_1 {
++		Condition {
++			Type String
++			Empty "${var:HDACaptureControlsPresent}"
++		}
++		False.Macro.0.HDACaptureDevice {
++			DevName "${var:DeviceMic}"
++			MicName "${var:DeviceMicName}"
++			DevComment "${var:DeviceMicComment}"
++			JackName "${var:DeviceMicJack}"
++			Priority "${var:DeviceMicPriority}"
++			ConflictCondition1 "${var:DeviceMic2Name}" ConflictDev1 "${var:DeviceMic2}"
++			ConflictCondition2 "${var:DeviceMic3Name}" ConflictDev2 "${var:DeviceMic3}"
++			ConflictCondition3 "${var:DeviceMic4Name}" ConflictDev3 "${var:DeviceMic4}"
++		}
+ 	}
+ }
+ 
+@@ -410,14 +438,20 @@ If.mic2 {
+ 		Type String
+ 		Empty "${var:DeviceMic2Name}"
+ 	}
+-	False.Macro.1.HDACaptureDevice {
+-		DevName "${var:DeviceMic2}"
+-		MicName "${var:DeviceMic2Name}"
+-		DevComment "${var:DeviceMic2Comment}"
+-		JackName "${var:DeviceMic2Jack}"
+-		Priority "${var:DeviceMic2Priority}"
+-		ConflictCondition1 "${var:DeviceMic3Name}" ConflictDev1 "${var:DeviceMic3}"
+-		ConflictCondition2 "${var:DeviceMic4Name}" ConflictDev2 "${var:DeviceMic4}"
++	False.If.hda_cap_present_2 {
++		Condition {
++			Type String
++			Empty "${var:HDACaptureControlsPresent}"
++		}
++		False.Macro.1.HDACaptureDevice {
++			DevName "${var:DeviceMic2}"
++			MicName "${var:DeviceMic2Name}"
++			DevComment "${var:DeviceMic2Comment}"
++			JackName "${var:DeviceMic2Jack}"
++			Priority "${var:DeviceMic2Priority}"
++			ConflictCondition1 "${var:DeviceMic3Name}" ConflictDev1 "${var:DeviceMic3}"
++			ConflictCondition2 "${var:DeviceMic4Name}" ConflictDev2 "${var:DeviceMic4}"
++		}
+ 	}
+ }
+ 
+@@ -426,13 +460,19 @@ If.mic3 {
+ 		Type String
+ 		Empty "${var:DeviceMic3Name}"
+ 	}
+-	False.Macro.1.HDACaptureDevice {
+-		DevName "${var:DeviceMic3}"
+-		MicName "${var:DeviceMic3Name}"
+-		DevComment "${var:DeviceMic3Comment}"
+-		JackName "${var:DeviceMic3Jack}"
+-		Priority "${var:DeviceMic3Priority}"
+-		ConflictCondition1 "${var:DeviceMic4Name}" ConflictDev1 "${var:DeviceMic4}"
++	False.If.hda_cap_present_3 {
++		Condition {
++			Type String
++			Empty "${var:HDACaptureControlsPresent}"
++		}
++		False.Macro.1.HDACaptureDevice {
++			DevName "${var:DeviceMic3}"
++			MicName "${var:DeviceMic3Name}"
++			DevComment "${var:DeviceMic3Comment}"
++			JackName "${var:DeviceMic3Jack}"
++			Priority "${var:DeviceMic3Priority}"
++			ConflictCondition1 "${var:DeviceMic4Name}" ConflictDev1 "${var:DeviceMic4}"
++		}
+ 	}
+ }
+ 
+@@ -441,11 +481,17 @@ If.mic4 {
+ 		Type String
+ 		Empty "${var:DeviceMic4Name}"
+ 	}
+-	False.Macro.1.HDACaptureDevice {
+-		DevName "${var:DeviceMic4}"
+-		MicName "${var:DeviceMic4Name}"
+-		DevComment "${var:DeviceMic4Comment}"
+-		JackName "${var:DeviceMic4Jack}"
+-		Priority "${var:DeviceMic4Priority}"
++	False.If.hda_cap_present_4 {
++		Condition {
++			Type String
++			Empty "${var:HDACaptureControlsPresent}"
++		}
++		False.Macro.1.HDACaptureDevice {
++			DevName "${var:DeviceMic4}"
++			MicName "${var:DeviceMic4Name}"
++			DevComment "${var:DeviceMic4Comment}"
++			JackName "${var:DeviceMic4Jack}"
++			Priority "${var:DeviceMic4Priority}"
++		}
+ 	}
+ }


### PR DESCRIPTION
**UPD:** The upstream have proposed a fix in https://github.com/alsa-project/alsa-ucm-conf/issues/673#issuecomment-3708328432; I have moved this PR to draft state because their fix is cleaner.

If you want to test the upstream fix, you can override your flake inputs like this:

```nix
nixos-hardware.url = "github:dniku/nixos-hardware/fw16-ai300-upstream-ucm-fix";
```

which will use https://github.com/NixOS/nixos-hardware/compare/master...dniku:nixos-hardware:fw16-ai300-upstream-ucm-fix for integrating the workaround.

---

**DISCLOSURE**: the patch proposed in this PR was created with heavy assistance from a language model. I am not an expert on Linux audio.

# Description of changes

Framework Laptop 16 (AMD AI 300) is jackless (has no 3.5mm port).

<details>

<summary>Before the fix: GNOME sound settings</summary>

<img width="1930" height="1730" alt="image" src="https://github.com/user-attachments/assets/44b6f340-503e-4736-95a1-405c9b1afeb3" />

</details>

i.e. by default:

1. The output is routed to non-existent headphones, and
2. The input is taken from a non-existent "stereo microphone".

The drop-down allows selecting a speaker as output and a "digital microphone" as input, which work correctly --- so the audio works, but the defaults are not sane.

<details>

<summary>After the fix: GNOME sound settings</summary>

<img width="1930" height="1730" alt="image" src="https://github.com/user-attachments/assets/ee2f93cb-a85b-4df6-af80-81428c6147c9" />

</details>

i.e. the phantom devices are gone.

My understanding of the root cause is:

1. https://github.com/alsa-project/alsa-ucm-conf/blob/5d175e1f7e3df15973945a9cc15e82fa7ca0d7b6/ucm2/HDA/HiFi-analog.conf assumes a 3.5mm jack always exists and defines the corresponding output unconditionally, and
2. https://github.com/alsa-project/alsa-ucm-conf/blob/5d175e1f7e3df15973945a9cc15e82fa7ca0d7b6/ucm2/HDA/HiFi-mic.conf has a similar problem for the microphone.

With massive assistance from a language model, I drafted a fix as a patch for `alsa-ucm-conf` and created the following test script:

<details>

<summary>fw16-audio-diag.sh</summary>

```bash
#!/usr/bin/env bash
# fw16-audio-diag.sh
#
# Usage:
#   # wipe state, restart audio services, run without workaround
#   ./fw16-audio-diag.sh > fw16-audio-diag-before.txt
#   # apply workaround, relogin, wipe state, restart user audio services
#   ./fw16-audio-diag.sh > fw16-audio-diag-after.txt
#   diff -u fw16-audio-diag-{before,after}.txt > fw16-audio-diag.diff

set -euo pipefail
export LC_ALL=C

HDA_CARD=2   # ALC285 “HD-Audio Generic” card index

run() {
  echo
  echo "### $*"
  "$@"
}

echo "== FW16 audio diagnostics =="

# Context
run nixos-version
run uname -a
echo
echo "### ALSA_CONFIG_UCM2=${ALSA_CONFIG_UCM2-<unset>}"

# Systemd user services
run systemctl --user status pipewire.service
run systemctl --user status pipewire-pulse.service
run systemctl --user status wireplumber.service

# WirePlumber
run wpctl status -n
run wpctl inspect @DEFAULT_AUDIO_SINK@
run wpctl inspect @DEFAULT_AUDIO_SOURCE@

# PipeWire factories
run nix shell nixpkgs#pipewire -c pw-cli ls Factory

# ALSA view of cards/devices
run cat /proc/asound/cards
run nix shell nixpkgs#alsa-utils -c aplay -l
run nix shell nixpkgs#alsa-utils -c arecord -l
run nix shell nixpkgs#alsa-utils -c amixer -c "$HDA_CARD" controls
run nix shell nixpkgs#alsa-utils -c amixer -c "$HDA_CARD" scontrols
run nix shell nixpkgs#alsa-utils -c alsaucm listcards

# UCM verb/device list + devstatus
echo
echo "### nix shell nixpkgs#alsa-utils -c alsaucm -n -b -  (open hw:${HDA_CARD}, set HiFi, list devices + devstatus)"
nix shell nixpkgs#alsa-utils -c alsaucm -n -b - <<EOM
open hw:${HDA_CARD}
set _verb HiFi
list _devices
get _devstatus/Headphones
get _devstatus/Speaker
list1 _enadevs
EOM
```

</details>

To test the fix, I followed this procedure:

```bash
# Ensure fix is not applied
$ nixos-rebuild test \
    --flake .#myhostname \
    --sudo \
    --ask-sudo-password \
    --override-input nixos-hardware github:NixOS/nixos-hardware/master
# Wipe state
$ wpctl clear-default
# Definitely wipe state
$ trash ~/.local/state/wireplumber
# Restart audio
$ systemctl --user restart wireplumber pipewire pipewire-pulse
# Run alsa-info
$ nix shell nixpkgs#alsa-utils -c alsa-info --no-upload --stdout > fw16-before-alsa-info.txt
# Run diagnostics script
$ bash fw16-audio-diag.sh > fw16-before-audio-diag.txt

# Apply fix
$ nixos-rebuild test \
    --flake .#myhostname \
    --sudo \
    --ask-sudo-password \
    --override-input nixos-hardware github:dniku/nixos-hardware/fw16-ai300-ucm-guards
# Wipe state
$ wpctl clear-default
$ trash ~/.local/state/wireplumber
$ systemctl --user restart wireplumber pipewire pipewire-pulse
# Run diagnostics
$ nix shell nixpkgs#alsa-utils -c alsa-info --no-upload --stdout > fw16-after-alsa-info.txt
$ bash fw16-audio-diag.sh > fw16-after-audio-diag.txt

# Compute diff
$ diff -u fw16-{before,after}-alsa-info.txt > fw16-alsa-info.diff
$ diff -u fw16-{before,after}-audio-diag.txt > fw16-audio-diag.diff
```

Results:

<details>

<summary>fw16-alsa-info.diff</summary>

```diff
--- fw16-before-alsa-info.txt	2026-01-02 23:11:37.282790931 +0000
+++ fw16-after-alsa-info.txt	2026-01-02 23:14:22.354057791 +0000
@@ -3,7 +3,7 @@
 !!ALSA Information Script v 0.5.3
 !!################################
 
-!!Script ran on: Fri Jan  2 23:11:34 UTC 2026
+!!Script ran on: Fri Jan  2 23:14:19 UTC 2026
 
 
 !!Linux Distribution
@@ -848,7 +848,7 @@
   Control: name="Bass Speaker Playback Volume", index=0, device=0
     ControlAmp: chs=3, dir=Out, idx=0, ofs=0
   Amp-Out caps: ofs=0x57, nsteps=0x57, stepsize=0x02, mute=0
-  Amp-Out vals:  [0x38 0x38]
+  Amp-Out vals:  [0x57 0x57]
   Converter: stream=0, channel=0
   PCM:
     rates [0x40]: 48000
@@ -861,7 +861,7 @@
     ControlAmp: chs=3, dir=Out, idx=0, ofs=0
   Device: name="ALC285 Analog", type="Audio", device=0
   Amp-Out caps: ofs=0x57, nsteps=0x57, stepsize=0x02, mute=0
-  Amp-Out vals:  [0x19 0x19]
+  Amp-Out vals:  [0x38 0x38]
   Converter: stream=0, channel=0
   PCM:
     rates [0x40]: 48000
@@ -953,7 +953,7 @@
   Control: name="Bass Speaker Playback Switch", index=0, device=0
     ControlAmp: chs=3, dir=Out, idx=0, ofs=0
   Amp-Out caps: ofs=0x00, nsteps=0x00, stepsize=0x00, mute=1
-  Amp-Out vals:  [0x80 0x80]
+  Amp-Out vals:  [0x00 0x00]
   Pincap 0x00010014: OUT EAPD Detect
   EAPD 0x2: EAPD
   Pin Default 0x90170110: [Fixed] Speaker at Int N/A
@@ -985,7 +985,7 @@
   Control: name="Speaker Playback Switch", index=0, device=0
     ControlAmp: chs=3, dir=Out, idx=0, ofs=0
   Amp-Out caps: ofs=0x00, nsteps=0x00, stepsize=0x00, mute=1
-  Amp-Out vals:  [0x80 0x80]
+  Amp-Out vals:  [0x00 0x00]
   Pincap 0x0000001c: OUT HP Detect
   Pin Default 0x90170110: [Fixed] Speaker at Int N/A
     Conn = Analog, Color = Unknown
@@ -1110,27 +1110,27 @@
 !!ALSA Device nodes
 !!-----------------
 
-crw-rw----+ 1 root audio 116, 13 Jan  2 23:08 /dev/snd/controlC0
-crw-rw----+ 1 root audio 116,  7 Jan  2 23:08 /dev/snd/controlC1
-crw-rw----+ 1 root audio 116, 20 Jan  2 23:08 /dev/snd/controlC2
-crw-rw----+ 1 root audio 116, 15 Jan  2 23:08 /dev/snd/controlC3
-crw-rw----+ 1 root audio 116, 12 Jan  2 23:08 /dev/snd/hwC0D0
-crw-rw----+ 1 root audio 116,  6 Jan  2 23:08 /dev/snd/hwC1D0
-crw-rw----+ 1 root audio 116, 19 Jan  2 23:08 /dev/snd/hwC2D0
-crw-rw----+ 1 root audio 116,  8 Jan  2 23:08 /dev/snd/pcmC0D3p
-crw-rw----+ 1 root audio 116,  9 Jan  2 23:08 /dev/snd/pcmC0D7p
-crw-rw----+ 1 root audio 116, 10 Jan  2 23:08 /dev/snd/pcmC0D8p
-crw-rw----+ 1 root audio 116, 11 Jan  2 23:08 /dev/snd/pcmC0D9p
-crw-rw----+ 1 root audio 116,  2 Jan  2 23:08 /dev/snd/pcmC1D3p
-crw-rw----+ 1 root audio 116,  3 Jan  2 23:08 /dev/snd/pcmC1D7p
-crw-rw----+ 1 root audio 116,  4 Jan  2 23:08 /dev/snd/pcmC1D8p
-crw-rw----+ 1 root audio 116,  5 Jan  2 23:08 /dev/snd/pcmC1D9p
-crw-rw----+ 1 root audio 116, 17 Jan  2 23:08 /dev/snd/pcmC2D0c
-crw-rw----+ 1 root audio 116, 16 Jan  2 23:08 /dev/snd/pcmC2D0p
-crw-rw----+ 1 root audio 116, 18 Jan  2 23:08 /dev/snd/pcmC2D2c
-crw-rw----+ 1 root audio 116, 14 Jan  2 23:08 /dev/snd/pcmC3D0c
-crw-rw----+ 1 root audio 116,  1 Jan  2 23:08 /dev/snd/seq
-crw-rw----+ 1 root audio 116, 33 Jan  2 23:08 /dev/snd/timer
+crw-rw----+ 1 root audio 116, 13 Jan  2 23:13 /dev/snd/controlC0
+crw-rw----+ 1 root audio 116,  7 Jan  2 23:13 /dev/snd/controlC1
+crw-rw----+ 1 root audio 116, 20 Jan  2 23:13 /dev/snd/controlC2
+crw-rw----+ 1 root audio 116, 15 Jan  2 23:13 /dev/snd/controlC3
+crw-rw----+ 1 root audio 116, 12 Jan  2 23:13 /dev/snd/hwC0D0
+crw-rw----+ 1 root audio 116,  6 Jan  2 23:13 /dev/snd/hwC1D0
+crw-rw----+ 1 root audio 116, 19 Jan  2 23:13 /dev/snd/hwC2D0
+crw-rw----+ 1 root audio 116,  8 Jan  2 23:13 /dev/snd/pcmC0D3p
+crw-rw----+ 1 root audio 116,  9 Jan  2 23:13 /dev/snd/pcmC0D7p
+crw-rw----+ 1 root audio 116, 10 Jan  2 23:13 /dev/snd/pcmC0D8p
+crw-rw----+ 1 root audio 116, 11 Jan  2 23:13 /dev/snd/pcmC0D9p
+crw-rw----+ 1 root audio 116,  2 Jan  2 23:13 /dev/snd/pcmC1D3p
+crw-rw----+ 1 root audio 116,  3 Jan  2 23:13 /dev/snd/pcmC1D7p
+crw-rw----+ 1 root audio 116,  4 Jan  2 23:13 /dev/snd/pcmC1D8p
+crw-rw----+ 1 root audio 116,  5 Jan  2 23:13 /dev/snd/pcmC1D9p
+crw-rw----+ 1 root audio 116, 17 Jan  2 23:13 /dev/snd/pcmC2D0c
+crw-rw----+ 1 root audio 116, 16 Jan  2 23:13 /dev/snd/pcmC2D0p
+crw-rw----+ 1 root audio 116, 18 Jan  2 23:13 /dev/snd/pcmC2D2c
+crw-rw----+ 1 root audio 116, 14 Jan  2 23:13 /dev/snd/pcmC3D0c
+crw-rw----+ 1 root audio 116,  1 Jan  2 23:13 /dev/snd/seq
+crw-rw----+ 1 root audio 116, 33 Jan  2 23:13 /dev/snd/timer
 
 /dev/snd/by-path:
 total 0
@@ -1252,21 +1252,21 @@
   Capabilities: pvolume pvolume-joined pswitch pswitch-joined
   Playback channels: Mono
   Limits: Playback 0 - 87
-  Mono: Playback 56 [64%] [-23.25dB] [on]
+  Mono: Playback 87 [100%] [0.00dB] [on]
 Simple mixer control 'Speaker',0
   Capabilities: pvolume pswitch
   Playback channels: Front Left - Front Right
   Limits: Playback 0 - 87
   Mono:
-  Front Left: Playback 56 [64%] [-23.25dB] [off]
-  Front Right: Playback 56 [64%] [-23.25dB] [off]
+  Front Left: Playback 56 [64%] [-23.25dB] [on]
+  Front Right: Playback 56 [64%] [-23.25dB] [on]
 Simple mixer control 'Bass Speaker',0
   Capabilities: pvolume pswitch
   Playback channels: Front Left - Front Right
   Limits: Playback 0 - 87
   Mono:
-  Front Left: Playback 87 [100%] [0.00dB] [off]
-  Front Right: Playback 87 [100%] [0.00dB] [off]
+  Front Left: Playback 87 [100%] [0.00dB] [on]
+  Front Right: Playback 87 [100%] [0.00dB] [on]
 Simple mixer control 'PCM',0
   Capabilities: pvolume
   Playback channels: Front Left - Front Right
@@ -1976,8 +1976,8 @@
 	control.2 {
 		iface MIXER
 		name 'Speaker Playback Switch'
-		value.0 false
-		value.1 false
+		value.0 true
+		value.1 true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -2003,8 +2003,8 @@
 	control.4 {
 		iface MIXER
 		name 'Bass Speaker Playback Switch'
-		value.0 false
-		value.1 false
+		value.0 true
+		value.1 true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -2014,7 +2014,7 @@
 	control.5 {
 		iface MIXER
 		name 'Master Playback Volume'
-		value 56
+		value 87
 		comment {
 			access 'read write'
 			type INTEGER
@@ -2022,7 +2022,7 @@
 			range '0 - 87'
 			dbmin -6525
 			dbmax 0
-			dbvalue.0 -2325
+			dbvalue.0 0
 		}
 	}
 	control.6 {
```

</details>

<details>

<summary>fw16-audio-diag.diff</summary>

```diff
--- fw16-before-audio-diag.txt	2026-01-02 23:12:18.491966080 +0000
+++ fw16-after-audio-diag.txt	2026-01-02 23:14:44.120716247 +0000
@@ -6,78 +6,78 @@
 ### uname -a
 Linux myhostname 6.18.2 #1-NixOS SMP PREEMPT_DYNAMIC Thu Dec 18 13:03:43 UTC 2025 x86_64 GNU/Linux
 
-### ALSA_CONFIG_UCM2=<unset>
+### ALSA_CONFIG_UCM2=/nix/store/n5jw4bmh4vkhp0gnh8adarhbklrvhgi3-alsa-ucm2-patched-fw16-ai300/share/alsa/ucm2
 
 ### systemctl --user status pipewire.service
 * pipewire.service - PipeWire Multimedia Service
      Loaded: loaded (/etc/systemd/user/pipewire.service; linked-runtime; preset: ignored)
-    Drop-In: /nix/store/ik7yvqwhfkcd2ld4zz3sm8nykbrchd5s-user-units/pipewire.service.d
+    Drop-In: /nix/store/3rfn6gql14wxh0dljpl1yvi3pr984s2b-user-units/pipewire.service.d
              `-overrides.conf
-     Active: active (running) since Fri 2026-01-02 23:08:48 GMT; 3min 28s ago
- Invocation: 3ddcc1d5e82d49589862e409981c4f6c
+     Active: active (running) since Fri 2026-01-02 23:13:34 GMT; 1min 9s ago
+ Invocation: d68492e5b93c436081c19e10c4a3b122
 TriggeredBy: * pipewire.socket
-   Main PID: 2972832 (pipewire)
+   Main PID: 2977072 (pipewire)
       Tasks: 4 (limit: 114942)
-     Memory: 5.1M (peak: 6.4M)
-        CPU: 34ms
+     Memory: 5.1M (peak: 6.3M)
+        CPU: 31ms
      CGroup: /user.slice/user-1000.slice/user@1000.service/session.slice/pipewire.service
-             `-2972832 /nix/store/286ik0x6mpmc8d7jj1vxnyc2fh2dixv0-pipewire-1.4.9/bin/pipewire
+             `-2977072 /nix/store/286ik0x6mpmc8d7jj1vxnyc2fh2dixv0-pipewire-1.4.9/bin/pipewire
 
-Jan 02 23:08:48 myhostname systemd[1954126]: Started PipeWire Multimedia Service.
+Jan 02 23:13:34 myhostname systemd[1954126]: Started PipeWire Multimedia Service.
 
 ### systemctl --user status pipewire-pulse.service
 * pipewire-pulse.service - PipeWire PulseAudio
      Loaded: loaded (/etc/systemd/user/pipewire-pulse.service; linked-runtime; preset: ignored)
-    Drop-In: /nix/store/ik7yvqwhfkcd2ld4zz3sm8nykbrchd5s-user-units/pipewire-pulse.service.d
+    Drop-In: /nix/store/3rfn6gql14wxh0dljpl1yvi3pr984s2b-user-units/pipewire-pulse.service.d
              `-overrides.conf
-     Active: active (running) since Fri 2026-01-02 23:08:48 GMT; 3min 28s ago
- Invocation: 57b53aaac77f49e38647fd37b72de7dd
+     Active: active (running) since Fri 2026-01-02 23:13:34 GMT; 1min 9s ago
+ Invocation: 0b9fae6642624a33b5f19df5962e80b4
 TriggeredBy: * pipewire-pulse.socket
-   Main PID: 2972833 (pipewire-pulse)
+   Main PID: 2977074 (pipewire-pulse)
       Tasks: 3 (limit: 114942)
-     Memory: 2.2M (peak: 3.4M)
-        CPU: 19ms
+     Memory: 2.4M (peak: 2.9M)
+        CPU: 18ms
      CGroup: /user.slice/user-1000.slice/user@1000.service/session.slice/pipewire-pulse.service
-             `-2972833 /nix/store/286ik0x6mpmc8d7jj1vxnyc2fh2dixv0-pipewire-1.4.9/bin/pipewire-pulse
+             `-2977074 /nix/store/286ik0x6mpmc8d7jj1vxnyc2fh2dixv0-pipewire-1.4.9/bin/pipewire-pulse
 
-Jan 02 23:08:48 myhostname systemd[1954126]: Started PipeWire PulseAudio.
+Jan 02 23:13:34 myhostname systemd[1954126]: Started PipeWire PulseAudio.
 
 ### systemctl --user status wireplumber.service
 * wireplumber.service - Multimedia Service Session Manager
      Loaded: loaded (/etc/systemd/user/wireplumber.service; enabled; preset: ignored)
-    Drop-In: /nix/store/ik7yvqwhfkcd2ld4zz3sm8nykbrchd5s-user-units/wireplumber.service.d
+    Drop-In: /nix/store/3rfn6gql14wxh0dljpl1yvi3pr984s2b-user-units/wireplumber.service.d
              `-overrides.conf
-     Active: active (running) since Fri 2026-01-02 23:08:48 GMT; 3min 28s ago
- Invocation: 769944d157f74d238bb2b806b313daf7
-   Main PID: 2972834 (wireplumber)
+     Active: active (running) since Fri 2026-01-02 23:13:34 GMT; 1min 9s ago
+ Invocation: f68879b437d34af1b56e0f1961282848
+   Main PID: 2977075 (wireplumber)
       Tasks: 9 (limit: 114942)
-     Memory: 8.7M (peak: 9.8M)
-        CPU: 160ms
+     Memory: 8.8M (peak: 9.9M)
+        CPU: 2.066s
      CGroup: /user.slice/user-1000.slice/user@1000.service/session.slice/wireplumber.service
-             `-2972834 /nix/store/q1px8hvmlqmmfn5xi43gr2gar3hpb5nb-wireplumber-0.5.12/bin/wireplumber
+             `-2977075 /nix/store/q1px8hvmlqmmfn5xi43gr2gar3hpb5nb-wireplumber-0.5.12/bin/wireplumber
 
-Jan 02 23:08:48 myhostname wireplumber[2972834]: wp-event-dispatcher: wp_event_dispatcher_unregister_hook: assertion 'already_registered_dispatcher == self' failed
-Jan 02 23:08:49 myhostname wireplumber[2972834]: wp-device: SPA handle 'api.alsa.acp.device' could not be loaded; is it installed?
-Jan 02 23:08:49 myhostname wireplumber[2972834]: s-monitors: Failed to create 'api.alsa.acp.device' device
-Jan 02 23:08:49 myhostname wireplumber[2972834]: spa.alsa: Path Capture is not a volume or mute control
-Jan 02 23:08:49 myhostname wireplumber[2972834]: spa.alsa: Path Mic ACP LED is not a volume or mute control
-Jan 02 23:08:49 myhostname wireplumber[2972834]: spa.alsa: Path Capture is not a volume or mute control
-Jan 02 23:08:49 myhostname wireplumber[2972834]: spa.alsa: Path Mic ACP LED is not a volume or mute control
-Jan 02 23:08:49 myhostname wireplumber[2972834]: [42:20:53.711760428] [2972834]  INFO IPAManager ipa_manager.cpp:137 libcamera is not installed. Adding '/nix/store/src/ipa' to the IPA search path
-Jan 02 23:08:49 myhostname wireplumber[2972834]: [42:20:53.711964356] [2972834]  INFO Camera camera_manager.cpp:330 libcamera v0.5.2
-Jan 02 23:08:49 myhostname wireplumber[2972834]: [42:20:53.825507265] [2972853]  INFO Camera camera_manager.cpp:220 Adding camera '\_SB_.PCI0.GPPA.XHC1.RHUB.PRT1-1:1.0-32ac:001c' for pipeline handler uvcvideo
+Jan 02 23:13:34 myhostname wireplumber[2977075]: wp-event-dispatcher: wp_event_dispatcher_unregister_hook: assertion 'already_registered_dispatcher == self' failed
+Jan 02 23:13:34 myhostname wireplumber[2977075]: wp-event-dispatcher: wp_event_dispatcher_unregister_hook: assertion 'already_registered_dispatcher == self' failed
+Jan 02 23:13:34 myhostname wireplumber[2977075]: wp-event-dispatcher: wp_event_dispatcher_unregister_hook: assertion 'already_registered_dispatcher == self' failed
+Jan 02 23:13:34 myhostname wireplumber[2977075]: wp-event-dispatcher: wp_event_dispatcher_unregister_hook: assertion 'already_registered_dispatcher == self' failed
+Jan 02 23:13:36 myhostname wireplumber[2977075]: wp-device: SPA handle 'api.alsa.acp.device' could not be loaded; is it installed?
+Jan 02 23:13:36 myhostname wireplumber[2977075]: s-monitors: Failed to create 'api.alsa.acp.device' device
+Jan 02 23:13:36 myhostname wireplumber[2977075]: spa.alsa: Path Mic ACP LED is not a volume or mute control
+Jan 02 23:13:36 myhostname wireplumber[2977075]: [42:25:41.090037799] [2977075]  INFO IPAManager ipa_manager.cpp:137 libcamera is not installed. Adding '/nix/store/src/ipa' to the IPA search path
+Jan 02 23:13:36 myhostname wireplumber[2977075]: [42:25:41.090160757] [2977075]  INFO Camera camera_manager.cpp:330 libcamera v0.5.2
+Jan 02 23:13:36 myhostname wireplumber[2977075]: [42:25:41.203722792] [2977101]  INFO Camera camera_manager.cpp:220 Adding camera '\_SB_.PCI0.GPPA.XHC1.RHUB.PRT1-1:1.0-32ac:001c' for pipeline handler uvcvideo
 
 ### wpctl status -n
-PipeWire 'pipewire-0' [1.4.9, myuser@myhostname, cookie:2369339076]
+PipeWire 'pipewire-0' [1.4.9, myuser@myhostname, cookie:1554586636]
  └─ Clients:
-        34. .xdg-desktop-portal-wrapped         [1.4.9, myuser@myhostname, pid:2971647]
-        35. WirePlumber                         [1.4.9, myuser@myhostname, pid:2972834]
-        36. pipewire                            [1.4.9, myuser@myhostname, pid:2972833]
-        49. WirePlumber [export]                [1.4.9, myuser@myhostname, pid:2972834]
-        70. .gnome-shell-wrapped                [1.4.9, myuser@myhostname, pid:2971336]
-        71. GNOME Shell Volume Control          [1.4.9, myuser@myhostname, pid:2971336]
-        72. GNOME Volume Control Media Keys     [1.4.9, myuser@myhostname, pid:2971524]
-        73. wpctl                               [1.4.9, myuser@myhostname, pid:2973867]
+        34. .xdg-desktop-portal-wrapped         [1.4.9, myuser@myhostname, pid:2975858]
+        35. WirePlumber                         [1.4.9, myuser@myhostname, pid:2977075]
+        36. pipewire                            [1.4.9, myuser@myhostname, pid:2977074]
+        49. WirePlumber [export]                [1.4.9, myuser@myhostname, pid:2977075]
+        67. .gnome-shell-wrapped                [1.4.9, myuser@myhostname, pid:2975504]
+        68. GNOME Shell Volume Control          [1.4.9, myuser@myhostname, pid:2975504]
+        69. GNOME Volume Control Media Keys     [1.4.9, myuser@myhostname, pid:2975690]
+        70. wpctl                               [1.4.9, myuser@myhostname, pid:2977929]
 
 Audio
  ├─ Devices:
@@ -86,11 +86,10 @@
  │      52. alsa_card.pci-0000_c2_00.6          [alsa]
  │  
  ├─ Sinks:
- │  *   59. alsa_output.pci-0000_c2_00.6.HiFi__Headphones__sink [vol: 0.40]
+ │  *   59. alsa_output.pci-0000_c2_00.6.HiFi__Speaker__sink [vol: 0.40]
  │  
  ├─ Sources:
- │  *   60. alsa_input.pci-0000_c2_00.6.HiFi__Mic2__source [vol: 1.00]
- │      61. alsa_input.pci-0000_c2_00.6.HiFi__Mic1__source [vol: 1.00]
+ │  *   60. alsa_input.pci-0000_c2_00.6.HiFi__Mic1__source [vol: 1.00]
  │  
  ├─ Filters:
  │  
@@ -105,7 +104,7 @@
  ├─ Sinks:
  │  
  ├─ Sources:
- │  *   68. v4l2_input.pci-0000_c2_00.4-usb-0_1_1.0
+ │  *   65. v4l2_input.pci-0000_c2_00.4-usb-0_1_1.0
  │  
  ├─ Filters:
  │  
@@ -140,29 +139,29 @@
     api.alsa.pcm.stream = "playback"
     audio.channels = "2"
     audio.position = "FL,FR"
-    card.profile.device = "3"
+    card.profile.device = "0"
   * client.id = "49"
     clock.quantum-limit = "8192"
     device.api = "alsa"
     device.bus = "pci"
     device.class = "sound"
     device.icon-name = "audio-card-analog"
-    device.icon_name = "audio-headphones"
+    device.icon_name = "audio-speakers"
   * device.id = "52"
-    device.profile.description = "Headphones"
-    device.profile.name = "HiFi: Headphones: sink"
+    device.profile.description = "Speaker"
+    device.profile.name = "HiFi: Speaker: sink"
     device.routes = "1"
   * factory.id = "19"
     factory.name = "api.alsa.pcm.sink"
     library.name = "audioconvert/libspa-audioconvert"
   * media.class = "Audio/Sink"
-  * node.description = "Family 17h/19h/1ah HD Audio Controller Headphones"
+  * node.description = "Family 17h/19h/1ah HD Audio Controller Speaker"
     node.driver = "true"
     node.loop.name = "data-loop.0"
-  * node.name = "alsa_output.pci-0000_c2_00.6.HiFi__Headphones__sink"
+  * node.name = "alsa_output.pci-0000_c2_00.6.HiFi__Speaker__sink"
   * node.nick = "ALC285 Analog"
     node.pause-on-idle = "false"
-  * object.path = "alsa:acp:Generic_1:3:playback"
+  * object.path = "alsa:acp:Generic_1:0:playback"
   * object.serial = "59"
     port.group = "playback"
   * priority.driver = "1000"
@@ -170,18 +169,16 @@
 
 ### wpctl inspect @DEFAULT_AUDIO_SOURCE@
 id 60, type PipeWire:Interface:Node
-    alsa.card = "2"
-    alsa.card_name = "HD-Audio Generic"
+    alsa.card = "3"
+    alsa.card_name = "acp-pdm-mach"
     alsa.class = "generic"
-    alsa.components = "HDA:10ec0285,f111000d,00100002"
     alsa.device = "0"
-    alsa.driver_name = "snd_hda_intel"
-    alsa.id = "ALC285 Analog"
-    alsa.long_card_name = "HD-Audio Generic at 0x84dc0000 irq 153"
+    alsa.driver_name = "snd_acp_legacy_mach"
+    alsa.id = "DMIC capture dmic-hifi-0"
+    alsa.long_card_name = "Framework-Laptop16AMDRyzenAI300Series-A9-FRANMHCP09"
     alsa.mixer_device = "_ucm0004.hw:Generic_1"
-    alsa.mixer_name = "Realtek ALC285"
-    alsa.name = "ALC285 Analog"
-    alsa.resolution_bits = "16"
+    alsa.name = ""
+    alsa.resolution_bits = "32"
     alsa.subclass = "generic-mix"
     alsa.subdevice = "0"
     alsa.subdevice_name = "subdevice #0"
@@ -189,7 +186,7 @@
     api.alsa.card.longname = "HD-Audio Generic at 0x84dc0000 irq 153"
     api.alsa.card.name = "HD-Audio Generic"
     api.alsa.open.ucm = "true"
-    api.alsa.path = "hw:Generic_1"
+    api.alsa.path = "hw:acppdmmach"
     api.alsa.pcm.card = "2"
     api.alsa.pcm.stream = "capture"
     audio.channels = "2"
@@ -203,18 +200,18 @@
     device.icon-name = "audio-card-analog"
     device.icon_name = "audio-input-microphone"
   * device.id = "52"
-    device.profile.description = "Stereo Microphone"
-    device.profile.name = "HiFi: Mic2: source"
+    device.profile.description = "Digital Microphone"
+    device.profile.name = "HiFi: Mic1: source"
     device.routes = "1"
   * factory.id = "19"
     factory.name = "api.alsa.pcm.source"
     library.name = "audioconvert/libspa-audioconvert"
   * media.class = "Audio/Source"
-  * node.description = "Family 17h/19h/1ah HD Audio Controller Stereo Microphone"
+  * node.description = "Family 17h/19h/1ah HD Audio Controller Digital Microphone"
     node.driver = "true"
     node.loop.name = "data-loop.0"
-  * node.name = "alsa_input.pci-0000_c2_00.6.HiFi__Mic2__source"
-  * node.nick = "ALC285 Analog"
+  * node.name = "alsa_input.pci-0000_c2_00.6.HiFi__Mic1__source"
+  * node.nick = "Digital Microphone"
     node.pause-on-idle = "false"
   * object.path = "alsa:acp:Generic_1:1:capture"
   * object.serial = "60"
@@ -389,9 +386,5 @@
 ### nix shell nixpkgs#alsa-utils -c alsaucm -n -b -  (open hw:2, set HiFi, list devices + devstatus)
   0: Mic1
     Digital Microphone
-  1: Headphones
-    Headphones
-  2: Mic2
-    Stereo Microphone
-  3: Speaker
+  1: Speaker
     Speaker
```

</details>

I can provide full outputs (before/after) on request.

The workaround is implemented through patching just those two files in `pkgs.alsa-ucm-conf`, symlinking the rest into an updated package, and overriding the `ALSA_CONFIG_UCM2` environment variable for 3 audio-related systemd services: `pipewire`, `pipewire-pulse`, and `wireplumber`. The env variable is not really well documented but referred to e.g. [here](https://docs.chrultrabook.com/docs/installing/distros.html#alsa-ucm2-for-chromebooks).

<details>

<summary>Original (language model-generated) description for this PR</summary>

## Fix phantom Headphones + silent HDA capture devices on Framework 16 (AMD AI 300) by guarding generic HDA UCM devices

This machine is **jackless** (no 3.5mm port available to test), and the generic HDA UCM profile was creating a **phantom `Headphones` device** with higher priority than `Speaker`, causing PipeWire/WirePlumber to select it as the default sink. The same generic profile also created **HDA capture sources that record silence**, causing confusing/incorrect default microphone selection.

This PR adds a **hardware-scoped workaround** for Framework 16 AMD AI 300 series systems by providing a patched UCM2 tree via `ALSA_CONFIG_UCM2` (without disabling UCM globally).

### Evidence

The generic HDA UCM profile defines `Headphones` unconditionally with priority 200 while `Speaker` is conditional and priority 100, so `Headphones` wins even if it does not exist on the hardware. 

### Before workaround

Default sink was the phantom `Headphones` route:

```sh
$ wpctl status -n | sed -n '/Audio/,/Video/p'
Audio
 ├─ Sinks:
 │  *   ... alsa_output.pci-0000_c2_00.6.HiFi__Headphones__sink ...
 ├─ Sources:
 │  *   ... HiFi__Mic2__source ...
 │      ... HiFi__Mic1__source ...
```

Analog HDA capture devices record silence, while DMIC works:

```sh
nix shell nixpkgs#alsa-utils -c arecord -D hw:2,0 -f S16_LE -c2 -r48000 -d 5 hda0.wav  # silence
nix shell nixpkgs#alsa-utils -c arecord -D hw:2,2 -f S16_LE -c2 -r48000 -d 5 hda2.wav  # silence
nix shell nixpkgs#alsa-utils -c arecord -D hw:3,0 -f S32_LE -c2 -r48000 -d 5 dmic.wav  # sound
```

### After workaround

Only `Speaker` remains as the sink, and only the working DMIC-backed source remains:

```sh
$ wpctl status -n | sed -n '/Audio/,/Video/p'
Audio
 ├─ Sinks:
 │  *   ... alsa_output.pci-0000_c2_00.6.HiFi__Speaker__sink ...
 ├─ Sources:
 │  *   ... alsa_input.pci-0000_c2_00.6.HiFi__Mic1__source ...
```

Playback sanity check:

```sh
$ nix shell nixpkgs#pipewire -c pw-cat --playback dmic.wav  # plays correctly
```

### Implementation

* Build a patched copy of the UCM2 tree at activation time (symlink most files + copy files-to-patch + apply patches).
* Set `ALSA_CONFIG_UCM2` for:

  * `environment.sessionVariables`
  * systemd user units: `pipewire`, `pipewire-pulse`, `wireplumber`

### Notes

* Existing users may have WirePlumber defaults cached; if the fix doesn’t “take” immediately, clearing defaults/state helps:

```sh
wpctl clear-default
rm -rf ~/.local/state/wireplumber
systemctl --user restart wireplumber pipewire pipewire-pulse
```
</details>

### Related

This issue is discussed in https://github.com/NixOS/nixos-hardware/issues/1603, where disabling UCM globally was suggested as a workaround; this PR keeps UCM enabled and instead prevents phantom devices from being created. I previously proposed disabling UCM globally in https://github.com/NixOS/nixos-hardware/pull/1717; that PR can now probably be closed.

Framework forum related links:

* Thread about this issue: https://community.frame.work/t/no-sound-from-speaker-but-audio-expansion-module-and-bluetooth-headphones-works-how-to-troubleshoot/79259
* My request for feedback: https://community.frame.work/t/nixos-on-the-framework-laptop-16/46743/208

# Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input
- [ ] Get confirmation from at least one other FW16 owner that this fixes the same problem for them on their machine.
- [ ] Set `ALSA_CONFIG_UCM2` conditionally for each of the systemd services, instead of for all 3 conditionally on just `pipewire` being enabled?
- [x] Ideally, get someone familiar with [`alsa-ucm-conf`](https://github.com/alsa-project/alsa-ucm-conf) to review the patch.

