### PR TITLE
asus/proart/px13/hn7306eac: init

### DIFF
--- a/asus/proart/px13/default.nix
+++ b/asus/proart/px13/default.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../../common/hidpi.nix
+    ../../battery.nix
+  ];
+
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+  security.tpm2.enable = lib.mkDefault true;
+  hardware.sensor.iio.enable = lib.mkDefault true;
+}

--- a/asus/proart/px13/hn7306eac/default.nix
+++ b/asus/proart/px13/hn7306eac/default.nix
@@ -1,0 +1,68 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  imports = [
+    ../default.nix
+    ./tas2783-kernel-patches.nix
+  ];
+
+  hardware = {
+    alsa.enablePersistence = lib.mkDefault true;
+    firmware = lib.optional (lib.versionOlder pkgs.linux-firmware.version "20260519") (
+      pkgs.callPackage ./tas2783-firmware.nix { }
+    );
+  };
+
+  environment.etc = {
+    "alsa/ucm2/codecs/tas2783/init.conf".source = ./ucm2/codecs/tas2783/init.conf;
+    "alsa/ucm2/sof-soundwire/acp-dmic.conf".source = ./ucm2/sof-soundwire/acp-dmic.conf;
+    "alsa/ucm2/sof-soundwire/tas2783.conf".source = ./ucm2/sof-soundwire/tas2783.conf;
+    "alsa/ucm2/sof-soundwire/sof-soundwire.conf".source = ./ucm2/sof-soundwire/sof-soundwire.conf;
+  };
+
+  # WirePlumber config for TAS2783 smart amp speakers.
+  # UCM doesn’t expose a Speakers port for this card, so force pro-audio and
+  # prevent the speaker sink from suspending (prevents desync on idle).
+  # Firmware extraction recipe and original config:
+  # https://gist.github.com/cryptob1/f62aaf8517df2e540f447347f42c7a03
+  services.pipewire.wireplumber.extraConfig."51-strix-halo-audio" = {
+    "monitor.alsa.rules" = [
+      {
+        matches = [
+          { "device.name" = "alsa_card.pci-0000_c4_00.5-platform-amd_sdw"; }
+        ];
+        actions."update-props" = {
+          "device.profile" = "pro-audio";
+        };
+      }
+      {
+        matches = [
+          { "node.name" = "alsa_output.pci-0000_c4_00.5-platform-amd_sdw.pro-output-2"; }
+        ];
+        actions."update-props" = {
+          "session.suspend-timeout-seconds" = 0;
+          "node.description" = "Internal Speakers (TAS2783)";
+          "priority.session" = 2300;
+        };
+      }
+    ];
+  };
+
+  # Unmute the TAS2783 once detected.
+  services.udev.extraRules =
+    let
+      amixer = "${lib.getBin pkgs.alsa-utils}/bin/amixer";
+    in
+    /* udev */ ''
+      ACTION=="add", SUBSYSTEM=="sound", ATTR{id}=="sofsoundwire", RUN+="${amixer} -c $attr{number} set 'tas2783-1 Amp Playback Switch' 1"
+
+      ACTION=="add", SUBSYSTEM=="sound", ATTR{id}=="amdsoundwire", RUN+="${amixer} -c $attr{number} set 'tas2783-1 Amp' on"
+      ACTION=="add", SUBSYSTEM=="sound", ATTR{id}=="amdsoundwire", RUN+="${amixer} -c $attr{number} set 'tas2783-2 Amp' on"
+      ACTION=="add", SUBSYSTEM=="sound", ATTR{id}=="amdsoundwire", RUN+="${amixer} -c $attr{number} set 'tas2783-1 Speaker' on"
+      ACTION=="add", SUBSYSTEM=="sound", ATTR{id}=="amdsoundwire", RUN+="${amixer} -c $attr{number} set 'tas2783-2 Speaker' on"
+    '';
+}

--- a/asus/proart/px13/hn7306eac/fix-tas2783-fw-name-0x.patch
+++ b/asus/proart/px13/hn7306eac/fix-tas2783-fw-name-0x.patch
@@ -1,0 +1,21 @@
+diff --git a/sound/soc/codecs/tas2783-sdw.c b/sound/soc/codecs/tas2783-sdw.c
+--- a/sound/soc/codecs/tas2783-sdw.c
++++ b/sound/soc/codecs/tas2783-sdw.c
+@@ -1120,7 +1120,7 @@ static void tas_generate_fw_name(struct sdw_slave *slave, char *name, size_t siz
+ 	for (; dev; dev = dev->parent) {
+ 		if (dev->bus == &pci_bus_type) {
+ 			pci = to_pci_dev(dev);
+-			scnprintf(name, size, "%04X-%1X-%1X.bin",
++			scnprintf(name, size, "%04X-%1X-0x%X.bin",
+ 				  pci->subsystem_device, bus->link_id, unique_id);
+ 			pci_found = true;
+ 			break;
+@@ -1129,7 +1129,7 @@ static void tas_generate_fw_name(struct sdw_slave *slave, char *name, size_t siz
+ #endif
+ 
+ 	if (!pci_found)
+-		scnprintf(name, size, "tas2783-%1X-%1X.bin",
++		scnprintf(name, size, "tas2783-%1X-0x%X.bin",
+ 			  bus->link_id, unique_id);
+ }
+ 

--- a/asus/proart/px13/hn7306eac/tas2783-firmware.nix
+++ b/asus/proart/px13/hn7306eac/tas2783-firmware.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  icoutils,
+  p7zip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "asus-px13-tas2783-firmware";
+  version = "6.3.1.15";
+
+  src = fetchurl {
+    url = "https://dlcdnets.asus.com/pub/ASUS/nb/Image/Driver/Audio/47519/SmartAMP_TI_DCH_TexasInstruments_Z_V${finalAttrs.version}_47519.exe?model=HN7306EAC";
+    hash = "sha256-hyiDV5W+Rn05xyG2JF5uA41E/L8NDklxjvRctE64o84=";
+  };
+
+  nativeBuildInputs = [
+    icoutils
+    p7zip
+  ];
+
+  unpackPhase = ''
+    wrestool -x --raw -t ZIP -n 103 "$src" > driver.7z 2>/dev/null
+    7z x driver.7z -ozip_out -y >/dev/null 2>&1
+  '';
+
+  installPhase = ''
+    install -D -m 644 $(find zip_out -name "1714-1-0x8.bin" | head -1) $out/lib/firmware/1714-1-0x8.bin
+    install -D -m 644 $(find zip_out -name "1714-1-0xB.bin" | head -1) $out/lib/firmware/1714-1-0xB.bin
+  '';
+
+  meta = {
+    description = "TAS2783 Smart Amp firmware for ASUS ProArt PX13 HN7306EAC";
+    homepage = "https://www.asus.com/support/download/HN7306EAC/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = with lib.licenses; [ unfreeRedistributableFirmware ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/asus/proart/px13/hn7306eac/tas2783-kernel-patches.nix
+++ b/asus/proart/px13/hn7306eac/tas2783-kernel-patches.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+# See CachyOS’s discussion:
+# https://github.com/CachyOS/linux-cachyos/issues/737
+let
+  mkPatch = name: hash: {
+    inherit name;
+    patch = pkgs.fetchpatch {
+      inherit name;
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/${name}.patch?h=linux-cachyos-px13";
+      inherit hash;
+    };
+  };
+in
+{
+  assertions = [
+    {
+      assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "7.0";
+      message = "tas2783 patches require Linux ≥ 7.0 (found ${config.boot.kernelPackages.kernel.version})";
+    }
+  ];
+
+  boot.kernelPatches = [
+    (mkPatch "0001-ALSA-tas2783-sdw-add-Playback-to-volume-control" "sha512-IdIy81PXtmQAQ+MVChYDYkoa5RDhQwP2L5efN8cz+tST3nM0Oc0x4SJ4sBnVL7QDJc/WBB0OEnFfTkEt9Id+cQ==")
+    (mkPatch "0002-Names-to-match-snd_soc_dai_driver-playback-capturest" "sha512-SrCgzceh3rhyYz5tNWHY2jNWyG/qgmU7ZVLtV71iir8HwOrSES7JsunV2E7mb8R66dShY+loV8ovNeMkyuDB7w==")
+    (mkPatch "0003-removed-unused-fields" "sha512-mWKqFg8AG00TE3oPy5usPPxWf6aIvhxMLDGI+/0+vvjBIFwWv6qh9jSUeid6CAKgAcluPSA8Sag4ESguCeinyw==")
+    (mkPatch "0004-SOC_SINGLE_RANGE_TLV-uses-snd_soc_get_volsw-snd_soc_" "sha512-G51v725q17UHvfPg4H8V92eSbZ5lcuiF97Zt1EbAtuwrhXefeaZy+hl79sSpVlzzY8pvzIwf6wodAuvp44M01A==")
+    (mkPatch "0005-dev_set_drvdata-already-called-intas_sdw_probe" "sha512-zk+rKZ/l0oB7JdABtb89x6tUzggP99TSy+3cr+q6QjZFdjGsLPXHxre0YACuKBNx6+JazZE/zEilIvahS4wOLQ==")
+    (mkPatch "0006-refactor-setting-sa_func_data" "sha512-8djgIJV1LCzDhFLFn/PNfDkE+U0mh2h4Rm2LJMeLUYKQlwzgPMbICh5B3HhCgEVTaUd54OGOSFEf0i6AIm2SIQ==")
+    (mkPatch "0007-check-AF01-for-init-data" "sha512-gjpdnJDzve37MnyVE52+E9sRkXF9+HtA4XTrBZQiV8ozFwWgIzhO2ZDKSpWbE/kd23PdaUcKX/fPj3J7ZD5YqA==")
+    (mkPatch "0008-setup-ports" "sha512-uuDa92VXlCsszswv8PHcDbbyfseL6Jt7DWPc5ajG1WSM/FGojRIbbl/2smQyGfE2jPquy5GQfJps7k1cRfpl8w==")
+    (mkPatch "0009-Already-set-by-SOC_SINGLE_RANGE_TLV-Speaker-Playback" "sha512-qBveCsmwezD13oWF5jBlUybdns5OsDDZji0y0smaKWi9GPAvhw/v66WUnEyC77UF1mvq+OyrWpA4yXwxAFza3Q==")
+    (mkPatch "0010-control-to-set-channel" "sha512-pL8Ol1ml2QhyKnzZvD+oTaVUPyqOO49uuiEUzyKdnskFwVH+jIluY3IDsmzWv5wTg/9D+CTGC4J8gW55xKwWfg==")
+    (mkPatch "0011-mute-unmute-using-SND_SOC_DAPM_SWITCH" "sha512-6aB8mBACTIQxU7CTrpR3UXJFdR4KbUOT9/AymyGiuV/9PfWdXZoW/0A09SHFptxRwCv4FG5tZSDZRtKvvYNQdQ==")
+    (mkPatch "0012-use-SND_SOC_DAPM_REG-to-power-on-off" "sha512-mJ93TxZQ1GuDGar0/6tBd/dlJ3B/41AVhRsViuSaEhykPC4NlIAOWaN9eJj4bxjEEyEQ3REfjHXVnJ3wdCRK9w==")
+    (mkPatch "0013-reattach-after-resume" "sha512-OdkYPzRDkd4FCd1OTOAfRrQW6JQ9D3Opic/X+sg+pLNGoEEXfph/sLXVYGo9u6DGPJndQZNrXyS4qhJMGPWVMw==")
+    (mkPatch "0014-defer-check" "sha512-ABSrwsOB+KU39LMxh3N47Ji+edhu5rDQMKMi5rEVXtCU8W56qANpU+ui+bJmOLYyq8c9H1qme+b5nQ6u9zv01w==")
+    (mkPatch "0015-to-help-alsa-find-them" "sha512-gVJ+0ZO9Oz15/rC08moVSlVglbishJctjH5SnDdI8m3s9hkEY56o8v+R/PlRS3rL+mOa9q3VuO5J40+LrcxDKw==")
+    (mkPatch "0016-cleanup-controls" "sha512-Jkp7kdi0FmVMlBL/VVzq7hYkCmKoELO0epnExP7ggQuopCzRbVpUQ3giMlj10O69aUBZJ4z3gaMkb1HTYjIXmA==")
+    # Upstream linux-firmware took a different naming approach to the original patches
+    {
+      name = "0017-fix-tas2783-fw-name-0x";
+      patch = ./fix-tas2783-fw-name-0x.patch;
+    }
+  ];
+}

--- a/asus/proart/px13/hn7306eac/ucm2/codecs/tas2783/init.conf
+++ b/asus/proart/px13/hn7306eac/ucm2/codecs/tas2783/init.conf
@@ -1,0 +1,42 @@
+# TAS2783 specific switch control settings
+
+Define.SpeakerMixerElem "tas2783-1 Speaker Playback"
+
+If.twoAmpsStereoToOne {
+    Condition {
+        Type RegexMatch
+        Regex "2"
+        String "${var:SpeakerAmps}"
+    }
+    True {
+        Define.SpeakerMixerElem "tas2783 Speaker"
+        LibraryConfig.remap.Config {
+            ctl.default.map {
+                "name='tas2783 Speaker Playback Switch'" {
+                    "name='tas2783-1 Speaker Playback Switch'".vindex.0 0
+                    "name='tas2783-2 Speaker Playback Switch'".vindex.1 0
+                }
+                "name='tas2783 Speaker Playback Volume'" {
+                    "name='tas2783-1 Speaker Playback Volume'".vindex.0 0
+                    "name='tas2783-2 Speaker Playback Volume'".vindex.1 0
+                }
+            }
+        }
+    }
+}
+
+If.oneAmp {
+    Condition {
+        Type ControlExists
+        Control "name='tas2783-1 Speaker Playback Switch'"
+    }
+    True.Macro[{ SetLED { LED="speaker" Action="attach" CtlId="tas2783-1 Speaker Playback Switch" } }]
+}
+
+If.twoAmps {
+    Condition {
+        Type ControlExists
+        Control "name='tas2783-2 Speaker Playback Switch'"
+    }
+    True.Macro[{ SetLED { LED="speaker" Action="attach" CtlId="tas2783-2 Speaker Playback Switch" } }]
+}

--- a/asus/proart/px13/hn7306eac/ucm2/sof-soundwire/acp-dmic.conf
+++ b/asus/proart/px13/hn7306eac/ucm2/sof-soundwire/acp-dmic.conf
@@ -1,0 +1,8 @@
+SectionDevice."Mic" {
+    Comment "Digital Microphone"
+
+    Value {
+        CapturePriority 100
+        CapturePCM "hw:${CardId},4"
+    }
+}

--- a/asus/proart/px13/hn7306eac/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/asus/proart/px13/hn7306eac/ucm2/sof-soundwire/sof-soundwire.conf
@@ -1,0 +1,206 @@
+Syntax 7
+
+SectionUseCase."HiFi" {
+	File "/sof-soundwire/HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+Include.led.File "/common/ctl/led.conf"
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+
+Define {
+	SpeakerCodec1 ""
+	SpeakerChannels1 "2"
+	SpeakerAmps1 "0"
+	HeadsetCodec1 ""
+	MicCodec1 ""
+	Mics1 "0"
+	Iec61937Pcms1 ""
+	MultiCodec1 ""
+}
+
+DefineRegex {
+	SpeakerCodec {
+		Regex " spk:([a-z0-9]+((-sdca)|(-spk)|(-bridge))?(\\+[a-z0-9]+)?)"
+		String "${CardComponents}"
+	}
+	SpeakerChannels {
+		Regex " cfg-spk:([0-9]+)"
+		String "${CardComponents}"
+	}
+	SpeakerAmps {
+		Regex " cfg-amp:([0-9]+)"
+		String "${CardComponents}"
+	}
+	HeadsetCodec {
+		Regex " hs:([a-z0-9]+(-sdca)?)"
+		String "${CardComponents}"
+	}
+	MicCodec {
+		Regex " mic:([a-z0-9]+(-dmic)?+(-sdca)?)"
+		String "${CardComponents}"
+	}
+	Mics {
+		Regex " cfg-mics:([1-9][0-9]*)"
+		String "${CardComponents}"
+	}
+	Iec61937Pcms {
+		Regex "iec61937-pcm:(([0-9]+(,))*[0-9]+)"
+		String "${CardComponents}"
+	}
+	MultiCodec {
+		Regex "(rt712|rt713|rt721|rt722)"
+		String "${var:SpeakerCodec1} ${var:HeadsetCodec1} ${var:MicCodec1}"
+	}
+}
+
+If.multi_init {
+	Condition {
+		Type String
+		Empty "${var:MultiCodec1}"
+	}
+	False {
+		Define {
+			MultiSpeakerShadow "${var:SpeakerCodec1}"
+			MultiMicShadow "${var:MicCodec1}"
+		}
+		Include.multi_init.File "/codecs/${var:MultiCodec1}/init.conf"
+	}
+}
+
+If.multi_speaker {
+	Condition {
+		Type RegexMatch
+		# guard with "=" to avoid empty string matching
+		Regex "=(${var:MultiCodec1}(-sdca)?)="
+		String "=${var:SpeakerCodec1}="
+	}
+	True {
+		Define.SpeakerCodec1 ""
+	}
+}
+
+If.multi_mic {
+	Condition {
+		Type RegexMatch
+		# guard with "=" to avoid empty string matching
+		Regex "=(${var:MultiCodec1}(-sdca)?)="
+		String "=${var:MicCodec1}="
+	}
+	True {
+		Define.MicCodec1 ""
+	}
+}
+
+If.multi_headset {
+	Condition {
+		Type RegexMatch
+		# guard with "=" to avoid empty string matching
+		Regex "=(${var:MultiCodec1}(-sdca)?)="
+		String "=${var:HeadsetCodec1}="
+	}
+	True {
+		Define.HeadsetCodec1 ""
+	}
+}
+
+If.spk_init {
+	Condition {
+		Type RegexMatch
+		Regex "(rt1318(-1)?|cs35l56(-bridge)?|tas2783(-1)?)"
+		String "${var:SpeakerCodec1}"
+	}
+	True.Include.spk_init.File "/codecs/${var:SpeakerCodec1}/init.conf"
+}
+
+If.hs_init {
+	Condition {
+		Type RegexMatch
+		Regex "(cs42l43|cs42l45|rt5682|rt700|rt711|rt713(-sdca)?)"
+		String "${var:HeadsetCodec1}"
+	}
+	True.Include.hs_init.File "/codecs/${var:HeadsetCodec1}/init.conf"
+}
+
+If.mic_init {
+	Condition {
+		Type RegexMatch
+		Regex "(cs42l43-dmic|cs42l45-dmic|rt712-dmic|rt713-dmic|rt715(-sdca)?)"
+		String "${var:MicCodec1}"
+	}
+	True.Include.mic_init.File "/codecs/${var:MicCodec1}/init.conf"
+}
+
+If.mic_init_rt715 {
+	Condition {
+		Type String
+		Needle "rt715"
+		Haystack "${var:MicCodec1}"
+	}
+	True.Macro [{ SetLED { LED="mic" Action="detach" CtlId="PGA5.0 5 Master Capture Switch" } }]
+}
+
+If.pga_init_pga2 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA2.0 2 Master Capture Switch'"
+	}
+	True.BootSequence [
+		cset "name='PGA2.0 2 Master Capture Switch' 1"
+	]
+}
+
+If.pga_init_pga5 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA5.0 5 Master Capture Switch'"
+	}
+	True.BootSequence [
+		cset "name='PGA5.0 5 Master Capture Switch' 1"
+	]
+}
+
+If.mics-array {
+	Condition {
+		Type String
+		Empty "${var:Mics1}"
+	}
+	False.FixedBootSequence [
+		# dmic array info
+		exec "-nhlt-dmic-info -o ${var:LibDir}/dmics-nhlt.json"
+	]
+}
+
+Include.hdmi-pcm.File "/common/pcm/hdmi.conf"
+
+Macro.0.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 5 Idx 0 }
+Macro.1.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 6 Idx 1 }
+Macro.2.HdmiDevice { Iec61937Devices "${var:Iec61937Pcms1}" Dev 7 Idx 2 }
+
+If.HdmiIec61937 {
+	Condition {
+		Type RegexMatch
+		Regex "((^|,)[567](,|$))"
+		String "${var:Iec61937Pcms1}"
+	}
+	True.Macro.save_hdmi_cfg.HdmiPCMSave { Name "42-sof-hdmi" }
+}
+
+# Define macros to set up processing controls
+Include.dsp-variables.File "/Intel/sof-hda-dsp/dsp.conf"
+
+# Set BootSequence and FixedBootSequence for drc, eqiir, eqfir
+Macro.SpeakerDrc.SofDrcBootSetup "endpoint='PostMixerSpeaker' direction='Playback'"
+Macro.SpeakerIir.SofEqBootSetup "endpoint='PostMixerSpeaker' direction='Playback' eqtype='Iir'"
+Macro.SpeakerFir.SofEqBootSetup "endpoint='PostMixerSpeaker' direction='Playback' eqtype='Fir'"
+
+# Set BootSequence and FixedBootSequence for Mic array eqiir, tdfb, drc
+Macro.MicArrayIir.SofEqBootSetup "endpoint='MicArray' direction='Capture' eqtype='Iir'"
+Macro.MicArrayDrc.SofDrcBootSetup "endpoint='MicArray' direction='Capture'"
+Macro.MicarrayTdfb.SofBeamformerBootSetup "endpoint='MicArray' direction='Capture'"
+
+# For SoundWire PC with PCH-DMIC set BootSequence and FixedBootSequence for eqiir, tdfb, drc
+Macro.Dmic0ArrayIir.SofEqBootSetup "endpoint='Dmic0' direction='Capture' eqtype='Iir'"
+Macro.Dmic0ArrayDrc.SofDrcBootSetup "endpoint='Dmic0' direction='Capture'"
+Macro.Dmic0ArrayTdfb.SofBeamformerBootSetup "endpoint='Dmic0' direction='Capture'"

--- a/asus/proart/px13/hn7306eac/ucm2/sof-soundwire/tas2783.conf
+++ b/asus/proart/px13/hn7306eac/ucm2/sof-soundwire/tas2783.conf
@@ -1,0 +1,43 @@
+# TAS2783 Use case Configuration for sof-soundwire card
+
+#
+# Arguments:
+#   ForAmps - regex filter for var:SpeakerAmps
+#   Amp - amplifier number (1,2 etc.)
+#
+DefineMacro.tas2783spk.If.0 {
+    Condition {
+        Type RegexMatch
+        Regex "${var:__ForAmps}"
+        String "${var:SpeakerAmps}"
+    }
+    True {
+        EnableSequence [
+            cset "name='tas2783-${var:__Amp} Amp Playback Switch' 1"
+            cset "name='tas2783-${var:__Amp} Speaker Playback Switch' 1"
+        ]
+        DisableSequence [
+            cset "name='tas2783-${var:__Amp} Amp Playback Switch' 0"
+            cset "name='tas2783-${var:__Amp} Speaker Playback Switch' 0"
+        ]
+    }
+}
+
+SectionDevice."Speaker" {
+    Comment "Speaker"
+
+	EnableSequence [
+#		cset "name='tas2783 Speaker Playback Switch' on"
+	]
+
+	DisableSequence [
+#		cset "name='tas2783 Speaker Playback Switch' off"
+	]
+
+    Value {
+        PlaybackPriority 100
+        PlaybackPCM "hw:${CardId},2"
+        PlaybackMixer "default:${CardId}"
+        PlaybackMixerElem "${var:SpeakerMixerElem}"
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
           asus-flow-gv302x-amdgpu = import ./asus/flow/gv302x/amdgpu;
           asus-flow-gv302x-nvidia = import ./asus/flow/gv302x/nvidia;
           asus-flow-gz301vu = import ./asus/flow/gz301vu;
+          asus-proart-px13 = import ./asus/proart/px13;
           asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;
           asus-rog-gl552vw = import ./asus/rog-gl552vw;
           asus-rog-strix-g513im = import ./asus/rog-strix/g513im;

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
           asus-flow-gv302x-nvidia = import ./asus/flow/gv302x/nvidia;
           asus-flow-gz301vu = import ./asus/flow/gz301vu;
           asus-proart-px13 = import ./asus/proart/px13;
+          asus-proart-px13-hn7306eac = import ./asus/proart/px13/hn7306eac;
           asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;
           asus-rog-gl552vw = import ./asus/rog-gl552vw;
           asus-rog-strix-g513im = import ./asus/rog-strix/g513im;


### PR DESCRIPTION
###### Description of changes

ASUS ProArt PX13 HN7306EA patchset. Most changes are typical, common imports (such as the shared bits for all PX13 laptops), but the audio was gnarly—requiring fetching firmware extracted from the Microsoft Windows executable provided by ASUS’s support page.

There is quite a lot of chatter about such changes on [CachyOS’s proprietary bug tracker](https://github.com/CachyOS/linux-cachyos/issues/737) that helped guide the changes needed to be made.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
      
[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.

