### PR TITLE
14IMH9: Add & modify workarounds, add notes about 14imh9

### DIFF
--- a/lenovo/ideapad/14imh9/README.md
+++ b/lenovo/ideapad/14imh9/README.md
@@ -8,9 +8,24 @@ These devices support Conservation mode which charges the battery to 79/80%. See
 ```
 There is no dedicated graphics card. See specs [here](https://psref.lenovo.com/syspool/Sys/PDF/IdeaPad/IdeaPad_Pro_5_14IMH9/IdeaPad_Pro_5_14IMH9_Spec.pdf).
 
+## Avoid GPU hangs -> Turn off RC6!
+> TL;DR: RC6 *WILL* cause your GPU hangs and there is currently no mainlined way to workaround that. You will have to do it yourself.
+
+RC6 in this laptop is [malfunctioning](https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/14469) and will result in random GPU hangs. There is currently neither a PCODE fix nor a mainlined kernel param to disable RC6 at runtime.
+
+You can, however, apply [this off-tree patch](https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/14469#note_3170015) to the kernel and use `i915.enable_rc6=0` to disable RC6. It is currently not mainlined, so you will have to compile your own kernel, unfortunately.
+
+To avoid further gpu hangs, you should disable RC6 in UEFI settings. It is gated behind advanced BIOS settings and hidden by default. You will have to use something like [Smokeless Runtime EFI Patcher](https://winraid.level1techs.com/t/tool-smokelessruntimeefipatcher-srep/89351) to unlock advanced settings. After that, disabling RC6 in `Power Management` section will do the trick.
+
+NB: `i915.enable_dc=0` does not fix this problem because [hangs happen in the GT unit](https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/14469#note_3191689).
+
 ## Extra Configuration
 ### Bluetooth
 To enable bluetooth support, set `hardware.bluetooth.enable = true;`.
 
 ### Sound
 This laptop need extra firmware for hi-quality sound. To enable that, set `hardware.firmware = [ pkgs.sof-firmware ];`.
+
+## Troubleshooting
+### Apps report `VK_ERROR_DEVICE_LOST` after long uptime
+Hibernate & Resume your NixOS. It will save your life.

--- a/lenovo/ideapad/14imh9/default.nix
+++ b/lenovo/ideapad/14imh9/default.nix
@@ -1,5 +1,7 @@
 { lib, pkgs, ... }:
-
+let
+  nixosMajorVersion = lib.toInt (builtins.substring 0 2 (pkgs.lib.version));
+in
 {
   imports = [
     ../../../common/cpu/intel/meteor-lake
@@ -40,39 +42,70 @@
   };
 
   systemd = {
-    # Workaround: Sometimes xhci driver will become malfunctional after resuming from hibernate / suspend.
-    #             This will cause (almost) all external devices stop working.
-    #             A simple reset is enough to bring external devices alive :)
-    #
-    #             Note: to avoid unnecessary resets, we firstly check if integrated camera is presented
-    #                   (Should always be there as it was built into machine!).
-    #                   If not, just do the reset.
-    services.workaround-reset-xhci-driver-after-resume-if-needed = {
-      script = ''
-        result=$(${pkgs.usbutils}/bin/lsusb | ${pkgs.gnugrep}/bin/grep Chicony)
-        if [[ -z $result ]]; then
-          ${pkgs.kmod}/bin/rmmod xhci_pci xhci_hcd
-          ${pkgs.kmod}/bin/modprobe xhci_pci xhci_hcd
-        fi
-      '';
-      after = [
-        "suspend.target"
-        "hibernate.target"
-        "hybrid-sleep.target"
-      ];
-      wantedBy = [
-        "suspend.target"
-        "hibernate.target"
-        "hybrid-sleep.target"
-        "multi-user.target"
-      ];
+    services = {
+      # Workaround: Sometimes xhci driver will become malfunctional after resuming from hibernate / suspend.
+      #             This will cause (almost) all external devices stop working.
+      #             A simple reset is enough to bring external devices alive :)
+      #
+      #             Note: to avoid unnecessary resets, we firstly check if integrated camera is presented
+      #                   (Should always be there as it was built into machine!).
+      #                   If not, just do the reset.
+      workaround-reset-xhci-driver-after-resume-if-needed = {
+        script = ''
+          result=$(${pkgs.usbutils}/bin/lsusb | ${pkgs.gnugrep}/bin/grep Chicony)
+          if [[ -z $result ]]; then
+            ${pkgs.kmod}/bin/rmmod xhci_pci xhci_hcd
+            ${pkgs.kmod}/bin/modprobe xhci_pci xhci_hcd
+          fi
+        '';
+        after = [
+          "suspend.target"
+          "hibernate.target"
+          "hybrid-sleep.target"
+        ];
+        wantedBy = [
+          "suspend.target"
+          "hibernate.target"
+          "hybrid-sleep.target"
+          "multi-user.target"
+        ];
+      };
+
+      # Workaround: i915 0000:00:02.0: [drm] Resetting rcs0 for stopped heartbeat on rcs0
+      # See https://gitlab.freedesktop.org/drm/intel/-/issues/4858#note_1425529
+      workaround-max-gpu-frequency-to-avoid-gpu-hang = {
+        script = ''
+          ${pkgs.intel-gpu-tools}/bin/intel_gpu_frequency -m
+        '';
+        after = [
+          "suspend.target"
+          "hibernate.target"
+          "hybrid-sleep.target"
+        ];
+        wantedBy = [
+          "suspend.target"
+          "hibernate.target"
+          "hybrid-sleep.target"
+          "multi-user.target"
+        ];
+      };
     };
 
     # Workaround: Lenovo seems write bad acpi power management firmware. Without this config,
     #             suspend (to ram / disk) will simply reboot instead of power off. :(
-    sleep.extraConfig = ''
-      HibernateMode=shutdown
-    '';
+    sleep =
+      if (nixosMajorVersion >= 26) then
+        {
+          settings.Sleep = {
+            HibernateMode = "shutdown";
+          };
+        }
+      else
+        {
+          extraConfig = ''
+            HibernateMode=shutdown
+          '';
+        };
   };
 
   # TPM2 module


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
- Add workaround for `i915 0000:00:02.0: [drm] GT0: Resetting chip for stopped heartbeat on rcs0`
- Use `systemd.sleep.settings.Sleep` because `nixos-unstable` deprecates `systemd.sleep.extraConfig`
- Add note about how to turn off rc6. [It will cause GPU hangs](https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/14469) and currently no mainlined workaround is applicable, unfortunately. So users have to manually turn it off in various ways
- Add note about dealing with `VK_ERROR_DEVICE_LOST`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

