### PR TITLE
starfive visionfive2: cleanup kernel requirements

### DIFF
--- a/starfive/visionfive/v2/default.nix
+++ b/starfive/visionfive/v2/default.nix
@@ -11,8 +11,6 @@
 
   boot = {
     consoleLogLevel = lib.mkDefault 7;
-    # Switch to default as soon they reach >= 6.11
-    kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
     initrd.availableKernelModules = [ "dw_mmc_starfive" ];
 
@@ -31,10 +29,4 @@
     };
   };
 
-  assertions = [
-    {
-      assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.11";
-      message = "The VisionFive 2 requires at least mainline kernel version 6.11 for minimum hardware support.";
-    }
-  ];
 }


### PR DESCRIPTION
###### Description of changes

the latest stable kernel in nixos is 6.12 so we do not need the check anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

