### PR TITLE
framework: Reorganize readme

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -1,9 +1,42 @@
-# NOTE: Structure changes from 2023-11-11
+# [Framework Computer](https://frame.work/)
 
-Please read the [Deprecated Behaviour README](./OLD-BEHAVIOUR-DEPRECATION.md) to understand how some structural changes to
-the code might affect you!
+There is a configuration for every model of Framework Computer (Laptop and Desktop).
+Please refer to the the project's main [README](../README.md) for how to enable it.
 
-# [Framework Laptops](https://frame.work/)
+## Common Modules
+
+For the Framework 13 laptops, there are common configuration modules available under the `13-inch/common/` directory,
+including some modules specific to AMD- or Intel-based laptops. By preference, there will already be a specialised
+module for your model's configuration. Otherwise, it can be added alongside the existing modules.
+
+## OS integration
+
+`hardware.framework.enableKmod` enables the [community-created Framework kernel
+module](https://github.com/DHowett/framework-laptop-kmod) which exposes EC functionality like battery charge limit,
+privacy switches, and system LEDs as standard driver interfaces. This enables, for example, configuring the charge limit
+using the KDE settings GUI. The option is enabled by default when NixOS `>= 24.05` and linux kernel version `>= 6.10`.
+
+On AMD Framework 13 and 16, before kernel 6.10, additional kernel patches are required for the kernel module to function
+properly. Manually setting `hardware.framework.enableKmod = true` will apply the patches, requiring a kernel
+recompilation.
+
+## Support Tools
+
+### framework-tool
+
+Framework has an official tool to read various diagnostics from the system and change a couple of settings.
+It's a superset of fw-ectool/ectool.
+
+It's included in all common configurations and you can run it like `sudo framework_tool`.
+
+### fw-ectool
+
+There is a `fw-ectool` package available in nixpkgs that provides some system configuration options via the EC.
+This ectool only works with the Intel-based Framework laptops at present, as the Framework EC for AMD-based mainboards
+is based on the Zephyr port of the ChromeOS EC, which involves a slightly changed communication interface.
+
+The upstream ectool cannot easily be packaged in nixpkgs because it depends on
+a lot of Chromebook specific libraries that don't build outside of their SDK.
 
 ## Updating Firmware
 
@@ -14,7 +47,7 @@ services.fwupd.enable = true;
 ```
 
 > [!Note]
-> For Intel CPU's, even [stable BIOS versions](https://community.frame.work/t/responded-11th-gen-intel-core-bios-3-17-release/25137#update-april-11-2023-2) are currently marked as [test versions](https://fwupd.org/lvfs/devices/work.frame.Laptop.TGL.BIOS.firmware) in LVFS (the default remote fwupd uses to get firmware).
+> For Intel 11th Gen, the [stable BIOS versions](https://community.frame.work/t/responded-11th-gen-intel-core-bios-3-17-release/25137#update-april-11-2023-2) are currently marked as [test versions](https://fwupd.org/lvfs/devices/work.frame.Laptop.TGL.BIOS.firmware) in LVFS (the default remote fwupd uses to get firmware).
 >
 > If you want to use these versions, you'll have to [explicitly enable the lvfs-testing remote](https://community.frame.work/t/responded-11th-gen-intel-core-bios-3-17-release/25137#linuxlvfs-7):
 >
@@ -45,27 +78,7 @@ If you cannot boot into your system after upgrading:
    NIXOS_INSTALL_BOOTLOADER=1 /run/current-system/bin/switch-to-configuration boot
    ```
 
-## Common Modules
+# NOTE: Structure changes from 2023-11-11
 
-For the Framework 13 laptops, there are common configuration modules available under the `13-inch/common/` directory,
-including some modules specific to AMD- or Intel-based laptops. By preference, there will already be a specialised
-module for your model's configuration. Otherwise, it can be added alongside the existing modules.
-
-## OS integration
-
-`hardware.framework.enableKmod` enables the [community-created Framework kernel
-module](https://github.com/DHowett/framework-laptop-kmod) which exposes EC functionality like battery charge limit,
-privacy switches, and system LEDs as standard driver interfaces. This enables, for example, configuring the charge limit
-using the KDE settings GUI. The option is enabled by default when NixOS `>= 24.05` and linux kernel version `>= 6.10`.
-
-On AMD Framework 13 and 16, before kernel 6.10, additional kernel patches are required for the kernel module to function
-properly. Manually setting `hardware.framework.enableKmod = true` will apply the patches, requiring a kernel
-recompilation.
-
-## Support Tools
-
-### fw-ectool
-
-There is a `fw-ectool` package available in nixpkgs that provides some system configuration options via the EC.
-This ectool only works with the Intel-based Framework laptops at present, as the Framework EC for AMD-based mainboards
-is based on the Zephyr port of the ChromeOS EC, which involves a slightly changed communication interface.
+Please read the [Deprecated Behaviour README](./OLD-BEHAVIOUR-DEPRECATION.md) to understand how some structural changes to
+the code might affect you!


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
- The warning had been there for two and a half years, we can move it down. Most people don't have 11th Gen these days
- Clarify BIOS update. Only 11th gen has stable in testing remote
- Mention framework-tool. It's recommended over fw-ectool
- Add small note in the beginning

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

