### PR TITLE
Remove asusd from ga402x

### DIFF
--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -57,11 +57,6 @@ in
       };
 
       services = {
-        asusd = {
-          enable = mkDefault true;
-          enableUserService = mkDefault true;
-        };
-
         supergfxd.enable = mkDefault true;
 
         udev = {


### PR DESCRIPTION
As of March 1, rebuilding with nixpkgs-unstable and asusd enabled results in the error:

```
       - The option definition `services.asusd.enableUserService' in `/nix/store/p5qr9716nzilm0j5wnrjb6rldvkb0jc4-source/asus/zephyrus/ga402x/shared.nix' no longer has any effect; please remove it.
       The asusd user service is no longer required.
```

Removing asusd from the configuration resolves the error.

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

