### PR TITLE
update(dell/precision/5530): added kernel modules for better out of the box compatibility

### DIFF
--- a/dell/precision/5530/default.nix
+++ b/dell/precision/5530/default.nix
@@ -27,11 +27,11 @@
     ];
     initrd.availableKernelModules = [
       "xhci_pci"
-        "ahci"
-        "nvme"
-        "usb_storage"
-        "sd_mod"
-        "rtsx_pci_sdmmc"
+      "ahci"
+      "nvme"
+      "usb_storage"
+      "sd_mod"
+      "rtsx_pci_sdmmc"
     ];
   };
 

--- a/dell/precision/5530/default.nix
+++ b/dell/precision/5530/default.nix
@@ -25,6 +25,14 @@
       "i915.enable_psr=0"
       "nvidia_drm.modeset=1"
     ];
+    initrd.availableKernelModules = [
+      "xhci_pci"
+        "ahci"
+        "nvme"
+        "usb_storage"
+        "sd_mod"
+        "rtsx_pci_sdmmc"
+    ];
   };
 
   hardware = {

--- a/dell/precision/5530/default.nix
+++ b/dell/precision/5530/default.nix
@@ -26,13 +26,13 @@
       "nvidia_drm.modeset=1"
     ];
     initrd.availableKernelModules = [
-      "xhci_pci"
-      "ahci"
-      "nvme"
-      "usb_storage"
-      "sd_mod"
-      "rtsx_pci_sdmmc"
-      "thunderbolt"
+      "xhci_pci" # USB 3.0/3.1 compatibility
+      "ahci" # SATA support if installed
+      "nvme" # NVMe support
+      "usb_storage" # USB mass storage support
+      "sd_mod" # SD card support
+      "rtsx_pci_sdmmc" # Realtek SD card support
+      "thunderbolt" # Thunderbolt support
     ];
     kernelModules = [
       # For Intel wifi card

--- a/dell/precision/5530/default.nix
+++ b/dell/precision/5530/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ pkgs, lib, ... }:
 
 {
   imports = [
@@ -32,10 +32,26 @@
       "usb_storage"
       "sd_mod"
       "rtsx_pci_sdmmc"
+      "thunderbolt"
+    ];
+    kernelModules = [
+      # For Intel wifi card
+      "iwlwifi"
+      # Intel thermal/power management
+      "intel_lpss_pci"
+      "intel_pch_thermal"
+      "processor_thermal_device"
+      "intel_hid"
+      "dell_wmi"
+      "dell_smm" # Dell hardware monitoring
     ];
   };
 
   hardware = {
+    firmware = with pkgs; [
+      linux-firmware # Intel WiFi, Bluetooth, GPU, Thunderbolt, NVMe
+      alsa-firmware # Realtek audio codec
+    ];
     nvidia = {
       nvidiaSettings = lib.mkDefault true;
       modesetting.enable = lib.mkDefault true;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Added multiple kernel modules for better compatibility with all Precision 5530 models, and the necessary firmware and kernel modules for full functionality.

I don't know if I should enable `hardware.enableRedistributableFirmware`, because without it everything works, and with it it installs some firmware that is not useful 🤷🏻

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

