### PR TITLE
gpd-pocket4: fix suspend and device type

### DIFF
--- a/gpd/pocket-4/default.nix
+++ b/gpd/pocket-4/default.nix
@@ -33,4 +33,17 @@ in
 
   # More HiDPI settings
   services.xserver.dpi = 343;
+
+  # disable fingerprint reader, it currently has no linux drivers anyways and also blocks suspend (at least on my system)
+  services.udev.extraRules = /* udev */ ''
+    ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2808", ATTR{idProduct}=="0752", ATTR{authorized}="0"
+  '';
+
+  # classify device as convertible (see hostnamectl)
+  environment.etc.machine-info = {
+    text = ''
+      CHASSIS=convertible
+    '';
+    mode = "0440";
+  };
 }


### PR DESCRIPTION
###### Description of changes

Suspend got blocked by the fingerprint reader, (like 9 out of 10 times) This is probably caused, because there is not linux driver for the device,

I am unsure whether this is suited for nixos-hardware?
```nix
systemd.tpm2.enable = false;
boot.initrd.systemd.tpm2.enable = false;
````
If I don't disable the tpm it delays the boot for like 1.5min until the systemd timeout is reached. I don't know if this happens because I did not configure it properly (I actually did not configure anything tpm related) or because it's not supported?

Maybe some other GPD Pocket 4 users could verify the changes?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

