### PR TITLE
onenetbook/4: update stylus patch for 6.18 / 7.0

### DIFF
--- a/onenetbook/4/goodix-stylus-mastykin/6.17.patch.patch
+++ b/onenetbook/4/goodix-stylus-mastykin/6.17.patch.patch
@@ -1,0 +1,36 @@
+--- orig.patch
++++ updated-6.17.patch
+@@ -10,11 +10,11 @@
+  /* quirks to control the device */
+  #define MT_QUIRK_NOT_SEEN_MEANS_UP	BIT(0)
+  #define MT_QUIRK_SLOT_IS_CONTACTID	BIT(1)
+-@@ -70,6 +73,7 @@
+- #define MT_QUIRK_WIN8_PTP_BUTTONS	BIT(18)
+- #define MT_QUIRK_SEPARATE_APP_REPORT	BIT(19)
+- #define MT_QUIRK_FORCE_MULTI_INPUT	BIT(20)
+-+#define MT_QUIRK_NON_MT_PEN		BIT(21)
++@@ -76,6 +76,7 @@
++ #define MT_QUIRK_DISABLE_WAKEUP		BIT(21)
++ #define MT_QUIRK_ORIENTATION_INVERT	BIT(22)
++ #define MT_QUIRK_APPLE_TOUCHBAR		BIT(23)
+++#define MT_QUIRK_NON_MT_PEN		BIT(24)
+  
+  #define MT_INPUTMODE_TOUCHSCREEN	0x02
+  #define MT_INPUTMODE_TOUCHPAD		0x03
+@@ -37,13 +37,13 @@
+  
+  struct mt_device {
+ @@ -208,6 +216,7 @@
+- #define MT_CLS_GOOGLE				0x0111
+  #define MT_CLS_RAZER_BLADE_STEALTH		0x0112
+  #define MT_CLS_SMART_TECH			0x0113
+-+#define MT_CLS_NON_MT_PEN			0x0114
++ #define MT_CLS_APPLE_TOUCHBAR			0x0114
+++#define MT_CLS_NON_MT_PEN			0x0115
++ #define MT_CLS_SIS				0x0457
+  
+  #define MT_DEFAULT_MAXCONTACT	10
+- #define MT_MAX_MAXCONTACT	250
+ @@ -374,6 +383,9 @@
+  			MT_QUIRK_CONTACT_CNT_ACCURATE |
+  			MT_QUIRK_SEPARATE_APP_REPORT,

--- a/onenetbook/4/goodix-stylus-mastykin/6.18.patch.patch
+++ b/onenetbook/4/goodix-stylus-mastykin/6.18.patch.patch
@@ -1,0 +1,40 @@
+--- orig.patch
++++ updated-6.18.patch
+@@ -10,11 +10,11 @@
+  /* quirks to control the device */
+  #define MT_QUIRK_NOT_SEEN_MEANS_UP	BIT(0)
+  #define MT_QUIRK_SLOT_IS_CONTACTID	BIT(1)
+-@@ -70,6 +73,7 @@
+- #define MT_QUIRK_WIN8_PTP_BUTTONS	BIT(18)
+- #define MT_QUIRK_SEPARATE_APP_REPORT	BIT(19)
+- #define MT_QUIRK_FORCE_MULTI_INPUT	BIT(20)
+-+#define MT_QUIRK_NON_MT_PEN		BIT(21)
++@@ -78,6 +78,7 @@
++ #define MT_QUIRK_APPLE_TOUCHBAR		BIT(23)
++ #define MT_QUIRK_YOGABOOK9I		BIT(24)
++ #define MT_QUIRK_KEEP_LATENCY_ON_CLOSE	BIT(25)
+++#define MT_QUIRK_NON_MT_PEN		BIT(26)
+  
+  #define MT_INPUTMODE_TOUCHSCREEN	0x02
+  #define MT_INPUTMODE_TOUCHPAD		0x03
+@@ -36,14 +36,15 @@
+  };
+  
+  struct mt_device {
+-@@ -208,6 +216,7 @@
+- #define MT_CLS_GOOGLE				0x0111
+- #define MT_CLS_RAZER_BLADE_STEALTH		0x0112
++@@ -233,6 +234,7 @@
+  #define MT_CLS_SMART_TECH			0x0113
+-+#define MT_CLS_NON_MT_PEN			0x0114
++ #define MT_CLS_APPLE_TOUCHBAR			0x0114
++ #define MT_CLS_YOGABOOK9I			0x0115
++ #define MT_CLS_EGALAX_P80H84			0x0116
+++#define MT_CLS_NON_MT_PEN			0x0117
++ #define MT_CLS_SIS				0x0457
+  
+  #define MT_DEFAULT_MAXCONTACT	10
+- #define MT_MAX_MAXCONTACT	250
+ @@ -374,6 +383,9 @@
+  			MT_QUIRK_CONTACT_CNT_ACCURATE |
+  			MT_QUIRK_SEPARATE_APP_REPORT,

--- a/onenetbook/4/goodix-stylus-mastykin/default.nix
+++ b/onenetbook/4/goodix-stylus-mastykin/default.nix
@@ -1,3 +1,7 @@
+# quick command for testing:
+# nix build -L --impure --no-link --expr \
+#   '(import <nixpkgs> {}).linuxPackages_6_18.callPackage ./default.nix {}'
+
 {
   stdenv,
   lib,
@@ -25,8 +29,20 @@ let
     cat ${patch1_original} > $out
     ${patch}/bin/patch $out < ${./6.12.patch.patch}
   '';
+  patch1_updated_6_17 = runCommand "goodix-stylus-mastykin-1-pen-support-6.17.patch" { } ''
+    cat ${patch1_original} > $out
+    ${patch}/bin/patch $out < ${./6.17.patch.patch}
+  '';
+  patch1_updated_6_18 = runCommand "goodix-stylus-mastykin-1-pen-support-6.18.patch" { } ''
+    cat ${patch1_original} > $out
+    ${patch}/bin/patch $out < ${./6.18.patch.patch}
+  '';
   patch1 =
-    if (lib.versionAtLeast kernel.version "6.12") then
+    if (lib.versionAtLeast kernel.version "6.18.18") then
+      patch1_updated_6_18
+    else if (lib.versionAtLeast kernel.version "6.17") then
+      patch1_updated_6_17
+    else if (lib.versionAtLeast kernel.version "6.12") then
       patch1_updated_6_12
     else if (lib.versionAtLeast kernel.version "6.1") then
       patch1_updated_6_1
@@ -51,17 +67,32 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   src = ./.;
-  patches = [
-    patch1
-    patch2
-  ];
 
-  postUnpack = ''
-    tar -C goodix-stylus-mastykin \
-      --strip-components=3 -xf ${kernel.src} --wildcards \
-      '*/drivers/hid/hid-ids.h' '*/drivers/hid/hid-multitouch.c'
+  # default patchPhase doesn't try hard enough
+  patchPhase = ''
+    runHook prePatch
+    patch -p3 hid-multitouch.c < ${patch1}
+    patch -p3 hid-multitouch.c < ${patch2}
+    runHook postPatch
   '';
-  patchFlags = "-p3";
+
+  postUnpack =
+    let
+      hid = "${kernel.src}/drivers/hid";
+    in
+    ''
+      if [ -d ${kernel.src} ]; then  # -latest kernel
+        cp ${hid}/hid-ids.h ${hid}/hid-multitouch.c goodix-stylus-mastykin/
+        cp ${hid}/hid-haptic.h goodix-stylus-mastykin/ 2>/dev/null || true
+      else  # stable kernels with tarballs
+        tar -C goodix-stylus-mastykin \
+          --strip-components=3 -xf ${kernel.src} --wildcards \
+          '*/drivers/hid/hid-ids.h' '*/drivers/hid/hid-multitouch.c'
+        tar -C goodix-stylus-mastykin \
+          --strip-components=3 -xf ${kernel.src} --wildcards \
+          '*/drivers/hid/hid-haptic.h' 2>/dev/null || true
+      fi
+    '';
   postPatch = ''
     mv hid-multitouch.c hid-multitouch-onenetbook4.c
     substituteInPlace hid-multitouch-onenetbook4.c --replace \


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

I carry a patch for OneNetbook 4's custom stylus input, and it needs periodic updating for newer kernels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input