### PR TITLE
Enable fprintd and fwupd by default for Dell XPS 13 9350

### DIFF
--- a/dell/xps/13-9350/README.md
+++ b/dell/xps/13-9350/README.md
@@ -1,0 +1,13 @@
+# [Dell XPS 13 9350](https://www.dell.com/en-us/shop/dell-laptops/xps-13-laptop/spd/xps-13-9350-intel-laptop)
+
+The ones with Intel Core Ultra 256V/258V/288V ("Lunar Lake") SoCs.
+
+## Fingerprint Sensor
+
+On top of power button. To enable, use `fprintd-enroll`.
+
+## Updating Firmware
+
+This device is supported by [fwupd](https://fwupd.org/). To perform updates, simply use `fwupdmgr`.
+
+- [Latest Update](https://fwupd.org/lvfs/devices/com.dell.uefi1a99170e.firmware)

--- a/dell/xps/13-9350/default.nix
+++ b/dell/xps/13-9350/default.nix
@@ -15,6 +15,9 @@
   # Configure for the current user via `fprintd-enroll`.
   services.fprintd.enable = lib.mkDefault true;
 
+  # Allows for updating firmware via `fwupdmgr`.
+  services.fwupd.enable = lib.mkDefault true;
+
   # Recommended in NixOS/nixos-hardware#127
   services.thermald.enable = lib.mkDefault true;
 }

--- a/dell/xps/13-9350/default.nix
+++ b/dell/xps/13-9350/default.nix
@@ -10,6 +10,11 @@
   # The touchpad uses I²C, so PS/2 is unnecessary
   boot.blacklistedKernelModules = [ "psmouse" ];
 
+  # Enable fingerprint sensor located on the power button.
+  # Works out of the box with fprintd and no additional packages/drivers.
+  # Configure for the current user via `fprintd-enroll`.
+  services.fprintd.enable = lib.mkDefault true;
+
   # Recommended in NixOS/nixos-hardware#127
   services.thermald.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
Can be overridden, but enabled by default.

###### Description of changes

Enables `fprintd` and `fwupd` by default for Dell XPS 13 9350 (2024/Lunar Lake).

* `fprintd` - Enables support for the built-in fingerprint sensor.
* `fwupd` - Enables updating system firmware.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

