### PR TITLE
framework: audio tuning is for classic chassis only

### DIFF
--- a/framework/13-inch/common/classic-audio.nix
+++ b/framework/13-inch/common/classic-audio.nix
@@ -24,7 +24,8 @@ in
             - Equalizer
             - Slight compression
 
-          This option has been optimised for the Framework Laptop 13 AMD 7040 series, but should work on all models.
+          This option has been optimised for the classic Framework Laptop 13 chassis/speakers.
+          Framework Laptop 13 Pro needs different tuning.
 
           Before applying, ensure the speakers are set to 100%,
           because the volumes compound and the raw speaker device will be hidden by default.

--- a/framework/13-inch/common/default.nix
+++ b/framework/13-inch/common/default.nix
@@ -6,7 +6,7 @@
     ../../bluetooth.nix
     ../../kmod.nix
     ../../framework-tool.nix
-    ./audio.nix
+    ./classic-audio.nix
   ];
 
   # Fix TRRS headphones missing a mic


### PR DESCRIPTION
###### Description of changes
Rename file and comments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

