### PR TITLE
Add System76 Galago Pro (galp3) module

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ See code for all available configurations.
 | [System76 (generic)](system76)                                                    | `<nixos-hardware/system76>`                             | `system76`                             |
 | [System76 Darter Pro 6](system76/darp6)                                           | `<nixos-hardware/system76/darp6>`                       | `system76-darp6`                       |
 | [System76 Gazelle 18](system76/gaze18)                                            | `<nixos-hardware/system76/gaze18>`                      | `system76-gaze18`                      |
+| [System76 Galago Pro 3](system76/galp3)                                           | `<nixos-hardware/system76/galp3>`                       | `system76-galp3`                       |
 | [System76 Galago Pro 5](system76/galp5-1650)                                      | `<nixos-hardware/system76/galp5-1650>`                  | `system76-galp5-1650`                  |
 | [System76 Thelio Mega](system76/thelio-mega)                                      | `<nixos-hardware/system76/thelio-mega>`                 | `system76-thelio-mega`                 |
 | [Toshiba Chromebook 2 `swanky`](toshiba/swanky)                                   | `<nixos-hardware/toshiba/swanky>`                       | `toshiba-swanky`                       |

--- a/system76/galp3/default.nix
+++ b/system76/galp3/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ../.
+    # not import ../../common/pc/laptop since tlp and ppd both conflict with system76-power
+    ../../common/pc/ssd
+    ../../common/cpu/intel/kaby-lake
+    ../../common/hidpi.nix
+  ];
+}


### PR DESCRIPTION
###### Description of changes
Add support for galp3 laptop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

