### PR TITLE
raspberry-pi/common: fix infinite recursion when building options.json

### DIFF
--- a/raspberry-pi/common/config-txt.nix
+++ b/raspberry-pi/common/config-txt.nix
@@ -95,7 +95,7 @@ in
             (attrsOf molecule)
           ];
         in
-        attrsOf molecule;
+        attrsOf molecule // { description = "config.txt setting type"; };
       default = { };
       description = ''
         Structured configuration for the Raspberry Pi `config.txt` file.


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

