### PR TITLE
raspberry-pi/3: import common profile

### DIFF
--- a/raspberry-pi/3/default.nix
+++ b/raspberry-pi/3/default.nix
@@ -1,6 +1,10 @@
 { lib, pkgs, ... }:
 
 {
+  imports = [
+    ../common/default.nix
+  ];
+
   boot = {
     kernelPackages = lib.mkDefault (
       pkgs.linuxPackagesFor (pkgs.callPackage ../common/kernel.nix { rpiVersion = 3; })


### PR DESCRIPTION
#### Description of changes

The Pi 3 profile didn't import `../common/default.nix`, so it skipped the shared `boot.initrd.availableKernelModules` (`usb-storage`, `usbhid`, `vc4`). Every other board profile imports `common/`, so this just makes Pi 3 consistent.

Once #1861 lands, Pi 3 also picks up the `config.txt` defaults.

#### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input