### PR TITLE
machc-wa: updated the config to match up with the current common modules

### DIFF
--- a/huawei/machc-wa/README.md
+++ b/huawei/machc-wa/README.md
@@ -1,3 +1,5 @@
 # Huawei Matebook X Pro (2020)
 
 This is a very standard device that needs little configuration. The module mainly imports the common modules for its CPU, GPU, SSD etc. and enables ppd for power management. Nvidia prime offload is also enabled. This configuration should work with all Matebook X Pro models from 2020 (MACHC-WA*) other than MACHC-WAH9L as it does not contain the Nvidia GPU.
+
+Please also take a look at the `hardware.nvidia.primeBatterySaverSpecialisation ` to disable the dGPU to save battery.

--- a/huawei/machc-wa/default.nix
+++ b/huawei/machc-wa/default.nix
@@ -7,22 +7,19 @@
 {
   imports = [
     ../../common/cpu/intel/comet-lake
-    ../../common/gpu/nvidia
+    ../../common/gpu/intel/comet-lake
+    ../../common/gpu/nvidia/pascal
     ../../common/gpu/nvidia/prime.nix
-    ../../common/hidpi.nix
     ../../common/pc/laptop
     ../../common/pc/ssd
   ];
 
   hardware.nvidia = {
     modesetting.enable = lib.mkDefault true;
-    open = lib.mkDefault false;
     nvidiaSettings = lib.mkDefault true;
     prime = {
       intelBusId = "PCI:0:2:0";
       nvidiaBusId = "PCI:1:0:0";
     };
   };
-
-  services.power-profiles-daemon.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
I updated the Huawei Matebook Pro X config I did a while ago, the machine was unused but I have started to use it again and needed to update the config.

###### Things done
Added the comet-lake gpu module and changed the source of the nvidia common module to `common/gpu/nvidia/pascal`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

