### PR TITLE
lenovo/legion/16arha7: fix fprint driver & add lenovo-legion-module

### DIFF
--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -33,7 +33,7 @@ in
     package = pkgs.fprintd-tod;
     tod = {
       enable = true;
-      driver = pkgs.libfprint-2-tod1-elan;
+      driver = pkgs.libfprint-2-tod1-goodix-550a;
     };
   };
 }

--- a/lenovo/legion/16arha7/default.nix
+++ b/lenovo/legion/16arha7/default.nix
@@ -19,10 +19,13 @@ in
     ../../../common/pc/ssd
   ];
 
+  boot.extraModulePackages = [
+    config.boot.kernelPackages.lenovo-legion-module
+  ]
   # Kernel 6.10 includes the speaker fix, so only install this on systems with older kernels.
-  boot.extraModulePackages =
-    lib.mkIf (lib.versionOlder config.boot.kernelPackages.kernel.version "6.10")
-      [ lenovo-speaker-fix ];
+  ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.10") [
+    lenovo-speaker-fix
+  ];
 
   # √(2560² + 1600²) px / 16 in ≃ 189 dpi
   services.xserver.dpi = 189;


### PR DESCRIPTION
### Description of changes
- The fingerprint driver is incorrect & does not work. I've been using goodix-550a from the first month since I got this laptop.
- Enable lenovo-legion-module to support extra features.

### Things done
- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

