### PR TITLE
lenovo/ideapad/14imh9: fix deprecated systemd.sleep.extraConfig

### DIFF
--- a/lenovo/ideapad/14imh9/default.nix
+++ b/lenovo/ideapad/14imh9/default.nix
@@ -70,9 +70,7 @@
 
     # Workaround: Lenovo seems write bad acpi power management firmware. Without this config,
     #             suspend (to ram / disk) will simply reboot instead of power off. :(
-    sleep.extraConfig = ''
-      HibernateMode=shutdown
-    '';
+    sleep.settings.Sleep.HibernateMode = "shutdown";
   };
 
   # TPM2 module

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -2,34 +2,28 @@
   "nodes": {
     "nixos-stable": {
       "locked": {
-        "lastModified": 1767799921,
-        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
-        "type": "github"
+        "lastModified": 1781216227,
+        "narHash": "sha256-PoRRDfm1khYEJCk5KyX4Snud03VzRcmxKil5n6drTI0=",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.1947.a0374025a863/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
       }
     },
     "nixos-unstable-small": {
       "locked": {
-        "lastModified": 1761789293,
-        "narHash": "sha256-zwQKLaUgHSpY6SvB/MDgPYRPomWAmbkS3Xfo6JvFVOA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8d42228a0de7c23b012e2f7dd963425a372e1b0e",
-        "type": "github"
+        "lastModified": 1781332575,
+        "narHash": "sha256-b5zDI290fPWS3GogqVonydrdcpQPsRCzLIOA3T0ctrs=",
+        "rev": "51effaf9783e0226281ad10e95a4af6c8a145316",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1015892.51effaf9783e/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixos-unstable-small.url = "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz";
-    nixos-stable.url = "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz";
+    nixos-stable.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixos-unstable-small";
   };


### PR DESCRIPTION
###### Description of changes

Replace the deprecated `systemd.sleep.extraConfig` with `systemd.sleep.settings.Sleep.HibernateMode` (removed in NixOS/nixpkgs#493223). The new option needs nixpkgs 26.05, so this also bumps the stable test channel from `nixos-25.11` to `nixos-26.05`.

###### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input