### PR TITLE
raspberry-pi: add structuredExtraConfig for vendor kernel

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -12,7 +12,7 @@ let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
   modDirVersion = "6.12.75";
   hash = "sha256-qrljd20n4tj/7C7gzNnxw7JIyEF2Ppf1PWm2a7vxh1w=";
-  inherit (lib.kernel) freeform;
+  inherit (lib.kernel) freeform yes no;
 in
 (buildLinux (
   args
@@ -51,10 +51,36 @@ in
       request_key_helper
     ];
 
+    # Override nixpkgs common-config.nix defaults that conflict with the RPi vendor defconfigs.
+    # See: https://github.com/raspberrypi/linux/tree/rpi-6.12.y/arch/arm64/configs
     structuredExtraConfig = {
       # Vendor defconfigs set CONFIG_LOCALVERSION to -v7, -v8, -v8-16k, which
       # breaks modDirVersion. Clear it.
       LOCALVERSION = freeform "";
+
+      # RPi has 4 cores; nixpkgs common-config sets 384
+      NR_CPUS = lib.mkForce (freeform "4");
+      # nixpkgs sets 32MB; RPi vendor defconfig uses 5MB
+      CMA_SIZE_MBYTES = lib.mkForce (freeform "5");
+
+      # NFS root boot support (common RPi use case)
+      NFS_FS = lib.mkForce yes;
+      NFS_V4 = yes;
+      ROOT_NFS = yes;
+      IP_PNP = lib.mkForce yes;
+      IP_PNP_DHCP = yes;
+      IP_PNP_RARP = yes;
+
+      # Match vendor defconfig: built-in instead of module
+      NET_CLS_BPF = lib.mkForce yes;
+      NLS_CODEPAGE_437 = lib.mkForce yes;
+      FB_SIMPLE = yes;
+    }
+    # arm64 vendor defconfigs (bcm2711, bcm2712) use full preempt;
+    # arm32 ones (bcmrpi, bcm2709) use voluntary preempt (nixpkgs default)
+    // lib.optionalAttrs (rpiVersion >= 3) {
+      PREEMPT = lib.mkForce yes;
+      PREEMPT_VOLUNTARY = lib.mkForce no;
     };
 
     extraMeta =

--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -12,6 +12,7 @@ let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
   modDirVersion = "6.12.75";
   hash = "sha256-qrljd20n4tj/7C7gzNnxw7JIyEF2Ppf1PWm2a7vxh1w=";
+  inherit (lib.kernel) freeform;
 in
 (buildLinux (
   args
@@ -50,6 +51,12 @@ in
       request_key_helper
     ];
 
+    structuredExtraConfig = {
+      # Vendor defconfigs set CONFIG_LOCALVERSION to -v7, -v8, -v8-16k, which
+      # breaks modDirVersion. Clear it.
+      LOCALVERSION = freeform "";
+    };
+
     extraMeta =
       if (rpiVersion < 3) then
         {
@@ -66,12 +73,6 @@ in
   // (args.argsOverride or { })
 )).overrideAttrs
   {
-    postConfigure = ''
-      # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.
-      sed -i $buildRoot/.config -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
-      sed -i $buildRoot/include/config/auto.conf -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
-    '';
-
     # The vendor kernel uses different DTB names (bcm2708/bcm2709/bcm2710) than what
     # U-Boot expects (bcm2835/bcm2836/bcm2837). Starting with Pi 4, names match.
     # See: https://github.com/u-boot/u-boot/blob/master/board/raspberrypi/rpi/rpi.c


### PR DESCRIPTION
The RPi vendor kernel is built from `bcm{rpi,2709,2711,2712}_defconfig`, but several values in nixpkgs `common-config.nix` override those defconfigs. Set them back via `structuredExtraConfig`.

Two commits:
1. Replace the `postConfigure` sed hack with `LOCALVERSION = freeform "";`.
2. Add the remaining vendor-defconfig overrides.

`mkForce` is used only where nixpkgs sets a conflicting value at normal priority; everything else is plain assignment.

| Config | Value | Forced? | Why |
|---|---|---|---|
| `LOCALVERSION` | `""` | no | vendor sets `-v7`/`-v8`/`-v8-16k`, breaks `modDirVersion` |
| `NR_CPUS` | `4` | yes | nixpkgs sets 384 |
| `CMA_SIZE_MBYTES` | `5` | yes | nixpkgs sets 32 |
| `PREEMPT` (Pi 3+) | yes | yes | nixpkgs sets `no`; arm64 vendor defconfigs use full preempt |
| `PREEMPT_VOLUNTARY` (Pi 3+) | no | no | nixpkgs only sets it via `mkOptionDefault` |
| `NFS_FS` | yes | yes | nixpkgs sets `module` |
| `NFS_V4`, `ROOT_NFS`, `IP_PNP_DHCP`, `IP_PNP_RARP` | yes | no | not set by nixpkgs |
| `IP_PNP` | yes | yes | nixpkgs sets `no` |
| `NET_CLS_BPF`, `NLS_CODEPAGE_437` | yes | yes | nixpkgs sets `module` |
| `FB_SIMPLE` | yes | no | only set by nixpkgs on <5.15 |

Ref: https://github.com/raspberrypi/linux/tree/rpi-6.12.y/arch/arm64/configs

###### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `` or Flake input