### PR TITLE
don't set removed option `asusd.enableUserService`

### DIFF
--- a/asus/fa506ic/default.nix
+++ b/asus/fa506ic/default.nix
@@ -26,7 +26,6 @@
   services = {
     asusd = {
       enable = lib.mkDefault true;
-      enableUserService = lib.mkDefault true;
     };
     supergfxd.enable = lib.mkDefault true;
   };

--- a/asus/fa507nv/default.nix
+++ b/asus/fa507nv/default.nix
@@ -34,7 +34,6 @@
   services = {
     asusd = {
       enable = lib.mkDefault true;
-      enableUserService = lib.mkDefault true;
     };
   };
 

--- a/asus/flow/gv302x/shared.nix
+++ b/asus/flow/gv302x/shared.nix
@@ -60,7 +60,6 @@ in
       services = {
         asusd = {
           enable = mkDefault true;
-          enableUserService = mkDefault true;
         };
 
         supergfxd.enable = mkDefault true;

--- a/asus/flow/gz301vu/default.nix
+++ b/asus/flow/gz301vu/default.nix
@@ -39,7 +39,6 @@ in
       services = {
         asusd = {
           enable = mkDefault true;
-          enableUserService = mkDefault true;
         };
 
         supergfxd.enable = mkDefault true;

--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -59,7 +59,6 @@ in
       services = {
         asusd = {
           enable = mkDefault true;
-          enableUserService = mkDefault true;
         };
 
         supergfxd.enable = mkDefault true;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Removed mentions of `asusd.enableUserService`, since it has been removed in https://github.com/NixOS/nixpkgs/pull/494028.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input