### PR TITLE
chore: update old wiki links (nixos.wiki -> wiki.nixos.org)

### DIFF
--- a/asus/fa506nc/README.md
+++ b/asus/fa506nc/README.md
@@ -66,7 +66,7 @@ use on batter and which on power.
 ## More optimizations
 
 You may also want to enable thermald and powertop for the optimizations mentioned in
-https://nixos.wiki/wiki/Laptop.
+https://wiki.nixos.org/wiki/Laptop.
 
 ```nix
 services.thermald.enable = true;

--- a/hp/probook/440G5/default.nix
+++ b/hp/probook/440G5/default.nix
@@ -2,7 +2,7 @@
 
 {
   # https://www.intel.com/content/www/us/en/products/sku/124967/intel-core-i58250u-processor-6m-cache-up-to-3-40-ghz/specifications.html
-  # this one works: https://nixos.wiki/wiki/Accelerated_Video_Playback
+  # this one works: https://wiki.nixos.org/wiki/Accelerated_Video_Playback
   imports = [
     ../../../common/cpu/intel/kaby-lake
     ../../../common/pc


### PR DESCRIPTION
###### Description of changes

Working on updating all nixos.wiki references to wiki.nixos.org across `NixOS` and `nix-community` github repos.

###### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

###### Note
- `wiki.nixos.org/wiki/Laptop page` is fine, hasn't changed since, and has all the same instructions on `thermald` and `powertop`.
- But `wiki.nixos.org/wiki/Accelerated_Video_Playback` has reorganized sections and now i think it would be more appropriate to link to `Accelerated_Video_Playback#Intel` instead of `Accelerated_Video_Playback`?