### PR TITLE
raspberry-pi/common/kernel: 6.12.47-stable_20250916 -> 6.12.75-1+rpt1

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -10,22 +10,23 @@
 
 let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.12.47";
-  tag = "stable_20250916";
-  hash = "sha256-HG8Oc04V2t54l0SOn4gKmNJWQUrZfjWusgKcWvx74H0==";
+  modDirVersion = "6.12.75";
+  hash = "sha256-qrljd20n4tj/7C7gzNnxw7JIyEF2Ppf1PWm2a7vxh1w=";
 in
 lib.overrideDerivation
   (buildLinux (
     args
     // {
-      version = "${modDirVersion}-${tag}";
+      version = "${modDirVersion}-1+rpt1";
       inherit modDirVersion;
       pname = "linux-rpi";
 
       src = fetchFromGitHub {
         owner = "raspberrypi";
         repo = "linux";
-        inherit tag hash;
+        # https://github.com/RPi-Distro/linux-packaging/raw/refs/tags/pios/1%256.12.75-1+rpt1/debian/changelog
+        rev = "89050b1059997d38d55462b323b099a6436dc10d";
+        inherit hash;
       };
 
       defconfig =

--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -10,21 +10,22 @@
 
 let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.12.47";
-  tag = "stable_20250916";
-  hash = "sha256-HG8Oc04V2t54l0SOn4gKmNJWQUrZfjWusgKcWvx74H0==";
+  modDirVersion = "6.12.75";
+  hash = "sha256-qrljd20n4tj/7C7gzNnxw7JIyEF2Ppf1PWm2a7vxh1w=";
 in
 (buildLinux (
   args
   // {
-    version = "${modDirVersion}-${tag}";
+    version = "${modDirVersion}-1+rpt1";
     inherit modDirVersion;
     pname = "linux-rpi";
 
     src = fetchFromGitHub {
       owner = "raspberrypi";
       repo = "linux";
-      inherit tag hash;
+      # https://github.com/RPi-Distro/linux-packaging/raw/refs/tags/pios/1%256.12.75-1+rpt1/debian/changelog
+      rev = "89050b1059997d38d55462b323b099a6436dc10d";
+      inherit hash;
     };
 
     defconfig =


### PR DESCRIPTION
###### Description of changes

As mentioned in Nixpkgs PR [^1], Raspberry Pi folks stop tagging both raspberrypi/linux and raspberrypi/firmware GitHub repo. So, I switched my reference point to Raspberry Pi OS, which publishes their packaging for Linux kernel in RPi-Distro/linux-packaging.

The version is set to Debian packaging's version, and the commit comes from the changelog entry for that version.

The old code structure is somewhat kept in case Raspberry Pi ever tags their raspberrypi/linux repo again.

[^1]: https://github.com/NixOS/nixpkgs/pull/493115

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

