### PR TITLE
asus/flow/gz302ea: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ See code for all available configurations.
 | [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/amdgpu)                      | `<nixos-hardware/asus/flow/gv302x/amdgpu>`              | `asus-flow-gv302x-amdgpu`              |
 | [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/nvidia)                      | `<nixos-hardware/asus/flow/gv302x/nvidia>`              | `asus-flow-gv302x-nvidia`              |
 | [Asus ROG Flow Z13 gz301vu\* (2023)](asus/flow/gz301vu)                           | `<nixos-hardware/asus/flow/gz301vu>`                    | `asus-flow-gz301vu`              |
+| [Asus ROG Flow Z13 GZ302EA (2025, Strix Halo)](asus/flow/gz302ea)                 | `<nixos-hardware/asus/flow/gz302ea>`                    | `asus-flow-gz302ea`              |
 | [Asus ROG GL552VW](asus/rog-gl552vw)                                              | `<nixos-hardware/asus/rog-gl552vw>`                     | `asus-rog-gl552vw`                     |
 | [Asus ROG Strix G513IM](asus/rog-strix/g513im)                                    | `<nixos-hardware/asus/rog-strix/g513im>`                | `asus-rog-strix-g513im`                |
 | [Asus ROG Strix G533ZW](asus/rog-strix/g533zw)                                    | `<nixos-hardware/asus/rog-strix/g533zw>`                | `asus-rog-strix-g533zw`                |

--- a/asus/flow/gz302ea/default.nix
+++ b/asus/flow/gz302ea/default.nix
@@ -1,0 +1,68 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  inherit (lib) mkDefault;
+in
+{
+
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  boot = {
+    # kernel >7.2-rc1 where ism was rewritten
+    kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "7.2") pkgs.linuxPackages_testing;
+    kernelModules = [ "kvm-amd" ];
+    kernelParams = [
+      "pcie_aspm.policy=powersupersave"
+      "amdgpu.dcdebugmask=0x410" # 0x10 = disable PSR, 0x400 = disable panel replay
+    ];
+  };
+
+  # linux-firmware pinned past the 20260622 release for the DMCUB
+  # 0.1.65.0 update (e3e36153, 2026-06-26, includes dcn_3_5_1)
+  nixpkgs.overlays = [
+    (final: prev: {
+      linux-firmware =
+        if lib.versionOlder prev.linux-firmware.version "20260626" then
+          prev.linux-firmware.overrideAttrs {
+            version = "20260622-unstable-2026-06-26";
+            src = final.fetchFromGitLab {
+              owner = "kernel-firmware";
+              repo = "linux-firmware";
+              rev = "e3e36153ce3fff3f9c063dec7c267ce676a00a50";
+              hash = "sha256-XtTS975qrdABk0xCnisBgCEGvCIRzkoupsimXXGSuBQ=";
+            };
+          }
+        else
+          prev.linux-firmware;
+    })
+  ];
+
+  hardware.bluetooth.enable = mkDefault true;
+
+  services = {
+    asusd.enable = mkDefault true;
+
+    # services.asusd enables supergfxd, and we only have one gpu
+    supergfxd.enable = false;
+
+    udev.extraRules = ''
+      # The GZ302EA folio touchpad is USB-attached, so systemd's input_id builtin
+      # tags it as an *external* touchpad and libinput then hides "disable while
+      # typing" support. Force the touchpad to be internal.
+      ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_VENDOR_ID}=="0b05", ENV{ID_MODEL_ID}=="1a30", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+    '';
+  };
+
+  # for screen auto-rotate
+  hardware.sensor.iio.enable = mkDefault true;
+}

--- a/asus/flow/gz302ea/default.nix
+++ b/asus/flow/gz302ea/default.nix
@@ -1,0 +1,46 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  inherit (lib) mkDefault;
+in
+{
+
+  imports = [
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/amd
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  boot = {
+    kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "7.2") pkgs.linuxPackages_latest;
+    kernelModules = [ "kvm-amd" ];
+    kernelParams = [
+      "pcie_aspm.policy=powersupersave"
+    ];
+  };
+
+  hardware.bluetooth.enable = mkDefault true;
+
+  services = {
+    asusd.enable = mkDefault true;
+
+    # services.asusd enables supergfxd, and we only have one gpu
+    supergfxd.enable = false;
+
+    udev.extraRules = ''
+      # The GZ302EA folio touchpad is USB-attached, so systemd's input_id builtin
+      # tags it as an *external* touchpad and libinput then hides "disable while
+      # typing" support. Force the touchpad to be internal.
+      ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_VENDOR_ID}=="0b05", ENV{ID_MODEL_ID}=="1a30", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+    '';
+  };
+
+  # for screen auto-rotate
+  hardware.sensor.iio.enable = mkDefault true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
           asus-flow-gz301vu = import ./asus/flow/gz301vu;
           asus-proart-px13 = import ./asus/proart/px13;
           asus-proart-px13-hn7306eac = import ./asus/proart/px13/hn7306eac;
+          asus-flow-gz302ea = import ./asus/flow/gz302ea;
           asus-pro-ws-x570-ace = import ./asus/pro-ws-x570-ace;
           asus-rog-gl552vw = import ./asus/rog-gl552vw;
           asus-rog-strix-g513im = import ./asus/rog-strix/g513im;


### PR DESCRIPTION
###### Description of changes
Added asus/flow/gz302ea (2025 Asus ROG Flow Z13).

The most notable change here is in the `dcdebugmask` kernel param which works around amdgpu bugs on this hardware and makes the Z13 significantly more stable and usable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

