### PR TITLE
google/rex: Add support for rex Chromebooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ See code for all available configurations.
 | [GPD WIN Mini 2024](gpd/win-mini/2024)                                            | `<nixos-hardware/gpd/win-mini/2024>`                    | `gpd-win-mini-2024`                    |
 | [Google Pixelbook](google/pixelbook)                                              | `<nixos-hardware/google/pixelbook>`                     | `google-pixelbook`                     |
 | [Google Brya](google/brya)                                                        | `<nixos-hardware/google/brya>`                          | `google-brya`                          |
+| [Google Rex](google/rex)                                                          | `<nixos-hardware/google/rex>`                           | `google-rex`                           |
 | [HP Elitebook 2560p](hp/elitebook/2560p)                                          | `<nixos-hardware/hp/elitebook/2560p>`                   | `hp-elitebook-2560p`                   |
 | [HP Elitebook 830g6](hp/elitebook/830/g6)                                         | `<nixos-hardware/hp/elitebook/830/g6>`                  | `hp-elitebook-830g6`                   |
 | [HP Elitebook 845g7](hp/elitebook/845/g7)                                         | `<nixos-hardware/hp/elitebook/845/g7>`                  | `hp-elitebook-845g7`                   |

--- a/flake.nix
+++ b/flake.nix
@@ -193,6 +193,7 @@
           gmktec-nucbox-g3-plus = import ./gmktec/nucbox/g3-plus;
           google-pixelbook = import ./google/pixelbook;
           google-brya = import ./google/brya;
+          google-rex = import ./google/rex;
           gpd-micropc = import ./gpd/micropc;
           gpd-p2-max = import ./gpd/p2-max;
           gpd-pocket-3 = import ./gpd/pocket-3;

--- a/google/rex/default.nix
+++ b/google/rex/default.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  imports = [
+    ../../common/pc/laptop
+    ../../common/pc/ssd
+    ../../common/cpu/intel/meteor-lake
+  ];
+}


### PR DESCRIPTION
These Chromebooks are laptops with ssds based on meteor-lake platforms.

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Add rudimentary support for rex Chromebooks.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

