### PR TITLE
remove service.asusd.enableUserService for Asus FA506IC

### DIFF
--- a/asus/fa506ic/default.nix
+++ b/asus/fa506ic/default.nix
@@ -26,7 +26,6 @@
   services = {
     asusd = {
       enable = lib.mkDefault true;
-      enableUserService = lib.mkDefault true;
     };
     supergfxd.enable = lib.mkDefault true;
   };


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
This will remove `service.asusd.enableUserService` as it is not required anymore and causes error.

```
error:
       … while calling the 'head' builtin
         at /nix/store/kzqqrhnhh9q3dnrj3x10cdihmj09yc8p-source/lib/attrsets.nix:1713:13:
         1712|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1713|             head values
             |             ^
         1714|           else

       … while evaluating the attribute 'value'
         at /nix/store/kzqqrhnhh9q3dnrj3x10cdihmj09yc8p-source/lib/modules.nix:1160:7:
         1159|     // {
         1160|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1161|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/kzqqrhnhh9q3dnrj3x10cdihmj09yc8p-source/nixos/modules/system/activation/top-level.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error:
       Failed assertions:
       - The option definition `services.asusd.enableUserService' in `/nix/store/p5qr9716nzilm0j5wnrjb6rldvkb0jc4-source/asus/fa506ic' no longer has any effect; please remove it.
       The asusd user service is no longer required.
Error: 
   0: Failed to build configuration
   1: Command exited with status Exited(1)

Location:
   src/commands.rs:693
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

