### PR TITLE
raspberry-pi/5: set generic-extlinux-compatible by default

### DIFF
--- a/raspberry-pi/5/default.nix
+++ b/raspberry-pi/5/default.nix
@@ -12,6 +12,8 @@ in
   imports = [ ../common/default.nix ];
 
   boot = {
+    loader.grub.enable = lib.mkDefault false;
+    loader.generic-extlinux-compatible.enable = lib.mkDefault true;
     kernelPackages = lib.mkDefault (
       pkgs.linuxPackagesFor (pkgs.callPackage ../common/kernel.nix { rpiVersion = 5; })
     );


### PR DESCRIPTION
###### Description of changes

This PR provides an overlay for Raspberry Pi 5 U-Boot packages. Two U-Boot packages are provided: rev 1.0 and rev 1.1 compatible ones. Additionally, extlinux is made default in the Raspberry Pi 5 profile.

~This PR provides an installer as well for the board. The `options.hardware.rpiRevision` option is provided to choose between Raspberry Pi 5 board revisions. This in turn chooses the correct U-Boot package from the overlay.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

