### PR TITLE
raspberry/pi/4: disable compat checks when merging overlays

### DIFF
--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -34,32 +34,17 @@ with lib;
           ${flip (concatMapStringsSep "\n") overlays (o: ''
             overlayCompat="$(fdtget -t s "${o.dtboFile}" / compatible)"
 
-            # skip incompatible and non-matching overlays
-            if [[ ! "$dtbCompat" =~ "$overlayCompat" ]]; then
-              echo "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
-            elif ${
-              if ((o.filter or null) == null) then
-                "false"
-              else
-                ''
-                  [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]
-                ''
-            }
-            then
-              echo "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
-            else
-              echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
-              mv "$dtb"{,.in}
+            echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
+            mv "$dtb"{,.in}
 
-              # dtmerge requires a .dtbo ext for dtbo files, otherwise it adds it to the given file implicitly
-              dtboWithExt="$TMPDIR/$(basename "${o.dtboFile}").dtbo"
-              cp -r ${o.dtboFile} "$dtboWithExt"
+            # dtmerge requires a .dtbo ext for dtbo files, otherwise it adds it to the given file implicitly
+            dtboWithExt="$TMPDIR/$(basename "${o.dtboFile}").dtbo"
+            cp -r ${o.dtboFile} "$dtboWithExt"
 
-              dtmerge "$dtb.in" "$dtb" "$dtboWithExt"
+            dtmerge "$dtb.in" "$dtb" "$dtboWithExt"
 
-              echo "ok"
-              rm "$dtb.in" "$dtboWithExt"
-            fi
+            echo "ok"
+            rm "$dtb.in" "$dtboWithExt"
           '')}
 
         done'';

--- a/raspberry-pi/4/apply-overlays-dtmerge.nix
+++ b/raspberry-pi/4/apply-overlays-dtmerge.nix
@@ -27,17 +27,12 @@ with lib;
           | xargs -0 cp -v --no-preserve=mode --target-directory "$out" --parents
 
         for dtb in $(find "$out" -type f -name '*.dtb'); do
-          dtbCompat=$(fdtget -t s "$dtb" / compatible 2>/dev/null || true)
           # skip files without `compatible` string
-          test -z "$dtbCompat" && continue
+          fdtget -t s "$dtb" / compatible 2>/dev/null || continue
 
           ${flip (concatMapStringsSep "\n") overlays (o: ''
-            overlayCompat="$(fdtget -t s "${o.dtboFile}" / compatible)"
-
-            # skip incompatible and non-matching overlays
-            if [[ ! "$dtbCompat" =~ "$overlayCompat" ]]; then
-              echo "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
-            elif ${
+            # skip non-matching overlays
+            if ${
               if ((o.filter or null) == null) then
                 "false"
               else


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Disables compatibility checks for Pi 4 overlays per https://github.com/NixOS/nixos-hardware/issues/1529

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

