### PR TITLE
FIX: imx93 ATF compile fix with GCC 14+ and cross build fix for imx9x targets

### DIFF
--- a/compulab/ucm-imx95/bsp/ucm-imx95-boot.nix
+++ b/compulab/ucm-imx95/bsp/ucm-imx95-boot.nix
@@ -1,24 +1,17 @@
 {
-  callPackage,
-  fetchFromGitHub,
-  stdenv,
-  clang,
-  git,
-  dtc,
-  glibc,
-  zlib,
-  vim,
+  pkgs,
 }:
 let
+  bp = pkgs.buildPackages;
 
-  imx95-atf = callPackage ./ucm-imx95-atf.nix { };
-  imx95-firmware = callPackage ./ucm-imx95-firmware.nix { };
-  imx95-uboot = callPackage ./ucm-imx95-uboot.nix { };
-  imx95-optee-os = callPackage ./ucm-imx95-optee-os.nix { };
-  imx95-sm-fw = callPackage ./ucm-imx95-sm-fw.nix { };
-  imx95-oei-ddr = callPackage ./ucm-imx95-oei-ddr.nix { };
-  imx95-oei-tcm = callPackage ./ucm-imx95-oei-tcm.nix { };
-  src = fetchFromGitHub {
+  imx95-atf = pkgs.callPackage ./ucm-imx95-atf.nix { };
+  imx95-firmware = pkgs.callPackage ./ucm-imx95-firmware.nix { };
+  imx95-uboot = pkgs.callPackage ./ucm-imx95-uboot.nix { };
+  imx95-optee-os = pkgs.callPackage ./ucm-imx95-optee-os.nix { };
+  imx95-sm-fw = pkgs.callPackage ./ucm-imx95-sm-fw.nix { };
+  imx95-oei-ddr = pkgs.callPackage ./ucm-imx95-oei-ddr.nix { };
+  imx95-oei-tcm = pkgs.callPackage ./ucm-imx95-oei-tcm.nix { };
+  src = pkgs.fetchFromGitHub {
     owner = "nxp-imx";
     repo = "imx-mkimage";
     #tag: lf-6.6.52-2.2.1
@@ -28,7 +21,8 @@ let
   shortRev = builtins.substring 0 8 src.rev;
 in
 {
-  imx95-boot = stdenv.mkDerivation rec {
+  # mkimage runs on the build machine; use buildPackages when cross-compiling.
+  imx95-boot = bp.stdenv.mkDerivation {
     inherit src;
     name = "imx95-mkimage";
     version = "lf-6.6.52-2.2.1";
@@ -36,27 +30,22 @@ in
     postPatch = ''
       substituteInPlace Makefile \
           --replace-fail 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
-      substituteInPlace Makefile \
-          --replace-fail 'CC = gcc' 'CC = clang'
       substituteInPlace iMX95/soc.mak \
-        --replace-fail 'xxd' "${vim.xxd}/bin/xxd"
+        --replace-fail 'xxd' "${bp.vim.xxd}/bin/xxd"
       substituteInPlace scripts/fspi_fcb_gen.sh \
-        --replace-fail 'xxd' "${vim.xxd}/bin/xxd"
+        --replace-fail 'xxd' "${bp.vim.xxd}/bin/xxd"
       substituteInPlace scripts/fspi_packer.sh \
-        --replace-fail 'xxd' "${vim.xxd}/bin/xxd"
+        --replace-fail 'xxd' "${bp.vim.xxd}/bin/xxd"
       patchShebangs scripts
     '';
 
     nativeBuildInputs = [
-      clang
-      git
-      dtc
-    ];
-
-    buildInputs = [
-      glibc.static
-      zlib
-      zlib.static
+      bp.stdenv.cc
+      bp.git
+      bp.dtc
+      bp.glibc.static
+      bp.zlib
+      bp.zlib.static
     ];
 
     buildPhase = ''

--- a/compulab/ucm-imx95/overlay.nix
+++ b/compulab/ucm-imx95/overlay.nix
@@ -1,3 +1,3 @@
 final: _prev: {
-  inherit (final.callPackage ./bsp/ucm-imx95-boot.nix { }) imx95-boot;
+  inherit (final.callPackage ./bsp/ucm-imx95-boot.nix { pkgs = final; }) imx95-boot;
 }

--- a/nxp/imx93-evk/bsp/imx93-atf.nix
+++ b/nxp/imx93-evk/bsp/imx93-atf.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "imx93-trdc-header-guard.patch";
       url = "https://github.com/nxp-imx/imx-atf/commit/e194a14ec55f13386babc80c90098874367ab3d6.patch";
-      sha256 = "sha256-uXRgeyFmxDww93nJe04aoOLml2R7IbABZLhywyYmePk=";
+      sha256 = "sha256-K1JECateo4mUrOaV41PUmCXHn7DfmgRQXx4KdcIALqE=";
     })
   ];
 

--- a/nxp/imx93-evk/bsp/imx93-atf.nix
+++ b/nxp/imx93-evk/bsp/imx93-atf.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchgit,
+  fetchpatch,
   stdenv,
   buildPackages,
   pkgsCross,
@@ -21,6 +22,14 @@ stdenv.mkDerivation rec {
     rev = "28affcae957cb8194917b5246276630f9e6343e1";
     sha256 = "sha256-a8F+Lf8pwML+tCwawS0N/mrSXWPmFhlUeOg0MCRK3VE=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "imx93-trdc-header-guard.patch";
+      url = "https://github.com/nxp-imx/imx-atf/commit/e194a14ec55f13386babc80c90098874367ab3d6.patch";
+      sha256 = "sha256-uXRgeyFmxDww93nJe04aoOLml2R7IbABZLhywyYmePk=";
+    })
+  ];
 
   # Compiler dependencies
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/nxp/imx93-evk/bsp/imx93-boot.nix
+++ b/nxp/imx93-evk/bsp/imx93-boot.nix
@@ -1,8 +1,8 @@
 {
   pkgs,
 }:
-with pkgs;
 let
+  bp = pkgs.buildPackages;
 
   imx93-atf = pkgs.callPackage ./imx93-atf.nix { };
   imx93-firmware = pkgs.callPackage ./imx93-firmware.nix { };
@@ -17,7 +17,8 @@ let
   shortRev = builtins.substring 0 8 src.rev;
 in
 {
-  imx93-boot = pkgs.stdenv.mkDerivation rec {
+  # mkimage runs on the build machine; use buildPackages when cross-compiling.
+  imx93-boot = bp.stdenv.mkDerivation {
     inherit src;
     name = "imx93-mkimage";
     version = "lf-6.12.3";
@@ -25,28 +26,22 @@ in
     postPatch = ''
       substituteInPlace Makefile \
           --replace 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
-      substituteInPlace Makefile \
-          --replace 'CC = gcc' 'CC = clang'
       substituteInPlace iMX93/soc.mak \
-        --replace 'xxd' "${pkgs.vim.xxd}/bin/xxd"
+        --replace 'xxd' "${bp.vim.xxd}/bin/xxd"
       substituteInPlace scripts/fspi_fcb_gen.sh \
-        --replace 'xxd' "${pkgs.vim.xxd}/bin/xxd"
+        --replace 'xxd' "${bp.vim.xxd}/bin/xxd"
       substituteInPlace scripts/fspi_packer.sh \
-        --replace 'xxd' "${pkgs.vim.xxd}/bin/xxd"
+        --replace 'xxd' "${bp.vim.xxd}/bin/xxd"
       patchShebangs scripts
     '';
 
     nativeBuildInputs = [
-      clang
-      git
-      dtc
-    ];
-
-    buildInputs = [
-      git
-      glibc.static
-      zlib
-      zlib.static
+      bp.stdenv.cc
+      bp.git
+      bp.dtc
+      bp.glibc.static
+      bp.zlib
+      bp.zlib.static
     ];
 
     buildPhase = ''


### PR DESCRIPTION

###### Description of changes
Fixed i.MX93 ATF build failure on GCC 14+ caused by a mismatched TRDC header guard by applying the upstream patch without changing the pinned ATF revision.

Fixed i.MX93 and i.MX95 cross-build failures by ensuring imx-mkimage and its native tools are built with buildPackages (host toolchain) while keeping firmware artifacts from target packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

