### PR TITLE
framework/13-inch/intel-core-ultra-series3: Fix mic clipping

### DIFF
--- a/framework/13-inch/intel-core-ultra-series3/default.nix
+++ b/framework/13-inch/intel-core-ultra-series3/default.nix
@@ -11,6 +11,11 @@
     ../common/intel.nix
   ];
 
+  # Fixes mic clipping when set over 50% input volume
+  boot.extraModprobeConfig = ''
+    options snd-hda-intel model=limit-mic-boost
+  '';
+
   # Everything is updateable through fwupd
   services.fwupd.enable = true;
 


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
By default linux picks the highes mic boost level which will cause the built-in mic to clip when set to input percentage over 50%

Check that it applied:
> cat /sys/module/snd_hda_intel/parameters/model | grep -o limit-mic-boost
  limit-mic-boost

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

