### PR TITLE
Add DC ROMA II

### DIFF
--- a/deepcomputing/roma-ii/README.md
+++ b/deepcomputing/roma-ii/README.md
@@ -1,0 +1,17 @@
+# DC ROMA II
+
+The DC ROMA II is a RISC-V laptop inside of a Framework chassis.
+
+## Features
+
+- Display: **untested**
+  - X11: **untested**
+  - Wayland: **untested**
+- GPU driver: **untested**
+- WiFi: **untested**
+- Sound: **untested**
+- Fingerprint: **untested**
+
+## Installing
+
+This module is designed to install NixOS using UEFI. The installation process is no different than installing NixOS on an x86_64 or UEFI aarch64 system. The only requirement is including this module.

--- a/deepcomputing/roma-ii/default.nix
+++ b/deepcomputing/roma-ii/default.nix
@@ -1,0 +1,178 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  hardware = {
+    deviceTree = {
+      enable = true;
+      name = "eswin/eic7702-deepcomputing-fml13v03.dtb";
+    };
+    firmware = [
+      (pkgs.runCommand "firmware-fml13v03" { } ''
+        mkdir -p $out/lib/firmware
+        cp ${config.system.build.secboot}/*.bin $out/lib/firmware
+      '')
+    ];
+  };
+
+  boot.kernelPackages = lib.mkDefault (
+    pkgs.linuxPackagesFor (
+      pkgs.buildLinux rec {
+        version = "6.6.18";
+        modDirVersion = version;
+        src = pkgs.fetchFromGitHub {
+          owner = "DC-DeepComputing";
+          repo = "fml13v03_linux";
+          rev = "7842fe7eb2ccc33fc7002dd2a04e575831b921c3";
+          hash = "sha256-/ysRPYqIW1CJ0Itp1cVkQk5d3mzqqXYI4rleCIDY6yE=";
+        };
+        defconfig = "fml13v03_defconfig";
+        kernelPatches = [
+          {
+            name = "fix-eswin-ai-dsp";
+            patch = ./linux-fix-eswin-ai-dsp.patch;
+          }
+          {
+            name = "fix-eswin-media-ext";
+            patch = ./linux-fix-eswin-media-ext.patch;
+          }
+          {
+            name = "fix-ap12275";
+            patch = ./linux-fix-ap12275.patch;
+          }
+          {
+            name = "fix-eswin-mem";
+            patch = ./linux-fix-eswin-mem.patch;
+          }
+          {
+            name = "fix-eswin-headers";
+            patch = ./linux-fix-eswin-headers.patch;
+          }
+          {
+            name = "fix-eswin-dev-buff";
+            patch = ./linux-fix-eswin-dev-buff.patch;
+          }
+          {
+            name = "fix-eswin-codec-conflict";
+            patch = ./linux-fix-eswin-codec-conflict.patch;
+          }
+          {
+            name = "fix-eswin-sysfs";
+            patch = ./linux-fix-eswin-sysfs.patch;
+          }
+        ];
+        structuredExtraConfig = with lib.kernel; {
+          DWC_MIPI_TC_DPHY_GEN3 = no;
+          DEBUG_INFO_BTF = lib.mkForce no;
+        };
+      }
+    )
+  );
+
+  system.build = {
+    uboot = pkgs.buildUBoot {
+      defconfig = "deepcomputing-fml13v03_defconfig";
+      extraMeta.platforms = [ "riscv64-linux" ];
+      filesToInstall = [
+        "u-boot.bin"
+        "u-boot.dtb"
+      ];
+      version = "2024.01";
+      src = pkgs.fetchFromGitHub {
+        owner = "DC-DeepComputing";
+        repo = "fml13v03_u-boot";
+        rev = "d68387b6204343f98d82164fb62613029dfc8528";
+        hash = "sha256-cgVjGXityxsnqs/onLJ0E6tlLI4YH1LALUA/rM+LPUg=";
+      };
+      NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-int-conversion";
+    };
+    opensbi =
+      (pkgs.opensbi.overrideAttrs (
+        _f: p: {
+          src = pkgs.fetchFromGitHub {
+            owner = "DC-DeepComputing";
+            repo = "fml13v03_opensbi";
+            rev = "37fc216159a439a4810900a109f45aa4b54e4b3a";
+            hash = "sha256-RvZapBfQAokxVMNT2VU0tJqeI4LxMQTs1n+z74mR8XU=";
+          };
+
+          makeFlags = p.makeFlags ++ [
+            "CHIPLET=BR2_CHIPLET_2"
+            "CHIPLET_DIE_AVAILABLE=BR2_CHIPLET_1_DIE1_AVAILABLE"
+            "PLATFORM_CLUSTER_X_CORE=BR2_CLUSTER_4_CORE"
+            "MEM_MODE=BR2_MEMMODE_FLAT"
+          ];
+        }
+      )).override
+        {
+          withPlatform = "eswin/eic770x";
+          withPayload = "${config.system.build.uboot}/u-boot.bin";
+          withFDT = "${config.system.build.uboot}/u-boot.dtb";
+        };
+    secboot = pkgs.pkgsCross.riscv64-embedded.stdenv.mkDerivation (_finalAttrs: {
+      pname = "secboot";
+      version = "0-unstable-2025-07-27";
+
+      src = pkgs.fetchFromGitHub {
+        owner = "DC-DeepComputing";
+        repo = "fml13v03_secboot_fw";
+        rev = "16edc598e626aae096e3dfe16f4781f6731a8dec";
+        hash = "sha256-Fl1MwADKfM453Em+K6QBMfaHtxWK7Ehr/86+JmcNVY0=";
+      };
+
+      NIX_CFLAGS_COMPILE = "-no-pie";
+
+      makeFlags = [
+        "CROSS_COMPILE=${pkgs.pkgsCross.riscv64-embedded.stdenv.cc.targetPrefix}"
+        "BIN_DIR_FOR_DOWNLOAD=${placeholder "out"}"
+      ];
+
+      preBuild = ''
+        mkdir -p $out
+      '';
+
+      dontInstall = true;
+    });
+    firmware-tools =
+      let
+        pkgsx86_64 =
+          if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then
+            pkgs.buildPlatform
+          else
+            pkgs.pkgsCross.gnu64;
+      in
+      pkgsx86_64.stdenv.mkDerivation (finalAttrs: {
+        name = "firmware-eswin-fml13v03";
+
+        src = pkgsx86_64.fetchFromGitHub {
+          owner = "DC-DeepComputing";
+          repo = "fml13v03";
+          rev = "e93f8903f9eb9fc34e9130881f56d6f2a08205c2";
+          hash = "sha256-bMAYGA9/Ml5a0Eynmvcl+JGMZRf+1Uka43qCjxswO/s=";
+        };
+
+        sourceRoot = "${finalAttrs.src.name}/source";
+
+        nativeBuildInputs = [
+          pkgs.autoPatchelfHook
+        ];
+
+        buildInputs = [
+          pkgsx86_64.stdenv.cc.cc
+        ];
+
+        installPhase = ''
+          mkdir -p $out/bin
+          mv firmware-eswin/nsign $out/bin/nsign
+
+          patchelf --set-interpreter ${pkgsx86_64.stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 $out/bin/nsign
+
+          mkdir -p $out/lib
+          mv firmware-eswin $out/lib/$name
+        '';
+      });
+  };
+}

--- a/deepcomputing/roma-ii/linux-fix-ap12275.patch
+++ b/deepcomputing/roma-ii/linux-fix-ap12275.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/net/wireless/ap12275/Makefile b/drivers/net/wireless/ap12275/Makefile
+index 9379c7f122b7..ed0bf8aa7438 100644
+--- a/drivers/net/wireless/ap12275/Makefile
++++ b/drivers/net/wireless/ap12275/Makefile
+@@ -460,7 +460,7 @@ endif
+ endif
+ 
+ ARCH ?= riscv
+-BCMDHD_ROOT = $(src)
++BCMDHD_ROOT = $(srctree)/drivers/net/wireless/ap12275
+ #$(warning "BCMDHD_ROOT=$(BCMDHD_ROOT)")
+ EXTRA_CFLAGS = $(DHDCFLAGS)
+ EXTRA_CFLAGS += -DDHD_COMPILED=\"$(BCMDHD_ROOT)\"

--- a/deepcomputing/roma-ii/linux-fix-eswin-ai-dsp.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-ai-dsp.patch
@@ -1,0 +1,36 @@
+From dd790e6e69157abd948d7d418b09cdeb5cb5bdca Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Date: Mon, 7 Jul 2025 09:39:57 +0200
+Subject: [PATCH] eswin/ai_driver/dsp/dsp_platform: add missing include
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Avoid a build error:
+
+    drivers/soc/eswin/ai_driver/dsp/dsp_platform.c:
+    In function ‘es_dsp_clk_disable’:
+    drivers/soc/eswin/ai_driver/dsp/dsp_platform.c:276:19: error:
+    implicit declaration of function ‘__clk_is_enabled’;
+    did you mean ‘clk_enable’? [-Wimplicit-function-declaration]
+      276 |         enabled = __clk_is_enabled(hw->subsys->aclk);
+          |                   ^~~~~~~~~~~~~~~~
+          |                   clk_enable
+
+Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+---
+ drivers/soc/eswin/ai_driver/dsp/dsp_platform.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/soc/eswin/ai_driver/dsp/dsp_platform.c b/drivers/soc/eswin/ai_driver/dsp/dsp_platform.c
+index 61009112362c..155b31aace73 100644
+--- a/drivers/soc/eswin/ai_driver/dsp/dsp_platform.c
++++ b/drivers/soc/eswin/ai_driver/dsp/dsp_platform.c
+@@ -20,6 +20,7 @@
+  */
+ 
+ #include <linux/clk.h>
++#include <linux/clk-provider.h>
+ #include <linux/interrupt.h>
+ #include <linux/io.h>
+ #include <linux/module.h>

--- a/deepcomputing/roma-ii/linux-fix-eswin-codec-conflict.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-codec-conflict.patch
@@ -1,0 +1,23 @@
+diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
+index 319d89477279..6a7b1d939368 100644
+--- a/sound/soc/codecs/Kconfig
++++ b/sound/soc/codecs/Kconfig
+@@ -1060,15 +1060,18 @@ config SND_SOC_ES8326
+ 
+ config SND_SOC_ES8328
+ 	tristate
++  depends on !ESWIN_SND_ES8388_CODEC
+ 
+ config SND_SOC_ES8328_I2C
+ 	tristate "Everest Semi ES8328 CODEC (I2C)"
+ 	depends on I2C
++  depends on !ESWIN_SND_ES8388_CODEC
+ 	select SND_SOC_ES8328
+ 
+ config SND_SOC_ES8328_SPI
+ 	tristate "Everest Semi ES8328 CODEC (SPI)"
+ 	depends on SPI_MASTER
++  depends on !ESWIN_SND_ES8388_CODEC
+ 	select SND_SOC_ES8328
+ 
+ config SND_SOC_GTM601

--- a/deepcomputing/roma-ii/linux-fix-eswin-dev-buff.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-dev-buff.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/memory/eswin/es_dev_buf/Makefile b/drivers/memory/eswin/es_dev_buf/Makefile
+index 3ba183ff62bd..3c65ec4c1fae 100644
+--- a/drivers/memory/eswin/es_dev_buf/Makefile
++++ b/drivers/memory/eswin/es_dev_buf/Makefile
+@@ -1,5 +1,5 @@
+ obj-$(CONFIG_ESWIN_DEV_DMA_BUF) += es_dev_buf.o
+ 
+-ES_DEV_DMA_BUF_HEADER := drivers/memory/eswin/es_dev_buf/include/linux
+-COPY_HEADERS:=$(shell cp $(ES_DEV_DMA_BUF_HEADER)/*.h include/linux)
++ES_DEV_DMA_BUF_HEADER := $(srctree)/drivers/memory/eswin/es_dev_buf/include/linux
++COPY_HEADERS:=$(shell cp $(ES_DEV_DMA_BUF_HEADER)/*.h $(srctree)/include/linux)
+ 

--- a/deepcomputing/roma-ii/linux-fix-eswin-headers.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-headers.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/memory/eswin/es_proc/Makefile b/drivers/memory/eswin/es_proc/Makefile
+index 2afd49103e81..9b0bd6e25897 100644
+--- a/drivers/memory/eswin/es_proc/Makefile
++++ b/drivers/memory/eswin/es_proc/Makefile
+@@ -2,6 +2,6 @@
+ obj-$(CONFIG_ESWIN_PROC)	+= es_proc.o
+ ccflags-y := -DDEBUG
+ 
+-ES_PROC_HEADER := drivers/memory/eswin/es_proc/include/linux
++ES_PROC_HEADER := $(srctree)/drivers/memory/eswin/es_proc/include/linux
+ 
+-COPY_HEADERS := $(shell cp $(ES_PROC_HEADER)/*.h include/linux)
++COPY_HEADERS := $(shell cp $(ES_PROC_HEADER)/*.h $(srctree)/include/linux)

--- a/deepcomputing/roma-ii/linux-fix-eswin-media-ext.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-media-ext.patch
@@ -1,0 +1,21 @@
+diff --git a/drivers/staging/media/eswin/es-media-ext/Makefile b/drivers/staging/media/eswin/es-media-ext/Makefile
+index 326e4316fbd3..d1c438ef1b33 100644
+--- a/drivers/staging/media/eswin/es-media-ext/Makefile
++++ b/drivers/staging/media/eswin/es-media-ext/Makefile
+@@ -1,10 +1,10 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+-ccflags-y := -I$(src)
+-ccflags-y += -I$(src)/common/
+-ccflags-y += -I$(src)/module/
+-ccflags-y += -I$(src)/chn/
+-ccflags-y += -I$(src)/proc/
+-ccflags-y += -I$(src)/include/
++ccflags-y := -I$(srctree)/drivers/staging/media/eswin/es-media-ext
++ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/common/
++ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/module/
++ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/chn/
++ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/proc/
++ccflags-y += -I$(srctree)/drivers/staging/media/eswin/es-media-ext/include/
+ 
+ es_media_ext_drv-objs := es_media_ext_drv_main.o \
+ 						./chn/dev_channel.o	\

--- a/deepcomputing/roma-ii/linux-fix-eswin-mem.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-mem.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/memory/eswin/Makefile b/drivers/memory/eswin/Makefile
+index 9f256dc64dad..e3d2a67aac3a 100644
+--- a/drivers/memory/eswin/Makefile
++++ b/drivers/memory/eswin/Makefile
+@@ -11,6 +11,6 @@ obj-$(CONFIG_ESWIN_IOMMU_RSV)			+= es_iommu_rsv/
+ obj-$(CONFIG_ESWIN_DMA_MEMCP)           += es_dma_memcp/
+ obj-$(CONFIG_ESWIN_MALLOC_DMABUF)       += es_malloc_dmabuf/
+ 
+-ES_MEM_HEADER := drivers/memory/eswin/
++ES_MEM_HEADER := $(srctree)/drivers/memory/eswin/
+ 
+-COPY_HEADERS := $(shell cp $(ES_MEM_HEADER)/*.h include/linux)
++COPY_HEADERS := $(shell cp $(ES_MEM_HEADER)/*.h $(srctree)/include/linux)

--- a/deepcomputing/roma-ii/linux-fix-eswin-sysfs.patch
+++ b/deepcomputing/roma-ii/linux-fix-eswin-sysfs.patch
@@ -1,0 +1,27 @@
+diff --git a/drivers/media/platform/eswin/mipi-csi2/Makefile b/drivers/media/platform/eswin/mipi-csi2/Makefile
+index 60d981dc940b..b1eb0753d366 100755
+--- a/drivers/media/platform/eswin/mipi-csi2/Makefile
++++ b/drivers/media/platform/eswin/mipi-csi2/Makefile
+@@ -2,15 +2,15 @@
+ #
+ # Makefile for Synopsys DWC Platform drivers
+ #
+-# ifeq ($(CONFIG_DWC_MIPI_TC_DPHY_GEN3),y)#
+-# 	dw-csi-objs += dw-csi-sysfs.o
+-# endif
++ifeq ($(CONFIG_DWC_MIPI_TC_DPHY_GEN3),m)#
++ 	dw-csi-objs += dw-csi-sysfs.o
++endif
+ obj-$(CONFIG_DWC_MIPI_CSI2_HOST) += dw-csi.o
+ dw-csi-objs := dw-csi-plat.o dw-mipi-csi.o
+ 
+ # dw-dphy-objs := dw-dphy-plat.o dw-dphy-rx.o
+-# ifeq ($(CONFIG_DWC_MIPI_TC_DPHY_GEN3),y)
+-# 	dw-dphy-objs += dw-dphy-sysfs.o
+-# endif
++ifeq ($(CONFIG_DWC_MIPI_TC_DPHY_GEN3),m)
++	dw-dphy-objs += dw-dphy-sysfs.o
++endif
+ # obj-$(CONFIG_DWC_MIPI_DPHY_GEN3) += dw-dphy.o
+-#obj-$(CONFIG_ESWIN_MIPI_DMA) += eswin-mipi-dma.o
++# obj-$(CONFIG_ESWIN_MIPI_DMA) += eswin-mipi-dma.o

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
           asus-zephyrus-gu605my = import ./asus/zephyrus/gu605my;
           beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
           chuwi-minibook-x = import ./chuwi/minibook-x;
+          dc-roma-ii = import ./deepcomputing/roma-ii;
           deciso-dec = import ./deciso/dec;
           dell-e7240 = deprecated "1326" "dell-e7240" (import ./dell/e7240);
           dell-g3-3779 = import ./dell/g3/3779;


### PR DESCRIPTION
###### Description of changes

Adds initial support for the DC ROMA II laptop from DeepComputing. Over the next week, I will be testing the system out more.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

