### PR TITLE
asus/zephyrus/gu603vi: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ See code for all available configurations.
 | [Asus ROG Zephyrus G16 GU605CW](asus/zephyrus/gu605cw)                            | `<nixos-hardware/asus/zephyrus/gu605cw>`                | `asus-zephyrus-gu605cw`                |
 | [Asus ROG Zephyrus G16 GU605MY](asus/zephyrus/gu605my)                            | `<nixos-hardware/asus/zephyrus/gu605my>`                | `asus-zephyrus-gu605my`                |
 | [Asus ROG Zephyrus M16 GU603H](asus/zephyrus/gu603h)                              | `<nixos-hardware/asus/zephyrus/gu603h>`                 | `asus-zephyrus-gu603h`                 |
+| [Asus ROG Zephyrus M16 GU603VI (2023)](asus/zephyrus/gu603vi)                     | `<nixos-hardware/asus/zephyrus/gu603vi>`                | `asus-zephyrus-gu603vi`                |
 | [Asus TUF FX504GD](asus/fx504gd)                                                  | `<nixos-hardware/asus/fx504gd>`                         | `asus-fx504gd`                         |
 | [Asus TUF FX506HM](asus/fx506hm)                                                  | `<nixos-hardware/asus/fx506hm>`                         | `asus-fx506hm`                         |
 | [Asus TUF FA506IC](asus/fa506ic)                                                  | `<nixos-hardware/asus/fa506ic>`                         | `asus-fa506ic`                         |

--- a/asus/zephyrus/gu603vi/default.nix
+++ b/asus/zephyrus/gu603vi/default.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel
+    ../../../common/gpu/nvidia/prime.nix
+    ../../../common/gpu/nvidia/ada-lovelace
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../shared/backlight.nix
+  ];
+
+  hardware.nvidia = {
+    prime = {
+      intelBusId = "PCI:0:2:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+
+    modesetting.enable = lib.mkDefault true;
+    dynamicBoost.enable = lib.mkDefault true;
+  };
+
+  services.asusd.enable = lib.mkDefault true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,7 @@
           asus-zephyrus-ga502 = import ./asus/zephyrus/ga502;
           asus-zephyrus-ga503 = import ./asus/zephyrus/ga503;
           asus-zephyrus-gu603h = import ./asus/zephyrus/gu603h;
+          asus-zephyrus-gu603vi = import ./asus/zephyrus/gu603vi;
           asus-zephyrus-gu605cw = import ./asus/zephyrus/gu605cw;
           asus-zephyrus-gu605my = import ./asus/zephyrus/gu605my;
           beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;


### PR DESCRIPTION
###### Description of changes

Add a profile for the 2023 Asus ROG Zephyrus G16 GU603VI: 13th-gen Intel Raptor Lake (i7-13620H) with NVIDIA RTX 4070 Max-Q (Ada Lovelace).

The existing `asus-zephyrus-gu603h` profile covers the 2021/2022 GU603H (Tiger Lake + Ampere). The 2023 GU603V generation is hardware-distinct: Raptor Lake CPUs and Ada Lovelace dGPUs. Until now, GU603VI users had no closer profile than `gu603h`, which imports `common/gpu/nvidia/ampere` (it works today only because `ampere` and `ada-lovelace` happen to share contents — but the semantic mismatch will bite the moment one of them gains arch-specific tweaks).

The new profile is modeled on the existing `gu605my` (same Intel + Ada Lovelace + PRIME + asusd shape):

- `common/cpu/intel`
- `common/gpu/nvidia/{prime,ada-lovelace}`
- `common/pc/{laptop,ssd}`
- `asus/zephyrus/shared/backlight.nix` for hybrid backlight (DPCD via i915, NVIDIA backlight handler disabled)
- `services.asusd.enable = lib.mkDefault true;`
- PRIME bus IDs `PCI:0:2:0` (iGPU) / `PCI:1:0:0` (dGPU)

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input

Tested on real hardware (Asus ROG Zephyrus G16 GU603VI-N4014W). After `sudo nh os test` with the new profile imported in place of `gu603h`:

- PRIME offload works: `glxinfo` reports `Mesa Intel(R) Graphics (RPL-P)` by default and `nvidia-offload glxinfo` reports `NVIDIA GeForce RTX 4070 Laptop GPU`.
- `asusd` / `supergfxd` functional (`asusctl profile -l`, `supergfxctl -g`).
- Audio (PipeWire), Thunderbolt (`bolt`), `fstrim.timer` all behave as before.
- `nvd diff` against the previous `gu603h`-based generation shows zero version changes (only a small derivation-hash delta), confirming the new profile is a drop-in for this hardware.

The profile is intentionally narrow (`gu603vi`, not `gu603v`): I can only attest the RTX 4070 SKU. Future contributors with VV (4060) / VW (4080) variants can add their own profiles if they observe any difference.