### PR TITLE
dell/precision/5820: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ See code for all available configurations.
 | [Dell Precision 5530](dell/precision/5530)                                        | `<nixos-hardware/dell/precision/5530>`                  | `dell-precision-5530`                  |
 | [Dell Precision 5560](dell/precision/5560)                                        | `<nixos-hardware/dell/precision/5560>`                  | `dell-precision-5560`                  |
 | [Dell Precision 5570](dell/precision/5570)                                        | `<nixos-hardware/dell/precision/5570>`                  | `dell-precision-5570`                  |
+| [Dell Precision 5820](dell/precision/5820)                                        | `<nixos-hardware/dell/precision/5820>`                  | `dell-precision-5820`                  |
 | [Dell Precision 7520](dell/precision/7520)                                        | `<nixos-hardware/dell/precision/7520>`                  | `dell-precision-7520`                  |
 | [Dell XPS 13 7390](dell/xps/13-7390)                                              | `<nixos-hardware/dell/xps/13-7390>`                     | `dell-xps-13-7390`                     |
 | [Dell XPS 13 9300](dell/xps/13-9300)                                              | `<nixos-hardware/dell/xps/13-9300>`                     | `dell-xps-13-9300`                     |

--- a/dell/precision/5820/default.nix
+++ b/dell/precision/5820/default.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  ...
+}:
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/pc
+    ../../../common/pc/ssd
+    ../../../common/gpu/nvidia
+  ];
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  boot.initrd.availableKernelModules = [
+    "xhci_pci"
+    "ahci"
+    "vmd"
+    "nvme"
+  ];
+
+  hardware = {
+    nvidia = {
+      nvidiaSettings = lib.mkDefault true;
+      package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.legacy_580;
+      open = lib.mkDefault false;
+    };
+  };
+
+  powerManagement.cpuFreqGovernor = lib.mkDefault "performance";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,7 @@
           dell-precision-5530 = import ./dell/precision/5530;
           dell-precision-5560 = import ./dell/precision/5560;
           dell-precision-5570 = import ./dell/precision/5570;
+          dell-precision-5820 = import ./dell/precision/5820;
           dell-precision-7520 = import ./dell/precision/7520;
           dell-xps-13-7390 = import ./dell/xps/13-7390;
           dell-xps-13-9300 = import ./dell/xps/13-9300;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
add Dell Precision 5820 Tower

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

