### PR TITLE
common/gpu/intel: avoid enabling OneVPL runtime by default on pre-TGL GPUs

### DIFF
--- a/common/gpu/intel/default.nix
+++ b/common/gpu/intel/default.nix
@@ -22,12 +22,21 @@
       };
 
     computeRuntime = lib.mkOption {
-      description = "intel-compute-runtime variant to use";
+      description = "intel-compute-runtime variant to use (legacy for Gen8–11, default for Gen12+)";
       type = lib.types.enum [
         "default"
         "legacy"
       ];
       default = "default";
+    };
+
+    mediaRuntime = lib.mkOption {
+      description = "Intel media runtime to use (Media SDK for Gen8–11, OneVPL for Gen12+)";
+      type = lib.types.enum [
+        "vpl-gpu-rt"
+        "intel-media-sdk"
+      ];
+      default = "vpl-gpu-rt";
     };
 
     vaapiDriver = lib.mkOption {
@@ -71,7 +80,11 @@
           pkgs.intel-compute-runtime-legacy1
         else
           pkgs.intel-compute-runtime;
-      vpl-gpu-rt = pkgs.vpl-gpu-rt or pkgs.onevpl-intel-gpu;
+      intel-media-runtime =
+        if cfg.mediaRuntime == "vpl-gpu-rt" then
+          pkgs.vpl-gpu-rt or pkgs.onevpl-intel-gpu
+        else
+          pkgs.intel-media-sdk;
     in
     {
       boot.initrd.kernelModules = lib.optionals cfg.loadInInitrd [ cfg.driver ];
@@ -82,7 +95,7 @@
         ++ lib.optionals useIntelMediaDriver [
           intel-media-driver
           intel-compute-runtime
-          vpl-gpu-rt
+          intel-media-runtime
         ];
 
       hardware.graphics.extraPackages32 =


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Previously, enabling `intel-media-driver` would always pull in the OneVPL GPU runtime (`vpl-gpu-rt`), even on pre-Tiger Lake systems where it is not supported. This could result in a non-functional media runtime on Gen8–Gen11 hardware.

This patch introduces an explicit `mediaRuntime` option and makes the runtime selection configurable.

The default remains `vpl-gpu-rt`, since `intel-media-sdk` is currently marked as insecure in nixpkgs and cannot be enabled by default without breaking evaluation and CI.

Fixes #1755 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

