### PR TITLE
raspberry-pi: fix DTB name mapping for U-Boot

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -71,42 +71,37 @@ in
       sed -i $buildRoot/include/config/auto.conf -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
     '';
 
-    # Make copies of the DTBs named after the upstream names so that U-Boot finds them.
-    # This is ugly as heck, but I don't know a better solution so far.
-    postFixup = ''
-      dtbDir=${if stdenv.hostPlatform.isAarch64 then "$out/dtbs/broadcom" else "$out/dtbs"}
-      rm $dtbDir/bcm283*.dtb
-      copyDTB() {
-        cp -v "$dtbDir/$1" "$dtbDir/$2"
-      }
-    ''
-    + lib.optionalString (lib.elem stdenv.hostPlatform.system [ "armv6l-linux" ]) ''
-      copyDTB bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero.dtb
-      copyDTB bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero-w.dtb
-      copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
-      copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-b.dtb
-      copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-b-rev2.dtb
-      copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-a-plus.dtb
-      copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-b-plus.dtb
-      copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-zero.dtb
-      copyDTB bcm2708-rpi-cm.dtb bcm2835-rpi-cm.dtb
-    ''
-    + lib.optionalString (lib.elem stdenv.hostPlatform.system [ "armv7l-linux" ]) ''
-      copyDTB bcm2709-rpi-2-b.dtb bcm2836-rpi-2-b.dtb
-    ''
-    +
-      lib.optionalString
-        (lib.elem stdenv.hostPlatform.system [
-          "armv7l-linux"
-          "aarch64-linux"
-        ])
-        ''
-          copyDTB bcm2710-rpi-zero-2.dtb bcm2837-rpi-zero-2.dtb
-          copyDTB bcm2710-rpi-zero-2-w.dtb bcm2837-rpi-zero-2-w.dtb
-          copyDTB bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
-          copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-a-plus.dtb
-          copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
-          copyDTB bcm2710-rpi-cm3.dtb bcm2837-rpi-cm3.dtb
-          copyDTB bcm2711-rpi-4-b.dtb bcm2838-rpi-4-b.dtb
-        '';
+    # The vendor kernel uses different DTB names (bcm2708/bcm2709/bcm2710) than what
+    # U-Boot expects (bcm2835/bcm2836/bcm2837). Starting with Pi 4, names match.
+    # See: https://github.com/u-boot/u-boot/blob/master/board/raspberrypi/rpi/rpi.c
+    postFixup = lib.optionalString (rpiVersion < 4) (
+      ''
+        dtbDir=${if stdenv.hostPlatform.isAarch64 then "$out/dtbs/broadcom" else "$out/dtbs"}
+        rm $dtbDir/bcm283*.dtb
+        copyDTB() {
+          cp -v "$dtbDir/$1" "$dtbDir/$2"
+        }
+      ''
+      + lib.optionalString (rpiVersion == 1) ''
+        copyDTB bcm2708-rpi-zero.dtb bcm2835-rpi-zero.dtb
+        copyDTB bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero-w.dtb
+        copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
+        copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-b.dtb
+        copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-b-rev2.dtb
+        copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-a-plus.dtb
+        copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-b-plus.dtb
+        copyDTB bcm2708-rpi-cm.dtb bcm2835-rpi-cm.dtb
+      ''
+      + lib.optionalString (rpiVersion == 2) ''
+        copyDTB bcm2709-rpi-2-b.dtb bcm2836-rpi-2-b.dtb
+      ''
+      + lib.optionalString (rpiVersion == 3) ''
+        copyDTB bcm2710-rpi-zero-2.dtb bcm2837-rpi-zero-2.dtb
+        copyDTB bcm2710-rpi-zero-2-w.dtb bcm2837-rpi-zero-2-w.dtb
+        copyDTB bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
+        copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-a-plus.dtb
+        copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
+        copyDTB bcm2710-rpi-cm3.dtb bcm2837-rpi-cm3.dtb
+      ''
+    );
   }


### PR DESCRIPTION
The `postFixup` in kernel.nix renames the vendor kernel's DTBs so U-Boot can find them. U-Boot's lookup table is in `rpi.c` (`rpi_models_new_scheme[]` / `rpi_models_old_scheme[]`), and the only thing that varies per board within a family is the suffix — the prefix is the SoC:

| SoC (rpiVersion) | U-Boot expects | Vendor kernel produces |
| --- | --- | --- |
| BCM2835 (1) | `bcm2835-*` | `bcm2708-*` |
| BCM2836 (2) | `bcm2836-*` | `bcm2709-*` |
| BCM2837 (3) | `bcm2837-*` | `bcm2710-*` |
| BCM2711 (4) | `bcm2711-*` | `bcm2711-*` (matches) |
| BCM2712 (5) | `bcm2712-*` | `bcm2712-*` (matches) |

So the workaround only matters for Pi 1/2/3. A few fixes:
>
1. Gate on `rpiVersion` instead of `stdenv.hostPlatform.system`. The old logic keyed off host arch, which on `aarch64-linux` unconditionally produced `bcm2837-*` (plus a stray `bcm2838-*`) even when building for Pi 4 or 5. With this change, the rename is skipped entirely for `rpiVersion >= 4` since the names already match.
2. `bcm2835-rpi-zero.dtb` was being copied from `bcm2708-rpi-b-plus.dtb`, which is a B+, not a Zero. Use `bcm2708-rpi-zero.dtb` instead.
3. Drop the `bcm2711-rpi-4-b.dtb` -> `bcm2838-rpi-4-b.dtb` copy. U-Boot only looks for `bcm2711-rpi-4-b.dtb`, and nothing else in the tree references `bcm2838-*`.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input