### PR TITLE
init asus chromebox 4 duffy, celeron 5205u

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ See code for all available configurations.
 | [Apple MacMini (2010, Intel, Nvidia)](apple/macmini/4)                            | `<nixos-hardware/apple/macmini/4>`                      | `apple-macmini-4-1`                    |
 | [Apple Macs with a T2 Chip](apple/t2)                                             | `<nixos-hardware/apple/t2>`                             | `apple-t2`                             |
 | [Aoostar R1 N100](aoostar/r1/n100)                                                | `<nixos-hardware/aoostar/r1/n100>`                      | `aoostar-r1-n100`                      |
+| [Asus Chromebox 4 - Celeron 5205U](asus/chromebox/4/celeron-5205u)                | `<nixos-hardware/asus/chromebox/4/celeron-5205u>`       | `asus-chromebox-4-celeron`             |
 | [Asus Pro WS X570-ACE](asus/pro-ws-x570-ace)                                      | `<nixos-hardware/asus/pro-ws-x570-ace>`                 | `asus-pro-ws-x570-ace`                 |
 | [Asus ROG Ally RC71L (2023)](asus/ally/rc71l)                                     | `<nixos-hardware/asus/ally/rc71l>`                      | `asus-ally-rc71l`                      |
 | [Asus ROG Flow X13 GV302X\* (2023)](asus/flow/gv302x/amdgpu)                      | `<nixos-hardware/asus/flow/gv302x/amdgpu>`              | `asus-flow-gv302x-amdgpu`              |

--- a/asus/chromebox/4/celeron-5205u/default.nix
+++ b/asus/chromebox/4/celeron-5205u/default.nix
@@ -1,0 +1,13 @@
+{
+  imports = [
+    ../../../../common/cpu/intel/comet-lake
+    ../../../../common/gpu/intel/comet-lake
+  ];
+
+  # this does not enable sound by itself, but if you enable pipewire then this is required for non-bluetooth sinks
+  # 1 is the old Intel HD Audio driver
+  # 3 is the newer SOF driver that is incompatible with coreboot
+  boot.kernelParams = [
+    "snd_intel_dspcfg.dsp_driver=1"
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
           asrock-rack-altrad8ud-1l2t = import ./asrock-rack/altrad8ud-1l2t;
           asus-battery = import ./asus/battery.nix;
           asus-ally-rc71l = import ./asus/ally/rc71l;
+          asus-chromebox-4-celeron = import ./asus/chromebox/4/celeron-5205u;
           asus-fx504gd = import ./asus/fx504gd;
           asus-fx506hm = import ./asus/fx506hm;
           asus-fa506ic = import ./asus/fa506ic;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Import comet lake cpu and gpu

Set sound driver to old Intel HD Audio driver. This does not enable sound, but if you enable pipewire then this is required to create sinks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

###### Note

This sound fix could be more generically applicable to Intel chromebooks on coreboot but I have no other machines to test. I have noted this in #1770.