### PR TITLE
Adds support for bosgame b100

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ See code for all available configurations.
 | [Asus Zenbook Pro 17 UM6702](asus/zenbook/um6702/)                                | `<nixos-hardware/asus/zenbook/um6702>`                  | `asus-zenbook-um6702`                  |
 | [Asrock Rack ALTRAD8UD-1L2T](asrock-rack/altrad8ud-1l2t)                          | `<nixos-hardware/asrock-rack/altrad8ud-1l2t>`           | `asrock-rack-altrad8ud-1l2t`           |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                              | `<nixos-hardware/beagleboard/pocketbeagle>`             | `beagleboard-pocketbeagle`             |
+| [BOSGAME B100](bosgame/b100)                                                        | `<nixos-hardware/bosgame/b100>`                          | `bosgame-b100`                          |
 | [Chuwi MiniBook X](chuwi/minibook-x)                                              | `<nixos-hardware/chuwi/minibook-x>`                     | `chuwi-minibook-x`                     |
 | [Deciso DEC series](deciso/dec)                                                   | `<nixos-hardware/deciso/dec>`                           | `deciso-dec`                           |
 | [Dell G3 3779](dell/g3/3779)                                                      | `<nixos-hardware/dell/g3/3779>`                         | `dell-g3-3779`                         |

--- a/bosgame/b100/default.nix
+++ b/bosgame/b100/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../../common/cpu/intel/alder-lake
+    ../../common/pc/ssd
+  ];
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,7 @@
           asus-zephyrus-gu605cw = import ./asus/zephyrus/gu605cw;
           asus-zephyrus-gu605my = import ./asus/zephyrus/gu605my;
           beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
+          bosgame-b100 = import ./bosgame/b100;
           chuwi-minibook-x = import ./chuwi/minibook-x;
           deciso-dec = import ./deciso/dec;
           dell-e7240 = deprecated "1326" "dell-e7240" (import ./dell/e7240);


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Add a profile for the bosgame-b100

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

