### PR TITLE
Framework 13 AI 300: Disabling AMD ACP sound card

### DIFF
--- a/framework/13-inch/amd-ai-300-series/default.nix
+++ b/framework/13-inch/amd-ai-300-series/default.nix
@@ -22,5 +22,15 @@
     boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.15") (
       lib.mkDefault pkgs.linuxPackages_latest
     );
+
+    # The framework bios wrongly reports the ACP device as wired, causing
+    # issues with alsa ucm, but also generally adding a phantom interface
+    # to the system.
+    #
+    # See discussion in https://github.com/NixOS/nixos-hardware/issues/1603
+    boot.blacklistedKernelModules = [
+      "snd_acp70"
+      "snd_acp_pci"
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This issue became more obvious due to alsa-ucm profiles horribly misassigning a non-existent device as the default microphone and juggling profiles for the devices in a very weird way recently.

The first hotfix was this: https://github.com/NixOS/nixos-hardware/pull/1732

But upon more discussion it seems to be a Framework bios bug that falsely reports an AMD ACP as exitent and wired up via ACPI.

Until this is fixed at the source, the best way foward is to just blacklist the module.

I have tried this change now on 4 devices and and feel confident enough about it working well for most users.

See this discussion for all the details: https://github.com/NixOS/nixos-hardware/issues/1603

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

