### PR TITLE
apple/t2: LTS 6.12 -> 6.18; latest 6.18 -> 7.0; update kernelParams

### DIFF
--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -89,11 +89,11 @@ in
 
       services.udev.packages = [ audioFilesUdevRules ];
 
-      # For audio
+      # For audio and suspend
       boot.kernelParams = [
-        "pcie_ports=compat"
         "intel_iommu=on"
         "iommu=pt"
+        "pm_async=off"
       ];
 
       services.pipewire.package = pipewirePackage;

--- a/apple/t2/pkgs/linux-t2/default.nix
+++ b/apple/t2/pkgs/linux-t2/default.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_6_12, ... }@args:
+{ callPackage, linux_6_18, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_6_12;
+  kernel = linux_6_18;
   patchesFile = ./stable.json;
 }

--- a/apple/t2/pkgs/linux-t2/latest.json
+++ b/apple/t2/pkgs/linux-t2/latest.json
@@ -1,13 +1,13 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/5051ebba61fe8765ba452f46db9b944f33f07a86/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/7ee7d19c38e5df31a386b2a0c35ca8f064003960/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-oZgaj1ujKSjn5PEJ8khrqFnoAkXbC+TInlKfdX0X82Y="
+      "hash": "sha256-v/P3Ws3x+OPnmX3vSFLxARON0HNjjDRe7QJ+KP9tVsc="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-JHWLmSJ158Qs24cjnzolR4JKuNhzzf9e9hRR8T96Dp4="
+      "hash": "sha256-rK1lQ3fjHJH//50n37xgWrUs4CZ8lmFw0iDpbq5zoaY="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
@@ -35,7 +35,7 @@
     },
     {
       "name": "3005-applesmc-basic-mmio-interface-implementation.patch",
-      "hash": "sha256-Hh9DymQ+Y74oSs1zv9F0lTU3jfAenKTM+cmFH9tmN9Q="
+      "hash": "sha256-tnpfmZQw9KQNylpLfGZ+X0IVP79AgeDoTVYF6yUhCRI="
     },
     {
       "name": "3006-applesmc-fan-support-on-T2-Macs.patch",
@@ -55,7 +55,7 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-+YXyIjtlVrLo8allTO3M1A+xold5FUXaZ8dwD2j5HDc="
+      "hash": "sha256-ANHSNoy5nK2b+rSAG0bJ8j6ZBmNqgeCddHXVS31KyDw="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
@@ -70,16 +70,20 @@
       "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
     },
     {
+      "name": "5001-HID-appletb-kbd-add-option-to-switch-default-layer-o.patch",
+      "hash": "sha256-KV5DTjALzNugs92Jum6VUt0wgblK/6PG1KorovHcIX0="
+    },
+    {
       "name": "7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch",
       "hash": "sha256-/EKN7JsAxcpAgfJFtPp2NLYaGqQ0kl8wjJEXifSzJpY="
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-ozOkXGFfsT2iVjAZDoWya8tBY8yiChgLKkBnGACzyrY="
+      "hash": "sha256-EbIbfkncp5Jax2suny/jlFt+cD9MyYMV2rWFJIbgbg4="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",
-      "hash": "sha256-gh1z49QeKgTmGJ92KFNDvqn9gCW0dtrI7DMzaD2ZHGU="
+      "hash": "sha256-zCTetF2NPhMH2BknPumhPz2sf26X9Lcra7xCA3R2WMY="
     }
   ]
 }

--- a/apple/t2/pkgs/linux-t2/latest.nix
+++ b/apple/t2/pkgs/linux-t2/latest.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_6_19, ... }@args:
+{ callPackage, linux_7_0, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_6_19;
+  kernel = linux_7_0;
   patchesFile = ./latest.json;
 }

--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,57 +1,21 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/76956434864f852a31a8965d2848af3217848dca/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/facf1c778667c3ef62104949ef64c75ce7e43b0a/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-94oDsXFCaE+NMAmGiI1KOUX0j79glU3WSqDIpZGEzlU="
+      "hash": "sha256-rrL3oVkYeq5ZslnjCQw4hcEK6knsm6U/wp1XnJmQTSA="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-8SgFQtQ478DPdSD0zKXjgSsgE+lNSVjOcN/mlDQ+Zuw="
-    },
-    {
-      "name": "1005-HID-hid-appletb-bl-add-driver-for-the-backlight-of-A.patch",
-      "hash": "sha256-kEscS1FAyDxLZPOPInYTXFEf4fouBEa4zGctX14hSu8="
-    },
-    {
-      "name": "1006-HID-hid-appletb-kbd-add-driver-for-the-keyboard-mode.patch",
-      "hash": "sha256-eVEuvnoRItaDjwWu41nn9bTkgHgY+1SL/hFAvUR2IlY="
-    },
-    {
-      "name": "1007-HID-multitouch-Get-the-contact-ID-from-HID_DG_TRANSD.patch",
-      "hash": "sha256-iVWI1dSktiIByMJmf3PhTFihwo7BpJMbe1kROP/jsMU="
-    },
-    {
-      "name": "1008-HID-multitouch-support-getting-the-tip-state-from-HI.patch",
-      "hash": "sha256-m/NAKoHRC/HwxG5fFZxFl6DtY4Xv8kPBWvdKdtadrrk="
-    },
-    {
-      "name": "1009-HID-multitouch-take-cls-maxcontacts-into-account-for.patch",
-      "hash": "sha256-h6jk9yw/4txd8PATpMxB9mIzik9+X1zP6p4K35AqdXw="
-    },
-    {
-      "name": "1010-HID-multitouch-specify-that-Apple-Touch-Bar-is-direc.patch",
-      "hash": "sha256-5PbLynVnQqlJKPTWhcmwXCkYDEopLBQWnxWvZUt0EN4="
-    },
-    {
-      "name": "1011-HID-multitouch-add-device-ID-for-Apple-Touch-Bar.patch",
-      "hash": "sha256-2LjWtyYFBREgRC8UAmn5SVnZ9v21vaKzjMwRo9CPYA4="
-    },
-    {
-      "name": "1013-lib-vsprintf-Add-support-for-generic-FourCCs-by-exte.patch",
-      "hash": "sha256-h3gxaKtvdm/GSd+AP1sPC9avWHOsceUxTmoua/3rIf4="
-    },
-    {
-      "name": "1015-drm-tiny-add-driver-for-Apple-Touch-Bars-in-x86-Macs.patch",
-      "hash": "sha256-tDjK/VipVQbuNOURW38gssqeRLy3s8I+DVq0+4zGnHs="
+      "hash": "sha256-deWROYcncl51sOmtvUHM61e5FM1beHbOJVp4iI31LHM="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
-      "hash": "sha256-lZ7MWXZubmAlJCqBmuzueg7agENJbikxP1SE46SmwNw="
+      "hash": "sha256-S2osR1aSjqJiO7rNZP1sKt2+Uxyitwse/6BXMJvE9as="
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
-      "hash": "sha256-XKwlyJZjJLQz39mc0/S7sPnRnwrqMsq9OKy+QCO+oho="
+      "hash": "sha256-6i+fh/Ifle0di5/tMOdMm0NMkEmeUb17hYM/g2j2dfI="
     },
     {
       "name": "3001-applesmc-convert-static-structures-to-drvdata.patch",
@@ -71,7 +35,7 @@
     },
     {
       "name": "3005-applesmc-basic-mmio-interface-implementation.patch",
-      "hash": "sha256-Hh9DymQ+Y74oSs1zv9F0lTU3jfAenKTM+cmFH9tmN9Q="
+      "hash": "sha256-tnpfmZQw9KQNylpLfGZ+X0IVP79AgeDoTVYF6yUhCRI="
     },
     {
       "name": "3006-applesmc-fan-support-on-T2-Macs.patch",
@@ -91,39 +55,35 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-kfAYVovukZLD5ocHQxhoHJSa9c5XAJ1GhH1RlzGkS+k="
-    },
-    {
-      "name": "4002-HID-quirks-remove-T2-devices-from-hid_mouse_ignore_l.patch",
-      "hash": "sha256-0PMCE3IWHekir5YV1BD6Jakc7dOV6Fj2HfIGWZnXZV0="
+      "hash": "sha256-+YXyIjtlVrLo8allTO3M1A+xold5FUXaZ8dwD2j5HDc="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
-      "hash": "sha256-JTeYtaBqMyTu5IdGb8x7wbP9ZE1rXT4lpEjudR1ySFI="
+      "hash": "sha256-T2tYcFLeWUdx6QawANe3ZNVSRxmo1IdPiSpGLQk4IDY="
     },
     {
       "name": "4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch",
-      "hash": "sha256-HcPX7gY3hnlwM/tY06pbtXnch04AqwHgC596E8ZqGY8="
+      "hash": "sha256-ubchCEv1BZ7t/zkI9DpHA4gUln9cdu4yHzVJI2TNlS0="
     },
     {
-      "name": "4005-HID-apple-Add-necessary-IDs-and-support-for-replacem.patch",
-      "hash": "sha256-SRKESCbpxSYm7U0VyCmvkmT/er6/GEHhwo8tgJDO6mQ="
+      "name": "4005-HID-magicmouse-fix-regression-breaking-support-for-M.patch",
+      "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
     },
     {
-      "name": "4006-HID-magicmouse-Add-MacBookPro15-1-replacement-trackp.patch",
-      "hash": "sha256-uAlT/4ADwYyKvbuPQaGwqCjZ2/myruC63etVV6cfFLk="
+      "name": "5001-HID-appletb-kbd-add-option-to-switch-default-layer-o.patch",
+      "hash": "sha256-KV5DTjALzNugs92Jum6VUt0wgblK/6PG1KorovHcIX0="
     },
     {
       "name": "7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch",
-      "hash": "sha256-O6RHFxmKZn7aCq1D+r5z2T3jLt0r5+01EABD9rs0E5M="
+      "hash": "sha256-/EKN7JsAxcpAgfJFtPp2NLYaGqQ0kl8wjJEXifSzJpY="
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-4gtr9/k+Leg8CkKwe673IWSS/OCn3bwNyjQtrEdwgzQ="
+      "hash": "sha256-2By3Zlg/i5rUUJDlWc6JoiqapUnbVplk2lHzDhvAhzI="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",
-      "hash": "sha256-7pWy7C71AO2spULSzy/EEVcvgviqE0CMQ08zx4t7s9s="
+      "hash": "sha256-zCTetF2NPhMH2BknPumhPz2sf26X9Lcra7xCA3R2WMY="
     }
   ]
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Update LTS kernel and latest kernel to the latest supported branch. This also includes a suspend fix with the (currently) necessary kernel parameters.

Tested on `MacBookPro16,2`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

