### PR TITLE
dell/latitude/7430: Enable Caps Lock LED

### DIFF
--- a/dell/latitude/7430/default.nix
+++ b/dell/latitude/7430/default.nix
@@ -13,7 +13,6 @@
     "i915.enable_guc=3"
     "i915.fastboot=1"
     # needed for keyboard
-    "i8042.dumbkbd=1"
     "i8042.nopnp=1"
   ];
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Removed `i8042.dumbkbd=1` from `boot.kernelParams` to enable the Caps Lock LED of the Dell Latitude 7430.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

