### PR TITLE
Removed deprecated asusd user service in ga402x

### DIFF
--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -59,7 +59,6 @@ in
       services = {
         asusd = {
           enable = mkDefault true;
-          enableUserService = mkDefault true;
         };
 
         supergfxd.enable = mkDefault true;


### PR DESCRIPTION
Building with asusd user service enabled, as of March 1 with nixpkgs-unstable, results in the following error:

```
       error:
       Failed assertions:
       - The option definition `services.asusd.enableUserService' in `/nix/store/p5qr9716nzilm0j5wnrjb6rldvkb0jc4-source/asus/zephyrus/ga402x/shared.nix' no longer has any effect; please remove it.
       The asusd user service is no longer required.
```

This PR removes the line which enabled it, resolving the issue.

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

