### PR TITLE
framework: import ultra series 3 in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -177,6 +177,7 @@
           framework-13th-gen-intel = import ./framework/13-inch/13th-gen-intel;
           framework-12-13th-gen-intel = import ./framework/12-inch/13th-gen-intel;
           framework-intel-core-ultra-series1 = import ./framework/13-inch/intel-core-ultra-series1;
+          framework-intel-core-ultra-series3 = import ./framework/13-inch/intel-core-ultra-series3;
           framework-13-7040-amd = import ./framework/13-inch/7040-amd;
           framework-amd-ai-300-series = import ./framework/13-inch/amd-ai-300-series;
           framework-16-7040-amd = import ./framework/16-inch/7040-amd;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Found this missing trying to rebuild my configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

