### PR TITLE
raspberry-pi: wire config.txt module into common profile

### DIFF
--- a/raspberry-pi/common/default.nix
+++ b/raspberry-pi/common/default.nix
@@ -1,4 +1,9 @@
 {
+  imports = [
+    ./config-txt.nix
+    ./config-txt-defaults.nix
+  ];
+
   boot.initrd.availableKernelModules = [
     "usb-storage"
     "usbhid"


### PR DESCRIPTION
#### Description of changes

PR #1788 added `hardware.raspberry-pi.configtxt` and a defaults file, but nothing imported them, so the options had no effect. Import both from `common/default.nix`. Board profiles that already import `common/` (2, 4, 5) now apply the pi-gen-equivalent defaults.

Pi 3 doesn't import `common/` today; that's addressed separately in #1862.

#### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input