### PR TITLE
Add lenovo-thinkpad-t14-amd-gen6

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`         | `lenovo-thinkpad-t14-amd-gen3`         |
 | [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         | `lenovo-thinkpad-t14-amd-gen4`         |
 | [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         | `lenovo-thinkpad-t14-amd-gen5`         |
+| [Lenovo ThinkPad T14 AMD Gen 6](lenovo/thinkpad/t14/amd/gen6)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen6>`         | `lenovo-thinkpad-t14-amd-gen6`         |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                                        | `<nixos-hardware/lenovo/thinkpad/t14>`                  | `lenovo-thinkpad-t14`                  |
 | [Lenovo ThinkPad T14 Intel Gen 1](lenovo/thinkpad/t14/intel/gen1)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1>`       | `lenovo-thinkpad-t14-intel-gen1`       |
 | [Lenovo ThinkPad T14 Intel Gen 1 (Nvidia)](lenovo/thinkpad/t14/intel/gen1/nvidia) | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1/nvidia>`| `lenovo-thinkpad-t14-intel-gen1-nvidia`|

--- a/flake.nix
+++ b/flake.nix
@@ -276,6 +276,7 @@
           lenovo-thinkpad-t14-amd-gen3 = import ./lenovo/thinkpad/t14/amd/gen3;
           lenovo-thinkpad-t14-amd-gen4 = import ./lenovo/thinkpad/t14/amd/gen4;
           lenovo-thinkpad-t14-amd-gen5 = import ./lenovo/thinkpad/t14/amd/gen5;
+          lenovo-thinkpad-t14-amd-gen6 = import ./lenovo/thinkpad/t14/amd/gen6;
           lenovo-thinkpad-t14-intel-gen1 = import ./lenovo/thinkpad/t14/intel/gen1;
           lenovo-thinkpad-t14-intel-gen1-nvidia = import ./lenovo/thinkpad/t14/intel/gen1/nvidia;
           lenovo-thinkpad-t14-intel-gen6 = import ./lenovo/thinkpad/t14/intel/gen6;

--- a/lenovo/thinkpad/t14/amd/gen6/default.nix
+++ b/lenovo/thinkpad/t14/amd/gen6/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+{
+  imports = [
+    ../.
+    ../../../../../common/cpu/amd/pstate.nix
+    ../../../../../common/wifi/mediatek/mt7925
+  ];
+
+  # recommended for the mt7925 wireless adapter
+  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.18") pkgs.linuxPackages_latest;
+
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Add configuration for the Lenovo ThinkPad T14 AMD Gen 6, based on that of the Gen 5.

This device uses the mt7925 wireless adapter, so I've imported the relevant common module. My own experience suggests that importing the iwd module from that section makes matters worse, so I have not used that.

The `acpi.ec_no_wakeup=1` kernel param needed for gen5 no longer seems relevant as far as I can tell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

###### Additional notes

Closes #1742

