### PR TITLE
lenovo/thinkpad/x13s: add options and use other options

### DIFF
--- a/lenovo/thinkpad/x13s/README.md
+++ b/lenovo/thinkpad/x13s/README.md
@@ -7,4 +7,23 @@
 The MIPI camera does work, however, it's not accelerated by the ISP and therefore image processing is done on CPU.
 
 ## Wifi and Bluetooth MAC addresses
-Currently they need to be set manually
+Wifi mac address is automatically generated.
+
+Bluetooth mac is automatically generated.
+
+## TPM
+Currently TPM does not work. Disable in your config to help boot speed.
+
+```nix
+systemd.tpm2.enable = false;
+```
+
+## Recommends configurations
+
+```nix
+systemd.tpm2.enable = false;
+hardware.bluetooth.enable = true;
+networking.modemmanager.enable = true;
+networking.networkmanager.enable = true;
+boot.loader.systemd-boot.enable = true;
+```

--- a/lenovo/thinkpad/x13s/README.md
+++ b/lenovo/thinkpad/x13s/README.md
@@ -7,9 +7,9 @@
 The MIPI camera does work, however, it's not accelerated by the ISP and therefore image processing is done on CPU.
 
 ## Wifi and Bluetooth MAC addresses
-Wifi mac address is automatically generated.
+Wi-Fi MAC address is automatically generated.
 
-Bluetooth mac is automatically generated.
+Bluetooth MAC is automatically generated.
 
 ## TPM
 Currently TPM does not work. Disable in your config to help boot speed.

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -89,6 +89,11 @@ in
               $[RANDOM%256])"
           fi
 
+          while ! [ -d /sys/class/bluetooth ] ; do
+            echo "waiting for bluetooth"
+            sleep 5
+          done
+
           echo "assigning mac: $BLUETOOTH_MAC"
           yes | ${config.hardware.bluetooth.package}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
         '';
@@ -96,6 +101,12 @@ in
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
+        };
+      };
+
+      systemd.services.bluetooth = {
+        unitConfig = {
+          ConditionPathIsDirectory = "";
         };
       };
     })

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -7,6 +7,7 @@
 
 let
   deviceTree = config.hardware.deviceTree;
+  modemmanager = config.networking.modemmanager;
 
   cfg = config.hardware.lenovo.x13s;
 in
@@ -43,9 +44,12 @@ in
     # WiFi
     (lib.mkIf (cfg.wifiMac != null) {
       # https://github.com/jhovold/linux/wiki/X13s#wi-fi
-      services.udev.extraRules = ''
-        ACTION=="add", SUBSYSTEM=="net", KERNELS=="0006:01:00.0", RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"
-      '';
+      services.udev.extraRules = builtins.concatStringsSep ", " [
+        ''ACTION=="add"''
+        ''SUBSYSTEM=="net"''
+        ''KERNELS=="0006:01:00.0"''
+        ''RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"''
+      ];
     })
 
     # Bluetooth
@@ -86,7 +90,7 @@ in
           fi
 
           echo "assigning mac: $BLUETOOTH_MAC"
-          yes | ${pkgs.bluez}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
+          yes | ${config.hardware.bluetooth.package}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
         '';
 
         serviceConfig = {
@@ -97,12 +101,12 @@ in
     })
 
     # Modem
-    (lib.mkIf (config.networking.modemmanager.enable) {
+    (lib.mkIf (modemmanager.enable) {
       # https://github.com/jhovold/linux/wiki/X13s#modem
       networking.modemmanager.fccUnlockScripts = [
         {
           id = "105b:e0c3";
-          path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
+          path = "${modemmanager.package}/share/ModemManager/fcc-unlock.available.d/105b";
         }
       ];
     })

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -91,10 +91,13 @@ in
               $[RANDOM%256])"
           fi
 
+          # bluetooth module can be slow to get ready
+          # would like to find a better way to handle this.
           while ! [ -d /sys/class/bluetooth ] ; do
-            echo "waiting for bluetooth"
             sleep 5
+            echo "waiting for bluetooth"
           done
+          sleep 5
 
           echo "assigning mac: $BLUETOOTH_MAC"
           yes | ${config.hardware.bluetooth.package}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -49,7 +49,7 @@ in
     })
 
     # Bluetooth
-    {
+    (lib.mkIf (config.hardware.bluetooth.enable) {
       # https://github.com/jhovold/linux/wiki/X13s#bluetooth
       systemd.services.bluetooth-x13s-mac = {
         wantedBy = [ "multi-user.target" ];
@@ -86,7 +86,7 @@ in
           fi
 
           echo "assigning mac: $BLUETOOTH_MAC"
-          ${pkgs.bluez}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
+          yes | ${pkgs.bluez}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
         '';
 
         serviceConfig = {
@@ -94,10 +94,10 @@ in
           RemainAfterExit = true;
         };
       };
-    }
+    })
 
     # Modem
-    {
+    (lib.mkIf (config.networking.modemmanager.enable) {
       # https://github.com/jhovold/linux/wiki/X13s#modem
       networking.modemmanager.fccUnlockScripts = [
         {
@@ -105,7 +105,7 @@ in
           path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
         }
       ];
-    }
+    })
 
     # Camera
     {

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -6,12 +6,7 @@
 }:
 
 let
-  inherit (config.boot.kernelPackages) kernel;
-
-  dtbName = "sc8280xp-lenovo-thinkpad-x13s.dtb";
-  dtb = "${kernel}/dtbs/qcom/${dtbName}";
-  # Version the dtb based on the kernel
-  dtbEfiPath = "dtbs/x13s-${kernel.version}.dtb";
+  deviceTree = config.hardware.deviceTree;
 
   cfg = config.hardware.lenovo.x13s;
 
@@ -48,12 +43,12 @@ in
   config = {
     boot = {
       loader.systemd-boot.extraFiles = {
-        "${dtbEfiPath}" = dtb;
+        "dtbs/${deviceTree.kernelPackage.version}" = "${deviceTree.package}";
       };
 
       kernelParams = mkDefault [
         # needed to boot
-        "dtb=${dtbEfiPath}"
+        "dtb=dtbs/${deviceTree.kernelPackage.version}/${deviceTree.name}"
 
         # jhovold recommended
         "clk_ignore_unused"
@@ -85,7 +80,14 @@ in
       ];
     };
 
-    hardware.enableRedistributableFirmware = mkDefault true;
+    hardware = {
+      enableRedistributableFirmware = mkDefault true;
+      deviceTree = {
+        enable = true;
+        filter = lib.mkDefault "sc8280xp-lenovo-thinkpad-x13s*.dtb";
+        name = lib.mkDefault "qcom/sc8280xp-lenovo-thinkpad-x13s.dtb";
+      };
+    };
 
     # https://github.com/jhovold/linux/wiki/X13s#bluetooth
     systemd.services.bluetooth-x13s-mac = {

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -12,10 +12,9 @@ let
   dtb = "${kernel}/dtbs/qcom/${dtbName}";
   # Version the dtb based on the kernel
   dtbEfiPath = "dtbs/x13s-${kernel.version}.dtb";
-  cfg = {
-    wifiMac = "e4:65:38:52:22:a9";
-    bluetoothMac = "E4:25:18:22:44:AA";
-  };
+  
+  cfg = config.hardware.lenovo.x13s;
+
   inherit (lib) mkDefault;
 in
 {
@@ -24,85 +23,109 @@ in
     ../../../common/pc/laptop
   ];
 
-  boot = {
-    loader.systemd-boot.extraFiles = {
-      "${dtbEfiPath}" = dtb;
+  options.hardware.lenovo.x13s = {
+    wifiMac = lib.mkOption {
+      type = lib.types.nullOr lib.types.strMatching "([0-9a-f]{2}(:[0-9a-f]{2}){5})";
+      description = ''
+        WiFi MAC address to set on boot. When not set a random mac
+        address is assigned. Expects lowercase.
+      '';
+      default = null;
     };
 
-    kernelParams = mkDefault [
-      # needed to boot
-      "dtb=${dtbEfiPath}"
-
-      # jhovold recommended
-      "clk_ignore_unused"
-      "pd_ignore_unused"
-      "arm64.nopauth"
-    ];
-
-    kernelModules = mkDefault [
-      "nvme"
-      "phy-qcom-qmp-pcie"
-      "pcie-qcom"
-
-      "i2c-core"
-      "i2c-hid"
-      "i2c-hid-of"
-      "i2c-qcom-geni"
-
-      "leds_qcom_lpg"
-      "pwm_bl"
-      "qrtr"
-      "pmic_glink_altmode"
-      "gpio_sbu_mux"
-      "phy-qcom-qmp-combo"
-      "gpucc_sc8280xp"
-      "dispcc_sc8280xp"
-      "phy_qcom_edp"
-      "panel-edp"
-      "msm"
-    ];
-  };
-
-  hardware.enableRedistributableFirmware = mkDefault true;
-
-  systemd.services.bluetooth-x13s-mac = lib.mkIf (cfg.bluetoothMac != null) {
-    wantedBy = [ "multi-user.target" ];
-    before = [ "bluetooth.service" ];
-    requiredBy = [ "bluetooth.service" ];
-
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      ExecStart = "${pkgs.util-linux}/bin/script -q -c '${pkgs.bluez}/bin/btmgmt --index 0 public-addr ${cfg.bluetoothMac}'";
+    bluetoothMac = lib.mkOption {
+      type = lib.types.nullOr lib.types.strMatching "([0-9A-F]{2}(:[0-9A-F]{2}){5})";
+      description = ''
+        Bluetooth MAC address to set on boot. If null, the mac is
+        generated using /etc/machine-id to seed the random generator.
+        When not set, bluetooth.service fails to start. Expects
+        upper case.
+      '';
+      default = "";
     };
   };
 
-  # https://github.com/jhovold/linux/wiki/X13s#modem
-  networking.modemmanager.fccUnlockScripts = [
+  config = {
+    boot = {
+      loader.systemd-boot.extraFiles = {
+        "${dtbEfiPath}" = dtb;
+      };
 
-    {
-      id = "105b:e0c3";
-      path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
-    }
-  ];
+      kernelParams = mkDefault [
+        # needed to boot
+        "dtb=${dtbEfiPath}"
 
-  # https://github.com/jhovold/linux/wiki/X13s#camera
-  services.udev.extraRules = lib.strings.concatLines (
-    [
-      ''
-        ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="linux,cma", GROUP="video", MODE="0660"
-        ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="system", GROUP="video", MODE="0660"
-      ''
-    ]
-    ++ (
-      if cfg.wifiMac != null then
-        [
-          ''
-            ACTION=="add", SUBSYSTEM=="net", KERNELS=="0006:01:00.0", RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"
-          ''
-        ]
-      else
-        [ ]
-    )
-  );
+        # jhovold recommended
+        "clk_ignore_unused"
+        "pd_ignore_unused"
+        "arm64.nopauth"
+      ];
+
+      kernelModules = mkDefault [
+        "nvme"
+        "phy-qcom-qmp-pcie"
+        "pcie-qcom"
+
+        "i2c-core"
+        "i2c-hid"
+        "i2c-hid-of"
+        "i2c-qcom-geni"
+
+        "leds_qcom_lpg"
+        "pwm_bl"
+        "qrtr"
+        "pmic_glink_altmode"
+        "gpio_sbu_mux"
+        "phy-qcom-qmp-combo"
+        "gpucc_sc8280xp"
+        "dispcc_sc8280xp"
+        "phy_qcom_edp"
+        "panel-edp"
+        "msm"
+      ];
+    };
+
+    hardware.enableRedistributableFirmware = mkDefault true;
+
+    systemd.services.bluetooth-x13s-mac = lib.mkIf (cfg.bluetoothMac != null) {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "bluetooth.service" ];
+      requiredBy = [ "bluetooth.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.util-linux}/bin/script -q -c '${pkgs.bluez}/bin/btmgmt --index 0 public-addr ${cfg.bluetoothMac}'";
+      };
+    };
+
+    # https://github.com/jhovold/linux/wiki/X13s#modem
+    networking.modemmanager.fccUnlockScripts = [
+
+      {
+        id = "105b:e0c3";
+        path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
+      }
+    ];
+
+    # https://github.com/jhovold/linux/wiki/X13s#camera
+    services.udev.extraRules = lib.strings.concatLines (
+      [
+        ''
+          ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="linux,cma", GROUP="video", MODE="0660"
+          ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="system", GROUP="video", MODE="0660"
+        ''
+      ]
+      ++ (
+        if cfg.wifiMac != null then
+          [
+            ''
+              ACTION=="add", SUBSYSTEM=="net", KERNELS=="0006:01:00.0", RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"
+            ''
+          ]
+        else
+          [ ]
+      )
+    );
+  };
 }

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -187,21 +187,18 @@ in
     )
 
     # grub does not handle device tree yet
-    # (lib.mkIf (config.boot.loader.grub.enable) {
-    #   warnings = [
-    #     "x13s grub configuration has not been tested"
-    #   ];
-    #   boot = {
-    #     loader.grub = {
-    #       extraConfig = ''
-    #         devicetree /dtbs/${config.hardware.deviceTree.kernelPackage.version}/${config.hardware.deviceTree.name}
-    #       '';
-    #       extraFiles = {
-    #         "dtbs/${config.hardware.deviceTree.kernelPackage.version}" = "${config.hardware.deviceTree.package}";
-    #       };
-    #     };
-    #   };
-    # })
+    (lib.mkIf (config.boot.loader.grub.enable) {
+      boot = {
+        loader.grub = {
+          extraConfig = ''
+            devicetree dtbs/${deviceTree.kernelPackage.version}/${deviceTree.name}
+          '';
+          extraFiles = {
+            "dtbs/${deviceTree.kernelPackage.version}" = "${deviceTree.package}";
+          };
+        };
+      };
+    })
 
   ]);
 }

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -136,7 +136,7 @@ in
           # "efi=noruntime"
         ];
 
-        kernelModules = [
+        initrd.kernelModules = [
           "nvme"
           "phy-qcom-qmp-pcie"
           # "pcie-qcom" # this is no longer a module

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -9,8 +9,6 @@ let
   deviceTree = config.hardware.deviceTree;
 
   cfg = config.hardware.lenovo.x13s;
-
-  inherit (lib) mkDefault;
 in
 {
   imports = [
@@ -40,125 +38,164 @@ in
     };
   };
 
-  config = {
-    boot = {
-      loader.systemd-boot.extraFiles = {
-        "dtbs/${deviceTree.kernelPackage.version}" = "${deviceTree.package}";
-      };
+  config = lib.mkMerge ([
 
-      kernelParams = mkDefault [
-        # needed to boot
-        "dtb=dtbs/${deviceTree.kernelPackage.version}/${deviceTree.name}"
-
-        # jhovold recommended
-        "clk_ignore_unused"
-        "pd_ignore_unused"
-        "arm64.nopauth"
-      ];
-
-      kernelModules = mkDefault [
-        "nvme"
-        "phy-qcom-qmp-pcie"
-        "pcie-qcom"
-
-        "i2c-core"
-        "i2c-hid"
-        "i2c-hid-of"
-        "i2c-qcom-geni"
-
-        "leds_qcom_lpg"
-        "pwm_bl"
-        "qrtr"
-        "pmic_glink_altmode"
-        "gpio_sbu_mux"
-        "phy-qcom-qmp-combo"
-        "gpucc_sc8280xp"
-        "dispcc_sc8280xp"
-        "phy_qcom_edp"
-        "panel-edp"
-        "msm"
-      ];
-    };
-
-    hardware = {
-      enableRedistributableFirmware = mkDefault true;
-      deviceTree = {
-        enable = true;
-        filter = lib.mkDefault "sc8280xp-lenovo-thinkpad-x13s*.dtb";
-        name = lib.mkDefault "qcom/sc8280xp-lenovo-thinkpad-x13s.dtb";
-      };
-    };
-
-    # https://github.com/jhovold/linux/wiki/X13s#bluetooth
-    systemd.services.bluetooth-x13s-mac = {
-      wantedBy = [ "multi-user.target" ];
-      before = [ "bluetooth.service" ];
-      requiredBy = [ "bluetooth.service" ];
-
-      script = ''
-        BLUETOOTH_MAC="${if cfg.bluetoothMac == null then "" else cfg.bluetoothMac}"
-
-        if [ "$BLUETOOTH_MAC" = "" ] ; then
-          # we might be able to use the system serial number but, if we lost machine-id
-          # the system has probably lost the bluetooth device keys anyway
-          RANDOM=$(( $(cat /etc/machine-id | head -c 128 | sed -e 's/[^0-9]//g') % 32767 ))
-
-          # https://datatracker.ietf.org/doc/html/rfc7042#section-2.1
-          # > Two bits within the initial octet of an EUI-48 have special
-          # > significance in MAC addresses: the Group bit (01) and the Local bit
-          # > (02).  OUIs and longer MAC prefixes are assigned with the Local bit
-          # > zero and the Group bit unspecified.  Multicast identifiers may be
-          # > constructed by turning on the Group bit, and unicast identifiers may
-          # > be constructed by leaving the Group bit zero.
-          #
-          # First, and only argument is for passing a file to seed RANDOM.
-          # recommend using `/etc/machine-id` to pin the mac address if needed.
-          
-          BLUETOOTH_MAC="$(printf '%X%X:%02X:%02X:%02X:%02X:%02X' \
-            $[RANDOM%16] $[((RANDOM%4)+1)*4-2] \
-            $[RANDOM%256] \
-            $[RANDOM%256] \
-            $[RANDOM%256] \
-            $[RANDOM%256] \
-            $[RANDOM%256])"
-        fi
-
-        ${pkgs.bluez}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
+    # WiFi
+    (lib.mkIf (cfg.wifiMac != null) {
+      # https://github.com/jhovold/linux/wiki/X13s#wi-fi
+      services.udev.extraRules = ''
+        ACTION=="add", SUBSYSTEM=="net", KERNELS=="0006:01:00.0", RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"
       '';
+    })
 
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
+    # Bluetooth
+    {
+      # https://github.com/jhovold/linux/wiki/X13s#bluetooth
+      systemd.services.bluetooth-x13s-mac = {
+        wantedBy = [ "multi-user.target" ];
+        before = [ "bluetooth.service" ];
+        requiredBy = [ "bluetooth.service" ];
+
+        script = ''
+          BLUETOOTH_MAC="${if cfg.bluetoothMac == null then "" else cfg.bluetoothMac}"
+
+          if [ "$BLUETOOTH_MAC" = "" ] ; then
+            # we might be able to use the system serial number but, if we lost machine-id
+            # the system has probably lost the bluetooth device keys anyway
+            RANDOM=$(( $(cat /etc/machine-id | head -c 128 | sed -e 's/[^0-9]//g') % 32767 ))
+
+            # https://datatracker.ietf.org/doc/html/rfc7042#section-2.1
+            # > Two bits within the initial octet of an EUI-48 have special
+            # > significance in MAC addresses: the Group bit (01) and the Local bit
+            # > (02).  OUIs and longer MAC prefixes are assigned with the Local bit
+            # > zero and the Group bit unspecified.  Multicast identifiers may be
+            # > constructed by turning on the Group bit, and unicast identifiers may
+            # > be constructed by leaving the Group bit zero.
+            #
+            # First, and only argument is for passing a file to seed RANDOM.
+            # recommend using `/etc/machine-id` to pin the mac address if needed.
+            
+            BLUETOOTH_MAC="$(printf '%X%X:%02X:%02X:%02X:%02X:%02X' \
+              $[RANDOM%16] $[((RANDOM%4)+1)*4-2] \
+              $[RANDOM%256] \
+              $[RANDOM%256] \
+              $[RANDOM%256] \
+              $[RANDOM%256] \
+              $[RANDOM%256])"
+          fi
+
+          ${pkgs.bluez}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
+        '';
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
       };
-    };
+    }
 
-    # https://github.com/jhovold/linux/wiki/X13s#modem
-    networking.modemmanager.fccUnlockScripts = [
+    # Modem
+    {
+      # https://github.com/jhovold/linux/wiki/X13s#modem
+      networking.modemmanager.fccUnlockScripts = [
+        {
+          id = "105b:e0c3";
+          path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
+        }
+      ];
+    }
 
-      {
-        id = "105b:e0c3";
-        path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";
-      }
-    ];
+    # Camera
+    {
+      # https://github.com/jhovold/linux/wiki/X13s#camera
+      services.udev.extraRules = ''
+        ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="linux,cma", GROUP="video", MODE="0660"
+        ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="system", GROUP="video", MODE="0660"
+      '';
+    }
 
-    # https://github.com/jhovold/linux/wiki/X13s#camera
-    services.udev.extraRules = lib.strings.concatLines (
-      [
-        ''
-          ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="linux,cma", GROUP="video", MODE="0660"
-          ACTION=="add", SUBSYSTEM=="dma_heap", KERNEL=="system", GROUP="video", MODE="0660"
-        ''
-      ]
-      ++ (
-        if cfg.wifiMac != null then
-          [
-            ''
-              ACTION=="add", SUBSYSTEM=="net", KERNELS=="0006:01:00.0", RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"
-            ''
-          ]
-        else
-          [ ]
+    # Minimum requirements for a running system
+    {
+      hardware = {
+        enableRedistributableFirmware = lib.mkDefault true;
+        deviceTree = {
+          enable = true;
+          filter = lib.mkDefault "sc8280xp-lenovo-thinkpad-x13s*.dtb";
+          name = lib.mkDefault "qcom/sc8280xp-lenovo-thinkpad-x13s.dtb";
+        };
+      };
+
+      boot = {
+        # https://github.com/jhovold/linux/wiki/X13s#kernel-command-line
+        kernelParams = [
+          "clk_ignore_unused"
+          "pd_ignore_unused"
+          "arm64.nopauth"
+          # "efi=noruntime"
+        ];
+
+        kernelModules = [
+          "nvme"
+          "phy-qcom-qmp-pcie"
+          # "pcie-qcom" # this is no longer a module
+
+          "i2c-core"
+          "i2c-hid"
+          "i2c-hid-of"
+          "i2c-qcom-geni"
+
+          "leds_qcom_lpg"
+          "pwm_bl"
+          "qrtr"
+          "pmic_glink_altmode"
+          "gpio_sbu_mux"
+          "phy-qcom-qmp-combo"
+          "gpucc_sc8280xp"
+          "dispcc_sc8280xp"
+          "phy_qcom_edp"
+          "panel-edp"
+          "msm"
+        ];
+      };
+    }
+
+    # boot loader needs to know about and handle the dtb for the system. systemd-boot handles this
+    # automagically when hardware.deviceTree.enable is true since 24.11
+    (lib.mkIf
+      (
+        config.boot.loader.systemd-boot.enable
+        && deviceTree.enable
+        && (lib.versionOlder config.system.stateVersion "24.11")
       )
-    );
-  };
+      {
+        boot = {
+          loader.systemd-boot.extraFiles = {
+            "dtbs/${deviceTree.kernelPackage.version}" = "${deviceTree.package}";
+          };
+
+          kernelParams = [
+            "dtb=dtbs/${deviceTree.kernelPackage.version}/${deviceTree.name}"
+          ];
+        };
+      }
+    )
+
+    # grub does not handle device tree yet
+    # (lib.mkIf (config.boot.loader.grub.enable) {
+    #   warnings = [
+    #     "x13s grub configuration has not been tested"
+    #   ];
+    #   boot = {
+    #     loader.grub = {
+    #       extraConfig = ''
+    #         devicetree /dtbs/${config.hardware.deviceTree.kernelPackage.version}/${config.hardware.deviceTree.name}
+    #       '';
+    #       extraFiles = {
+    #         "dtbs/${config.hardware.deviceTree.kernelPackage.version}" = "${config.hardware.deviceTree.package}";
+    #       };
+    #     };
+    #   };
+    # })
+
+  ]);
 }

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -59,6 +59,8 @@ in
         wantedBy = [ "multi-user.target" ];
         before = [ "bluetooth.service" ];
         requiredBy = [ "bluetooth.service" ];
+        stopIfChanged = false;
+        restartIfChanged = false;
 
         script = ''
           BLUETOOTH_MAC="${if cfg.bluetoothMac == null then "" else cfg.bluetoothMac}"

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -63,7 +63,7 @@ in
         restartIfChanged = false;
 
         script = ''
-          BLUETOOTH_MAC="${if cfg.bluetoothMac == null then "" else cfg.bluetoothMac}"
+          BLUETOOTH_MAC="${lib.optionalString (cfg.bluetoothMac != null) cfg.bluetoothMac}"
 
           if [ "$BLUETOOTH_MAC" = "" ] ; then
             echo 'generating bluetooth mac'

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -18,19 +18,19 @@ in
   ];
 
   options.hardware.lenovo.x13s = {
-    wifiMac = lib.mkOption {
+    wifiMAC = lib.mkOption {
       type = lib.types.nullOr (lib.types.strMatching "([0-9a-f]{2}(:[0-9a-f]{2}){5})");
       description = ''
-        WiFi MAC address to set on boot. When not set a random mac
+        Wi-Fi MAC address to set on boot. When not set a random MAC
         address is assigned. Expects lowercase.
       '';
       default = null;
     };
 
-    bluetoothMac = lib.mkOption {
+    bluetoothMAC = lib.mkOption {
       type = lib.types.nullOr (lib.types.strMatching "([0-9A-F]{2}(:[0-9A-F]{2}){5})");
       description = ''
-        Bluetooth MAC address to set on boot. If null, the mac is
+        Bluetooth MAC address to set on boot. If null, the MAC is
         generated using /etc/machine-id to seed the random generator.
         When not set, bluetooth.service fails to start. Expects
         upper case.
@@ -41,14 +41,14 @@ in
 
   config = lib.mkMerge ([
 
-    # WiFi
-    (lib.mkIf (cfg.wifiMac != null) {
+    # Wi-Fi
+    (lib.mkIf (cfg.wifiMAC != null) {
       # https://github.com/jhovold/linux/wiki/X13s#wi-fi
       services.udev.extraRules = builtins.concatStringsSep ", " [
         ''ACTION=="add"''
         ''SUBSYSTEM=="net"''
         ''KERNELS=="0006:01:00.0"''
-        ''RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMac}"''
+        ''RUN+="${pkgs.iproute2}/bin/ip link set dev $name address ${cfg.wifiMAC}"''
       ];
     })
 
@@ -63,10 +63,10 @@ in
         restartIfChanged = false;
 
         script = ''
-          BLUETOOTH_MAC="${lib.optionalString (cfg.bluetoothMac != null) cfg.bluetoothMac}"
+          BLUETOOTH_MAC="${lib.optionalString (cfg.bluetoothMAC != null) cfg.bluetoothMAC}"
 
           if [ "$BLUETOOTH_MAC" = "" ] ; then
-            echo 'generating bluetooth mac'
+            echo 'Generating Bluetooth MAC'
             # we might be able to use the system serial number but, if we lost machine-id
             # the system has probably lost the bluetooth device keys anyway
             SEED=$(( $(cat /etc/machine-id | head -c 128 | sed -e 's/[^0-9]//g;s/^0*//') ))
@@ -80,7 +80,7 @@ in
             # > be constructed by leaving the Group bit zero.
             #
             # First, and only argument is for passing a file to seed RANDOM.
-            # recommend using `/etc/machine-id` to pin the mac address if needed.
+            # recommend using `/etc/machine-id` to pin the MAC address if needed.
             
             BLUETOOTH_MAC="$(RANDOM=$SEED ; printf '%X%X:%02X:%02X:%02X:%02X:%02X' \
               $[RANDOM%16] $[((RANDOM%4)+1)*4-2] \
@@ -95,11 +95,11 @@ in
           # would like to find a better way to handle this.
           while ! [ -d /sys/class/bluetooth ] ; do
             sleep 5
-            echo "waiting for bluetooth"
+            echo "Waiting for Bluetooth"
           done
           sleep 5
 
-          echo "assigning mac: $BLUETOOTH_MAC"
+          echo "Assigning MAC: $BLUETOOTH_MAC"
           yes | ${config.hardware.bluetooth.package}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
         '';
 
@@ -202,7 +202,7 @@ in
       }
     )
 
-    # grub does not handle device tree yet
+    # GRUB does not handle device tree yet
     (lib.mkIf (config.boot.loader.grub.enable) {
       warnings = lib.optional (
         !config.boot.loader.grub.efiSupport

--- a/lenovo/thinkpad/x13s/default.nix
+++ b/lenovo/thinkpad/x13s/default.nix
@@ -56,9 +56,11 @@ in
     (lib.mkIf (config.hardware.bluetooth.enable) {
       # https://github.com/jhovold/linux/wiki/X13s#bluetooth
       systemd.services.bluetooth-x13s-mac = {
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "bluetooth.target" ];
         before = [ "bluetooth.service" ];
         requiredBy = [ "bluetooth.service" ];
+        after = [ "sys-subsystem-bluetooth-devices-hci0.device" ];
+        bindsTo = [ "sys-subsystem-bluetooth-devices-hci0.device" ];
         stopIfChanged = false;
         restartIfChanged = false;
 
@@ -91,27 +93,26 @@ in
               $[RANDOM%256])"
           fi
 
-          # bluetooth module can be slow to get ready
-          # would like to find a better way to handle this.
-          while ! [ -d /sys/class/bluetooth ] ; do
-            sleep 5
-            echo "Waiting for Bluetooth"
-          done
-          sleep 5
+          echo "Waiting for Adapter"
+
+          # Listen to the hardware setup and wait for the adapter to
+          # finish receiving its firmware, and finish loading
+          mkfifo /tmp/btmon.log
+          stdbuf -oL ${config.hardware.bluetooth.package}/bin/btmon --mgmt --kernel >> /tmp/btmon.log &
+          BTPID=$!
+          grep -q -m 1 "Unconfigured Index Ad" /tmp/btmon.log || true
+          kill $BTPID 2>/dev/null
 
           echo "Assigning MAC: $BLUETOOTH_MAC"
-          yes | ${config.hardware.bluetooth.package}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
+
+          ${config.hardware.bluetooth.package}/bin/btmgmt --index 0 public-addr $BLUETOOTH_MAC
         '';
 
         serviceConfig = {
           Type = "oneshot";
+          PrivateTmp = "true";
           RemainAfterExit = true;
-        };
-      };
-
-      systemd.services.bluetooth = {
-        unitConfig = {
-          ConditionPathIsDirectory = "";
+          TimeoutSec = "1m";
         };
       };
     })


### PR DESCRIPTION
###### Description of changes

Use options for x13s specific information. Change the way the device tree is selected as well. The built-in NixOS options better handle this now. `systemd-boot` needs no additional configuration when using `hardware.deviceTree`. There's now a rough, commented out, implementation for booting using Grub. The system bluetooth device will now get a MAC address automatically generated based on `/etc/machine-id`.

I've attempted to break the changes up in 4 commits splitting up the different changes in easier to review chunks. Drafting the PR now to get feedback and any feedback is appreciated.

Booting the configs
- [x] systemd-boot is working on: https://github.com/BrainWart/nixos-config/commit/318224199966579d933d472b54c09b585b7be575
- [x] grub is working on: https://github.com/BrainWart/nixos-config/commit/d15a84423d3092d7af58d0638d1c7d8dafb770e3
- [x] no macs set: https://github.com/BrainWart/nixos-config/commit/318224199966579d933d472b54c09b585b7be575
- [x] macs set: https://github.com/BrainWart/nixos-config/commit/398c79b2fd9b82acaff3840986567823b960fefb

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input

