### PR TITLE
framework/13-inch: fix enhanced audio device priority

### DIFF
--- a/framework/13-inch/common/classic-audio.nix
+++ b/framework/13-inch/common/classic-audio.nix
@@ -315,12 +315,11 @@ in
           "device.api" = "dsp";
           "node.virtual" = "false";
 
-          # Lower seems to mean "more preferred",
-          # bluetooth devices seem to be ~1000, speakers seem to be ~2000
-          # since this is between the two, bluetooth devices take over when they connect,
-          # and hand over to this instead of the speakers when they disconnect.
-          "priority.session" = 1500;
-          "priority.driver" = 1500;
+          # 1009 is the default priority of the "first" analog audio device.
+          # Higher priorities (e.g., 1010 for bluetooth and 1100 for usb audio)
+          # are preferred.
+          "priority.session" = 1009;
+          "priority.driver" = 1009;
           "state.default-volume" = 0.343;
           "device.icon-name" = "audio-card-analog-pci";
         };


### PR DESCRIPTION
###### Description of changes

On framework laptops, ensure that the "enhanced audio" sink for the laptop speakers has a lower priority than bluetooth speakers (by giving it the same priority as the built-in laptop speakers, [1009](https://gitlab.freedesktop.org/pipewire/wireplumber/-/blob/7fa44ef8d0b2f603bd826d399718cef8cf6a800a/src/scripts/monitors/alsa.lua#L218)). Bluetooth speakers have a priority of [1010](https://gitlab.freedesktop.org/pipewire/wireplumber/-/blob/7fa44ef8d0b2f603bd826d399718cef8cf6a800a/src/scripts/monitors/bluez.lua#L275) by default.

NOTE: the existing comment in the code claiming that higher values mean lower priority is incorrect; lower priorities values mean lower priority.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

After testing, my audio switches from my laptop speakers to my bluetooth headphones when I connect them.