### PR TITLE
lenovo/ideapad/15iah7: Add IdeaPad Gaming 3 15IAH7 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ See code for all available configurations.
 | [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                                  | `<nixos-hardware/lenovo/ideapad/15alc6>`                | `lenovo-ideapad-15alc6`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)                         | `<nixos-hardware/lenovo/ideapad/15arh05>`               | `lenovo-ideapad-15arh05`               |
 | [Lenovo IdeaPad Gaming 3 15ach6](lenovo/ideapad/15ach6)                           | `<nixos-hardware/lenovo/ideapad/15ach6>`                | `lenovo-ideapad-15ach6`                |
+| [Lenovo IdeaPad Gaming 3 15iah7](lenovo/ideapad/15iah7)                           | `<nixos-hardware/lenovo/ideapad/15iah7>`                |       `lenovo-ideapad-15iah7`                |
 | [Lenovo IdeaPad 5 Pro 14imh9](lenovo/ideapad/14imh9)                              | `<nixos-hardware/lenovo/ideapad/14imh9>`                | `lenovo-ideapad-14imh9`                |
 | [Lenovo IdeaPad 5 Pro 16ach6](lenovo/ideapad/16ach6)                              | `<nixos-hardware/lenovo/ideapad/16ach6>`                | `lenovo-ideapad-16ach6`                |
 | [Lenovo IdeaPad Z510](lenovo/ideapad/z510)                                        | `<nixos-hardware/lenovo/ideapad/z510>`                  | `lenovo-ideapad-z510`                  |

--- a/flake.nix
+++ b/flake.nix
@@ -214,6 +214,7 @@
           lenovo-ideapad-15alc6 = import ./lenovo/ideapad/15alc6;
           lenovo-ideapad-15arh05 = import ./lenovo/ideapad/15arh05;
           lenovo-ideapad-15ach6 = import ./lenovo/ideapad/15ach6;
+          lenovo-ideapad-15iah7 = import ./lenovo/ideapad/15iah7;
           lenovo-ideapad-16ach6 = import ./lenovo/ideapad/16ach6;
           lenovo-ideapad-16ahp9 = import ./lenovo/ideapad/16ahp9;
           lenovo-ideapad-s5-16iah8 = import ./lenovo/ideapad/16iah8;

--- a/lenovo/ideapad/15iah7/README.md
+++ b/lenovo/ideapad/15iah7/README.md
@@ -1,0 +1,33 @@
+# Lenovo IdeaPad Gaming 3 15IAH7
+
+This profile provides configuration for the Lenovo IdeaPad Gaming 3 15IAH7 (82S9).
+
+## Features
+- **CPU:** Intel 12th Gen (Alder Lake) support.
+- **GPU:** Hybrid graphics support via NVIDIA Prime (Ampere).
+- **Battery & Hardware Control:** Specialized group and permissions for IdeaPad-specific ACPI features.
+
+## Hardware Control
+This profile creates a Unix group called `ideapad_laptop`. Users in this group can modify hardware settings in `/sys/bus/platform/drivers/ideapad_acpi/` without root privileges.
+
+To enable this for your user:
+```nix
+users.users.yourusername.extraGroups = [ "ideapad_laptop" ];
+```
+
+Once added, you can toggle features like **Conservation Mode** (limits charge to 60% to extend battery lifespan) via the command line:
+```bash
+# Enable Conservation Mode
+echo 1 > /sys/bus/platform/drivers/ideapad_acpi/pnp*/conservation_mode
+```
+
+## NVIDIA Prime
+This laptop uses a hybrid GPU setup. While this profile enables the driver pattern, you must define the exact PCI Bus IDs in your `configuration.nix` if they differ from the defaults:
+
+```nix
+hardware.nvidia.prime = {
+  intelBusId = "PCI:0:2:0";
+  nvidiaBusId = "PCI:1:0:0";
+};
+```
+*Note: You can find these IDs by running `lspci | grep -E "VGA|3D"`.*

--- a/lenovo/ideapad/15iah7/default.nix
+++ b/lenovo/ideapad/15iah7/default.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ampere
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  users.groups.ideapad_laptop = { };
+
+  systemd.tmpfiles.rules =
+    map (node: "z /sys/bus/platform/drivers/ideapad_acpi/*/${node} 0664 - ideapad_laptop -")
+      [
+        "conservation_mode"
+        "camera_power"
+        "fan_mode"
+        "fn_lock"
+        "touchpad"
+        "usb_charging"
+      ];
+
+  boot.kernelModules = [
+    "ideapad_laptop"
+  ];
+
+  hardware.nvidia.prime = {
+    intelBusId = lib.mkDefault "PCI:0:2:0";
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
+}


### PR DESCRIPTION
This PR introduces Lenovo's 15IAH7 for nixos-hardware. Let me know if anything doesn't look right or if I wasn't supposed to do something the way I've done in this PR.

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

