### PR TITLE
framework-13-amd-ai-300-series: disable ALSA UCM profiles by default

### DIFF
--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -22,5 +22,13 @@
     boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") (
       lib.mkDefault pkgs.linuxPackages_latest
     );
+
+    # Disable the broken ALSA UCM profiles by default.
+    # See https://github.com/NixOS/nixos-hardware/issues/1603
+    services.pipewire.wireplumber.extraConfig."10-no-ucm" = {
+      "monitor.alsa.properties" = {
+        "alsa.use-ucm" = lib.mkDefault false;
+      };
+    };
   };
 }


### PR DESCRIPTION
Fīxes https://github.com/NixOS/nixos-hardware/issues/1603 for Framework 13 AMD AI series laptops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

