### PR TITLE
treewide: enhance flake inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the following:
 ```nix
 {
   description = "NixOS configuration with flakes";
-  inputs.nixos-hardware.url = "github:NixOS/nixos-hardware/master";
+  inputs.nixos-hardware.url = "github:NixOS/nixos-hardware";
 
   outputs = { self, nixpkgs, nixos-hardware }: {
     # replace <your-hostname> with your actual hostname

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the following:
   inputs = {
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     nixos-hardware = {
-      url = "github:nixos/nixos-hardware";
+      url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ the following:
 ```nix
 {
   description = "NixOS configuration with flakes";
-  inputs.nixos-hardware.url = "github:NixOS/nixos-hardware";
+
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+    nixos-hardware = {
+      url = "github:nixos/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   outputs = { self, nixpkgs, nixos-hardware }: {
     # replace <your-hostname> with your actual hostname

--- a/asus/zenbook/ux535/README.md
+++ b/asus/zenbook/ux535/README.md
@@ -12,7 +12,7 @@ Configuration for the ScreenPad is unable to be provided here at this time, due 
   inputs = {
 
     nixpkgs = {
-      url = "github:NixOS/nixpkgs/nixos-unstable";
+      url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     };
 
     screenpad-driver={

--- a/hardkernel/odroid-m1/README.md
+++ b/hardkernel/odroid-m1/README.md
@@ -10,7 +10,7 @@ To create an initial SD card image for installation:
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     nixos-hardware = {
       url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -83,7 +83,7 @@ flake:
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     nixos-hardware = {
       url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hardkernel/odroid-m1/README.md
+++ b/hardkernel/odroid-m1/README.md
@@ -10,9 +10,9 @@ To create an initial SD card image for installation:
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixos-hardware = {
-      url = "github:nixos/nixos-hardware";
+      url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -83,9 +83,9 @@ flake:
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixos-hardware = {
-      url = "github:nixos/nixos-hardware";
+      url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/hardkernel/odroid-m1/README.md
+++ b/hardkernel/odroid-m1/README.md
@@ -11,7 +11,10 @@ To create an initial SD card image for installation:
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-hardware.url = "github:nixos/nixos-hardware";
+    nixos-hardware = {
+      url = "github:nixos/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs = { self, nixpkgs, nixos-hardware }: rec {
     nixosConfigurations.m1 = nixpkgs.lib.nixosSystem {
@@ -81,7 +84,10 @@ flake:
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-hardware.url = "github:nixos/nixos-hardware";
+    nixos-hardware = {
+      url = "github:nixos/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs = { nixpkgs, nixos-hardware, ... }: {
     nixosConfigurations.m1 = nixpkgs.lib.nixosSystem {

--- a/hardkernel/odroid-m1/README.md
+++ b/hardkernel/odroid-m1/README.md
@@ -11,7 +11,7 @@ To create an initial SD card image for installation:
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-hardware.url = "github:nixos/nixos-hardware/master";
+    nixos-hardware.url = "github:nixos/nixos-hardware";
   };
   outputs = { self, nixpkgs, nixos-hardware }: rec {
     nixosConfigurations.m1 = nixpkgs.lib.nixosSystem {
@@ -81,7 +81,7 @@ flake:
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-hardware.url = "github:nixos/nixos-hardware/master";
+    nixos-hardware.url = "github:nixos/nixos-hardware";
   };
   outputs = { nixpkgs, nixos-hardware, ... }: {
     nixosConfigurations.m1 = nixpkgs.lib.nixosSystem {

--- a/milkv/pioneer/README.md
+++ b/milkv/pioneer/README.md
@@ -5,7 +5,7 @@ Create and customize a `flake.nix` file:
 ```nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     nixos-hardware = {
       url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/milkv/pioneer/README.md
+++ b/milkv/pioneer/README.md
@@ -5,9 +5,9 @@ Create and customize a `flake.nix` file:
 ```nix
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixos-hardware = {
-      url = "github:nixos/nixos-hardware"; 
+      url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/milkv/pioneer/README.md
+++ b/milkv/pioneer/README.md
@@ -6,7 +6,10 @@ Create and customize a `flake.nix` file:
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-hardware.url = "github:nixos/nixos-hardware";
+    nixos-hardware = {
+      url = "github:nixos/nixos-hardware"; 
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { nixpkgs, nixos-hardware, ... }:

--- a/mnt/reform/rk3588/README.md
+++ b/mnt/reform/rk3588/README.md
@@ -5,7 +5,7 @@
 Create and configure the `flake.nix` file:
 ``` nix
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
   inputs.nixos-hardware = {
     url = "github:NixOS/nixos-hardware";
     inputs.nixpkgs.follows = "nixpkgs";

--- a/mnt/reform/rk3588/README.md
+++ b/mnt/reform/rk3588/README.md
@@ -6,7 +6,10 @@ Create and configure the `flake.nix` file:
 ``` nix
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
+  inputs.nixos-hardware = {
+    url = "github:nixos/nixos-hardware"; 
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, nixos-hardware, flake-utils, ... }:

--- a/mnt/reform/rk3588/README.md
+++ b/mnt/reform/rk3588/README.md
@@ -5,9 +5,9 @@
 Create and configure the `flake.nix` file:
 ``` nix
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.nixos-hardware = {
-    url = "github:nixos/nixos-hardware"; 
+    url = "github:NixOS/nixos-hardware";
     inputs.nixpkgs.follows = "nixpkgs";
   };
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/pine64/star64/README.md
+++ b/pine64/star64/README.md
@@ -5,7 +5,10 @@ Create and configure the `flake.nix` file:
 ``` nix
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
+  inputs.nixos-hardware = {
+    url = "github:nixos/nixos-hardware"; 
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
 
   outputs = { self, nixpkgs, nixos-hardware, ... }:

--- a/pine64/star64/README.md
+++ b/pine64/star64/README.md
@@ -4,7 +4,7 @@ Create and configure the `flake.nix` file:
 
 ``` nix
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
   inputs.nixos-hardware = {
     url = "github:NixOS/nixos-hardware";
     inputs.nixpkgs.follows = "nixpkgs";

--- a/pine64/star64/README.md
+++ b/pine64/star64/README.md
@@ -4,9 +4,9 @@ Create and configure the `flake.nix` file:
 
 ``` nix
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.nixos-hardware = {
-    url = "github:nixos/nixos-hardware"; 
+    url = "github:NixOS/nixos-hardware";
     inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/radxa/README.md
+++ b/radxa/README.md
@@ -40,6 +40,7 @@ Below is an annoated flake example to create the initial boot image.
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
     nixos-hardware.url = "github:NixOS/nixos-hardware";
+    nixos-hardware.inputs.nixpkgs.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     nixpkgs-unfree.url = "github:numtide/nixpkgs-unfree/nixos-unstable";
   };

--- a/radxa/README.md
+++ b/radxa/README.md
@@ -41,7 +41,7 @@ Below is an annoated flake example to create the initial boot image.
     disko.inputs.nixpkgs.follows = "nixpkgs";
     nixos-hardware.url = "github:NixOS/nixos-hardware";
     nixos-hardware.inputs.nixpkgs.follows = "nixpkgs";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     nixpkgs-unfree.url = "github:numtide/nixpkgs-unfree/nixos-unstable";
   };
 

--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -4,7 +4,10 @@ Create and configure the `flake.nix` file:
 ``` nix
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.nixos-hardware.url = "github:nixos/nixos-hardware";
+  inputs.nixos-hardware = {
+    url = "github:nixos/nixos-hardware";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
   # Some dependencies of this flake are not yet available on non linux systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";

--- a/starfive/visionfive/v2/README.md
+++ b/starfive/visionfive/v2/README.md
@@ -3,9 +3,9 @@
 Create and configure the `flake.nix` file:
 ``` nix
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
   inputs.nixos-hardware = {
-    url = "github:nixos/nixos-hardware";
+    url = "github:NixOS/nixos-hardware";
     inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -2,8 +2,8 @@
   description = "Private dev inputs for nixos-hardware";
 
   inputs = {
-    nixos-unstable-small.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-    nixos-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixos-unstable-small.url = "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz";
+    nixos-stable.url = "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixos-unstable-small";
   };


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

- fallback to default branch instead of hardcoding `master` (which was already being done in most of the codebase, so it's an harmonization)
- makes nixos-hardware follow nixpkgs (FIXES: https://github.com/NixOS/nixos-hardware/pull/1723#issuecomment-4591059652)
- harmonize "NixOS" capitalisation
- make nixpkgs flake inputs target hydra tarballs (see https://discourse.nixos.org/t/questions-about-inputs-nixpkgs/69095/14?u=malix)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

