### PR TITLE
msi/gf63: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ See code for all available configurations.
 | [MSI B550-A PRO](msi/b550-a-pro)                                                  | `<nixos-hardware/msi/b550-a-pro>`                       | `msi-b550-a-pro`                       |
 | [MSI B350 TOMAHAWK](msi/b350-tomahawk)                                            | `<nixos-hardware/msi/b350-tomahawk>`                    | `msi-b350-tomahawk`                    |
 | [MSI B550 TOMAHAWK](msi/b550-tomahawk)                                            | `<nixos-hardware/msi/b550-tomahawk>`                    | `msi-b550-tomahawk`                    |
+| [MSI GF63 Thin](msi/gf63)                                                         | `<nixos-hardware/msi/gf63>`                             | `msi-gf63`                             |
 | [MSI GS60 2QE](msi/gs60)                                                          | `<nixos-hardware/msi/gs60>`                             | `msi-gs60`                             |
 | [MSI GL62/CX62](msi/gl62)                                                         | `<nixos-hardware/msi/gl62>`                             | `msi-gl62`                             |
 | [MSI GL65 10SDR-492](msi/gl65/10SDR-492)                                          | `<nixos-hardware/msi/gl65/10SDR-492>`                   | `msi-gl65-10SDR-492`                   |

--- a/flake.nix
+++ b/flake.nix
@@ -380,6 +380,7 @@
           msi-b350-tomahawk = import ./msi/b350-tomahawk;
           msi-b550-a-pro = import ./msi/b550-a-pro;
           msi-b550-tomahawk = import ./msi/b550-tomahawk;
+          msi-gf63 = import ./msi/gf63;
           msi-gs60 = import ./msi/gs60;
           msi-gl62 = import ./msi/gl62;
           msi-gl65-10SDR-492 = import ./msi/gl65/10SDR-492;

--- a/msi/gf63/README.md
+++ b/msi/gf63/README.md
@@ -1,0 +1,9 @@
+This module supports the following laptop models:
+
+- MSI GF63 Thin 9SC
+- MSI GF63 Thin 9SCX
+- MSI GF63 Thin 9SCXR
+- MSI GF63 Thin 9SCSR
+
+For specifications, visit MSI's
+[product page](https://www.msi.com/Laptop/GF63-Thin-9SX-GTX/Specification).

--- a/msi/gf63/default.nix
+++ b/msi/gf63/default.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../../common/cpu/intel
+    ../../common/gpu/nvidia/turing
+    ../../common/gpu/nvidia/prime.nix
+  ];
+
+  boot.kernelParams = [
+    # For Power consumption in case of NVME SSD
+    # was installed.
+    "nvme.noacpi=1"
+
+    # For fixing interferences with Fn- action keys
+    "video.report_key_events=0"
+  ];
+
+  hardware.nvidia.prime = {
+    # Bus ID of the Intel GPU.
+    intelBusId = lib.mkDefault "PCI:0:2:0";
+
+    # Bus ID of the NVIDIA GPU.
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
+}


### PR DESCRIPTION
###### Description of changes

Adds hardware support for MSI GF63 Thin 9SC (and other similar models).
Link: https://www.msi.com/Laptop/GF63-Thin-9SX-GTX/Specification

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

