### PR TITLE
Add config for HP Victus 16-e0105nw

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -209,6 +209,7 @@
           hp-laptop-15s-fq1xxx = import ./hp/laptop/15s-fq1xxx;
           huawei-machc-wa = import ./huawei/machc-wa;
           hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
+          hp-victus-16-e0105nw = import ./hp/victus/16-e0105nw;
           intel-nuc-5i5ryb = import ./intel/nuc/5i5ryb;
           intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
           intel-nuc-12wshi7 = import ./intel/nuc/12wshi7;

--- a/hp/victus/16-e0105nw/default.nix
+++ b/hp/victus/16-e0105nw/default.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ampere
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  hardware.nvidia = {
+    modesetting.enable = lib.mkDefault true;
+    open = lib.mkDefault false;
+    nvidiaSettings = lib.mkDefault true;
+    dynamicBoost.enable = lib.mkDefault true;
+
+    prime = {
+      amdgpuBusId = "PCI:7:0:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes
This PR adds Nvidia configuration for the HP Victus 16-e0105nw laptop (Ryzen 5 5600H + Nvidia RTX 3050).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

I'm only not sure if the name I used is the right one. Fastfetch reports the host name as `103C_5335M7` (which is what `/sys/class/dmi/id/product_family` reports). But in shops the model is called `HP Victus 16-e0105nw`.