### PR TITLE
fix: enable acpi.ec_no_wakeup in Thinkpad T14 AMD Gen 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`         | `lenovo-thinkpad-t14-amd-gen3`         |
 | [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         | `lenovo-thinkpad-t14-amd-gen4`         |
 | [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         | `lenovo-thinkpad-t14-amd-gen5`         |
+| [Lenovo ThinkPad T14 AMD Gen 6](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen6>`         | `lenovo-thinkpad-t14-amd-gen6`         |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                                        | `<nixos-hardware/lenovo/thinkpad/t14>`                  | `lenovo-thinkpad-t14`                  |
 | [Lenovo ThinkPad T14 Intel Gen 1](lenovo/thinkpad/t14/intel/gen1)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1>`       | `lenovo-thinkpad-t14-intel-gen1`       |
 | [Lenovo ThinkPad T14 Intel Gen 1 (Nvidia)](lenovo/thinkpad/t14/intel/gen1/nvidia) | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1/nvidia>`| `lenovo-thinkpad-t14-intel-gen1-nvidia`|

--- a/flake.nix
+++ b/flake.nix
@@ -287,6 +287,7 @@
           lenovo-thinkpad-t14-amd-gen3 = import ./lenovo/thinkpad/t14/amd/gen3;
           lenovo-thinkpad-t14-amd-gen4 = import ./lenovo/thinkpad/t14/amd/gen4;
           lenovo-thinkpad-t14-amd-gen5 = import ./lenovo/thinkpad/t14/amd/gen5;
+          lenovo-thinkpad-t14-amd-gen6 = import ./lenovo/thinkpad/t14/amd/gen6;
           lenovo-thinkpad-t14-intel-gen1 = import ./lenovo/thinkpad/t14/intel/gen1;
           lenovo-thinkpad-t14-intel-gen1-nvidia = import ./lenovo/thinkpad/t14/intel/gen1/nvidia;
           lenovo-thinkpad-t14-intel-gen6 = import ./lenovo/thinkpad/t14/intel/gen6;

--- a/lenovo/thinkpad/t14/amd/gen6/default.nix
+++ b/lenovo/thinkpad/t14/amd/gen6/default.nix
@@ -1,0 +1,14 @@
+{
+  ...
+}:
+
+{
+  imports = [
+    ../.
+    ../../../../../common/cpu/amd/pstate.nix
+  ];
+
+  # Embedded controller wake-ups drain battery in s2idle on this device
+  # See https://lore.kernel.org/all/ZnFYpWHJ5Ml724Nv@ohnotp/
+  boot.kernelParams = [ "acpi.ec_no_wakeup=1" ];
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Add acpi.ec_no_wakeup=1 kernel param to stop the embedded controller from waking the system during s2idle. Fixes wake-on-plug for USB-C charger and peripheral hot-plug on ThinkPad T14 Gen 6 AMD.

This is the same fix required in Gen 5 of the Thinkpad T14 series.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

