### PR TITLE
nvidia/pascal: use legacy_580 drivers by default

### DIFF
--- a/common/gpu/nvidia/pascal/default.nix
+++ b/common/gpu/nvidia/pascal/default.nix
@@ -1,7 +1,8 @@
-{ lib, ... }:
+{ config, lib, ... }:
 {
   imports = [ ../. ];
 
   # The open source driver does not support Pascal GPUs.
   hardware.nvidia.open = false;
+  hardware.nvidia.package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.legacy_580;
 }


### PR DESCRIPTION


<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Drivers 590+ have dropped support for Pascal, use `legacy_580` by default

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

