### PR TITLE
asus/zephyrus/gu605cw: use tlp instead of tuned

### DIFF
--- a/asus/zephyrus/gu605cw/default.nix
+++ b/asus/zephyrus/gu605cw/default.nix
@@ -23,7 +23,4 @@
   services = {
     asusd.enable = lib.mkDefault true;
   };
-
-  services.tuned.enable = true;
-  services.tlp.enable = lib.mkOverride 500 false;
 }


### PR DESCRIPTION
tuned is not suitable for laptops as it doesn't have any battery management features.

Let's use the nixos-hardware default for laptops instead which is tlp for a good reason

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

