### PR TITLE
framework: Add package for official wallpapers

### DIFF
--- a/framework/12-inch/common/default.nix
+++ b/framework/12-inch/common/default.nix
@@ -5,6 +5,7 @@
     ../../../common/pc/ssd
     ../../kmod.nix
     ../../framework-tool.nix
+    ../../wallpapers.nix
   ];
 
   # Fix TRRS headphones missing a mic

--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -6,6 +6,7 @@
     ../../kmod.nix
     ../../framework-tool.nix
     ./classic-audio.nix
+    ../../wallpapers.nix
   ];
 
   # Fix TRRS headphones missing a mic

--- a/framework/16-inch/common/default.nix
+++ b/framework/16-inch/common/default.nix
@@ -5,6 +5,7 @@
     ../../../common/pc/ssd
     ../../kmod.nix
     ../../framework-tool.nix
+    ../../wallpapers.nix
   ];
 
   # For fingerprint support

--- a/framework/README.md
+++ b/framework/README.md
@@ -62,6 +62,33 @@ On AMD Framework 13 and 16, before kernel 6.10, additional kernel patches are re
 properly. Manually setting `hardware.framework.enableKmod = true` will apply the patches, requiring a kernel
 recompilation.
 
+## Wallpapers
+
+Framework publishes [wallpaper packs](https://frame.work/wallpapers) for each
+laptop and the Framework Desktop. Each pack is opt-in and registers with GNOME
+and KDE Plasma's wallpaper pickers. Enable the one(s) matching your hardware:
+
+```nix
+# Just the Framework Laptop 13 Pro (Intel Core Ultra Series 3) pack
+hardware.framework.wallpapers.laptop13pro.enable = true;
+
+# Or install every pack
+hardware.framework.wallpapers.enableAll = true;
+```
+
+Available packs: `desktop`, `laptop12`, `laptop13`, `laptop13pro`, `laptop16`.
+
+Once enabled, the wallpapers appear in GNOME's *Settings → Appearance* and
+KDE Plasma's wallpaper picker. To set one as the default in GNOME, add a
+GSettings override, e.g.:
+
+```nix
+services.desktopManager.gnome.extraGSettingsOverrides = ''
+  [org.gnome.desktop.background]
+  picture-uri='file:///run/current-system/sw/share/backgrounds/framework-laptop13pro-wallpapers/framework-laptop13pro-1.png'
+'';
+```
+
 ## Support Tools
 
 ### fw-ectool

--- a/framework/desktop/amd-ai-max-300-series/default.nix
+++ b/framework/desktop/amd-ai-max-300-series/default.nix
@@ -11,6 +11,7 @@
     ../../../common/gpu/amd
     ../../../common/pc/ssd
     ../../framework-tool.nix
+    ../../wallpapers.nix
   ];
 
   # 6.14 and above have good GPU support

--- a/framework/wallpapers.nix
+++ b/framework/wallpapers.nix
@@ -1,0 +1,148 @@
+# Framework-branded wallpaper packs, installed system-wide so GNOME and
+# KDE Plasma wallpaper pickers can find them.
+#
+# Each pack is opt-in; pick the ones that match your hardware, for example:
+#   hardware.framework.wallpapers.laptop13pro.enable = true;
+#
+# Or enable every pack at once:
+#   hardware.framework.wallpapers.enableAll = true;
+#
+# To set one as the default in GNOME, add a GSettings override, e.g.:
+#   services.desktopManager.gnome.extraGSettingsOverrides = ''
+#     [org.gnome.desktop.background]
+#     picture-uri='file:///run/current-system/sw/share/backgrounds/framework-laptop13pro-wallpapers/framework-laptop13pro-1.png'
+#   '';
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.framework.wallpapers;
+
+  mkPack =
+    {
+      id,
+      url,
+      hash,
+    }:
+    pkgs.stdenvNoCC.mkDerivation {
+      pname = "framework-${id}-wallpapers";
+      version = "2026-04-24";
+      src = pkgs.fetchzip {
+        inherit url hash;
+        stripRoot = false;
+        # The CDN rejects curl's default user agent with HTTP 408
+        curlOptsList = [
+          "--user-agent"
+          "Mozilla/5.0"
+        ];
+      };
+
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        bg_dir="$out/share/backgrounds/framework-${id}-wallpapers"
+        mkdir -p "$bg_dir" "$out/share/gnome-background-properties"
+
+        xml="$out/share/gnome-background-properties/framework-${id}.xml"
+        {
+          echo '<?xml version="1.0" encoding="UTF-8"?>'
+          echo '<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">'
+          echo '<wallpapers>'
+        } > "$xml"
+
+        i=1
+        while IFS= read -r -d "" f; do
+          base=$(basename "$f")
+          ext="''${base##*.}"
+          name="''${base%.*}"
+          slug="framework-${id}-$i"
+          dest="$bg_dir/$slug.$ext"
+          cp "$f" "$dest"
+
+          {
+            echo '  <wallpaper deleted="false">'
+            echo "    <name>$name</name>"
+            echo "    <filename>$dest</filename>"
+            echo '    <options>zoom</options>'
+            echo '    <shade_type>solid</shade_type>'
+            echo '    <pcolor>#000000</pcolor>'
+            echo '    <scolor>#000000</scolor>'
+            echo '  </wallpaper>'
+          } >> "$xml"
+
+          kde_dir="$out/share/wallpapers/$slug/contents/images"
+          mkdir -p "$kde_dir"
+          ln -s "$dest" "$kde_dir/$slug.$ext"
+          {
+            echo '[Desktop Entry]'
+            echo "Name=$name"
+            echo "X-KDE-PluginInfo-Name=$slug"
+          } > "$out/share/wallpapers/$slug/metadata.desktop"
+
+          i=$((i + 1))
+        done < <(find "$src" -type f \( -iname '*.png' -o -iname '*.jpg' \) -print0 | sort -z)
+
+        echo '</wallpapers>' >> "$xml"
+
+        runHook postInstall
+      '';
+
+      meta = {
+        description = "Framework ${id} wallpaper pack";
+        homepage = "https://frame.work/wallpapers";
+        platforms = lib.platforms.all;
+      };
+    };
+
+  packs = {
+    desktop = mkPack {
+      id = "desktop";
+      url = "https://downloads.frame.work/assets/framework-desktop-wallpaper-pack.zip";
+      hash = "sha256-MRCBf+8lWJMf6xys3aV4a5yeJOfrqU0ntoEGV7QAGe4=";
+    };
+    laptop12 = mkPack {
+      id = "laptop12";
+      url = "https://downloads.frame.work/assets/framework-laptop12-wallpaper-pack.zip";
+      hash = "sha256-r6VCLMBd0HtR9YzDg94UB7FuuNa4PTsjvpPCR3MHKRA=";
+    };
+    laptop13 = mkPack {
+      id = "laptop13";
+      url = "https://downloads.frame.work/assets/framework-laptop13-wallpaper-pack.zip";
+      hash = "sha256-biTp0uoEFScCyulszGSwdceC97xouOMQgoivB43vZpo=";
+    };
+    laptop13pro = mkPack {
+      id = "laptop13pro";
+      url = "https://downloads.frame.work/assets/framework-laptop13pro-wallpaper-pack.zip";
+      hash = "sha256-BHo7glMjORE5IPRPTfScJ4QBXqiu/+Ga7oruH6rHYms=";
+    };
+    laptop16 = mkPack {
+      id = "laptop16";
+      url = "https://downloads.frame.work/assets/framework-laptop16-wallpaper-pack.zip";
+      hash = "sha256-u+zWlIVZ/Gqk71F6r35Y1akLCwcVxcP/CzDZWcmsSU8=";
+    };
+  };
+in
+{
+  options.hardware.framework.wallpapers = {
+    enableAll = lib.mkEnableOption "all Framework wallpaper packs";
+    desktop.enable = lib.mkEnableOption "the Framework Desktop wallpaper pack";
+    laptop12.enable = lib.mkEnableOption "the Framework Laptop 12 wallpaper pack";
+    laptop13.enable = lib.mkEnableOption "the Framework Laptop 13 wallpaper pack";
+    laptop13pro.enable = lib.mkEnableOption "the Framework Laptop 13 Pro wallpaper pack";
+    laptop16.enable = lib.mkEnableOption "the Framework Laptop 16 wallpaper pack";
+  };
+
+  config.environment.systemPackages = lib.concatLists [
+    (lib.optional (cfg.enableAll || cfg.desktop.enable) packs.desktop)
+    (lib.optional (cfg.enableAll || cfg.laptop12.enable) packs.laptop12)
+    (lib.optional (cfg.enableAll || cfg.laptop13.enable) packs.laptop13)
+    (lib.optional (cfg.enableAll || cfg.laptop13pro.enable) packs.laptop13pro)
+    (lib.optional (cfg.enableAll || cfg.laptop16.enable) packs.laptop16)
+  ];
+}


### PR DESCRIPTION
###### Description of changes
See README

<img width="2150" height="1606" alt="image" src="https://github.com/user-attachments/assets/569e97dc-2d80-4438-a458-ee7b70eb1413" />


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

