### PR TITLE
apple/t2: sync stable patches (6.12.44 -> 6.12.63)

### DIFF
--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/5eaf1261d069bbc67aba7fe2737a5fe981e05a9e/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/1f514a15e2b20ce2e1f99018493c71de9784fcf0/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
@@ -127,7 +127,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-QpIPsMjWNPOkw6rSKn7rW0Fmx9HUwJaiGy3pZeT5Fd0="
+      "hash": "sha256-rTdmORTT2oeBTh6R8LbXimgiaA7X6AgQO+lUuN5hJYI="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Updates apple/t2 patches to sync up with whats present in nixos-25.11. Tried upgrading from 25.05 on my t2 MBA and had some breakages. Incorporating these changes from my fork seemed to sort things out!

Side question, does it normally take a few hours for other apple/t2 users to build their patched kernel? I'm on an i5-8210Y MBA, so definitely not much horsepower, so I didnt bother with trying out the `latest` kernel setup here - but stable worked well! Maybe its time I look into distributed build configurations 😅 

###### Things done

```sh
cd apple/t2/pkgs/linux-t2
python3 -m venv venv
source venv/bin/activate
python3 -m pip install requests
python3 update-patches.py --branch 6.12 stable.json 
```

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

