### PR TITLE
.git-blame-ignore-revs: ignore nixfmt commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,4 @@
 
 # nixfmt-rfc-style formatting
 51e51e601448705c0d2f92ef90ec7b680123077c #!autorebase cd tests && nix fmt ..
+166dee4f88a7e3ba1b7a243edb1aca822f00680e


### PR DESCRIPTION
###### Description of changes

Found out the nixfmt commit 166dee4f88a7e3ba1b7a243edb1aca822f00680e was not part of the ignored commits while running a `git blame`.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
