### PR TITLE
Add hydra jobs & flake packages for Raspberry Pi kernels

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -492,8 +492,28 @@
           imx93-boot = (pkgs.callPackage ./nxp/imx93-evk/bsp/imx93-boot.nix { }).imx93-boot;
           imx8mp-boot = (pkgs.callPackage ./nxp/imx8mp-evk/bsp/imx8mp-boot.nix { }).imx8m-boot;
           imx8mq-boot = (pkgs.callPackage ./nxp/imx8mq-evk/bsp/imx8mq-boot.nix { }).imx8m-boot;
+          # Raspberry Pi kernels (aarch64-linux only)
+          rpi2-kernel = (pkgs.callPackage ./raspberry-pi/common/kernel.nix { rpiVersion = 2; });
+          rpi3-kernel = (pkgs.callPackage ./raspberry-pi/common/kernel.nix { rpiVersion = 3; });
+          rpi4-kernel = (pkgs.callPackage ./raspberry-pi/common/kernel.nix { rpiVersion = 4; });
+          rpi5-kernel = (pkgs.callPackage ./raspberry-pi/common/kernel.nix { rpiVersion = 5; });
         }
       );
+
+      # Hydra jobset for Raspberry Pi kernels
+      hydraJobs = {
+        raspberry-pi-kernels = eachSystem (
+          pkgs: system:
+          pkgs.lib.optionalAttrs (system == "aarch64-linux") {
+            inherit (self.packages.${system})
+              rpi2-kernel
+              rpi3-kernel
+              rpi4-kernel
+              rpi5-kernel
+              ;
+          }
+        );
+      };
 
       # Add checks for `nix run .#run-tests`
       checks = eachSystem (


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Hi :wave: 

This MR introduces hydra jobs to build raspberry pi kernels.\
This is relates to https://github.com/NixOS/nixpkgs/pull/284391, because compiling a kernel takes several hours.\
This can also be a first step towards caching things on Hydra (https://github.com/NixOS/nixos-hardware/issues/854).

Feedback and suggestions are very welcome 🙂

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

