### PR TITLE
prime.nix: disable enableOffloadCmd in battery-saver specialisation

### DIFF
--- a/common/gpu/nvidia/prime.nix
+++ b/common/gpu/nvidia/prime.nix
@@ -26,6 +26,7 @@
         ];
         hardware.nvidia = {
           prime.offload.enable = lib.mkForce false;
+          prime.offload.enableOffloadCmd = lib.mkForce false;
           powerManagement = {
             enable = lib.mkForce false;
             finegrained = lib.mkForce false;


### PR DESCRIPTION
The battery-saver specialisation forces offload.enable = false but did not also force enableOffloadCmd = false. Hardware modules (e.g. asus/zephyrus/ga402x/nvidia) set enableOffloadCmd = mkDefault true unconditionally, so when the specialisation disables offloading the nixpkgs nvidia module assertion fires:

  "Offload command requires offloading or reverse prime sync to be enabled."

Fix by explicitly forcing enableOffloadCmd = false alongside offload.enable = false in the battery-saver specialisation.

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input