### PR TITLE
google/brya: Add support for brya Chromebooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ See code for all available configurations.
 | [GPD WIN Max 2 2023](gpd/win-max-2/2023)                                          | `<nixos-hardware/gpd/win-max-2/2023>`                   | `gpd-win-max-2-2023`                   |
 | [GPD WIN Mini 2024](gpd/win-mini/2024)                                            | `<nixos-hardware/gpd/win-mini/2024>`                    | `gpd-win-mini-2024`                    |
 | [Google Pixelbook](google/pixelbook)                                              | `<nixos-hardware/google/pixelbook>`                     | `google-pixelbook`                     |
+| [Google Brya](google/brya)                                                        | `<nixos-hardware/google/brya>`                          | `google-brya`                          |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                                          | `<nixos-hardware/hp/elitebook/2560p>`                   | `hp-elitebook-2560p`                   |
 | [HP Elitebook 830g6](hp/elitebook/830/g6)                                         | `<nixos-hardware/hp/elitebook/830/g6>`                  | `hp-elitebook-830g6`                   |
 | [HP Elitebook 845g7](hp/elitebook/845/g7)                                         | `<nixos-hardware/hp/elitebook/845/g7>`                  | `hp-elitebook-845g7`                   |

--- a/flake.nix
+++ b/flake.nix
@@ -192,6 +192,7 @@
           gigabyte-b650 = import ./gigabyte/b650;
           gmktec-nucbox-g3-plus = import ./gmktec/nucbox/g3-plus;
           google-pixelbook = import ./google/pixelbook;
+          google-brya = import ./google/brya;
           gpd-micropc = import ./gpd/micropc;
           gpd-p2-max = import ./gpd/p2-max;
           gpd-pocket-3 = import ./gpd/pocket-3;

--- a/google/brya/default.nix
+++ b/google/brya/default.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../../common/cpu/intel/alder-lake
+  ];
+}


### PR DESCRIPTION
These Chromebooks are laptops with ssds based on alder-lake platforms.

###### Description of changes

Add rudimentary support for brya chromebooks.

###### Things done

Added laptop, ssd, and alderlake configurations to a config file.

Things to potentially do:
* Add patches for better audio support (Chromebooks have quirks that apply widely)
* Add in some deamons that are useful for Chromebooks. This however appears to violate the constraint of avoiding being opinionated.

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

