### PR TITLE
framework/12-inch: Add support for unl0kr

### DIFF
--- a/framework/12-inch/13th-gen-intel/README.md
+++ b/framework/12-inch/13th-gen-intel/README.md
@@ -12,3 +12,22 @@ $ fwupdmgr update
 ```
 
 - [Latest Update](https://fwupd.org/lvfs/devices/work.frame.Laptop12.RPL.BIOS.firmware)
+
+## Touchscreen support in initrd (for unl0kr)
+
+To unlock your LUKS disk encryption with an onscreen touch keyboard, you can use unl0kr.
+
+This module will automatically included the necessary kernel modules in initrd to make touchpad and touchscreen work when `boot.initrd.unl0kr.enable = true`.
+
+Example configuration:
+
+```nix
+{
+  boot.initrd.systemd.enable = true;
+  boot.initrd.unl0kr.enable = true;
+
+  boot.initrd.luks.devices."cryptroot" = {
+    device = "/dev/disk/by-uuid/YOUR-UUID-HERE";
+  };
+}
+```

--- a/framework/12-inch/13th-gen-intel/default.nix
+++ b/framework/12-inch/13th-gen-intel/default.nix
@@ -9,5 +9,15 @@
   # before soc_button_array. Otherwise the tablet mode gpio doesn't work.
   # If correctly loaded, dmesg should show
   # input: gpio-keys as /devices/platform/INT33D3:00
-  boot.initrd.kernelModules = [ "pinctrl_tigerlake" ];
+  boot.initrd.kernelModules = [
+    "pinctrl_tigerlake"
+  ]
+  # Additional modules for touchscreen/touchpad in initrd (for unl0kr on-screen keyboard)
+  ++ lib.optionals config.boot.initrd.unl0kr.enable [
+    "intel_lpss_pci"
+    "i2c_hid_acpi"
+    "i2c_hid"
+    "hid_multitouch"
+    "hid_generic"
+  ];
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Automatically load kernel modules for initrd onscreen keyboard with unl0kr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

