### PR TITLE
Add support for ThinkPad P1 Gen 5 with Intel and Nvidia GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad L14 (Intel)](lenovo/thinkpad/l14/intel)                          | `<nixos-hardware/lenovo/thinkpad/l14/intel>`            | `lenovo-thinkpad-l14-intel`            |
 | [Lenovo ThinkPad L480](lenovo/thinkpad/l480)                                      | `<nixos-hardware/lenovo/thinkpad/l480>`                 | `lenovo-thinkpad-l480`                 |
 | [Lenovo ThinkPad P1 Gen 3](lenovo/thinkpad/p1/3th-gen)                            | `<nixos-hardware/lenovo/thinkpad/p1/3th-gen>`           | `lenovo-thinkpad-p1-gen3`              |
+| [Lenovo ThinkPad P1 Gen 5](lenovo/thinkpad/p1/gen5)                               | `<nixos-hardware/lenovo/thinkpad/p1/gen5>`              | `lenovo-thinkpad-p1-gen5`              |
 | [Lenovo ThinkPad P1 Gen 5 (Nvidia)](lenovo/thinkpad/p1/gen5/nvidia)               | `<nixos-hardware/lenovo/thinkpad/p1/gen5/nvidia>`       | `lenovo-thinkpad-p1-gen5-nvidia`       |
 | [Lenovo ThinkPad P14s AMD Gen 1](lenovo/thinkpad/p14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen1>`        | `lenovo-thinkpad-p14s-amd-gen1`        |
 | [Lenovo ThinkPad P14s AMD Gen 2](lenovo/thinkpad/p14s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen2>`        | `lenovo-thinkpad-p14s-amd-gen2`        |

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad L14 (Intel)](lenovo/thinkpad/l14/intel)                          | `<nixos-hardware/lenovo/thinkpad/l14/intel>`            | `lenovo-thinkpad-l14-intel`            |
 | [Lenovo ThinkPad L480](lenovo/thinkpad/l480)                                      | `<nixos-hardware/lenovo/thinkpad/l480>`                 | `lenovo-thinkpad-l480`                 |
 | [Lenovo ThinkPad P1 Gen 3](lenovo/thinkpad/p1/3th-gen)                            | `<nixos-hardware/lenovo/thinkpad/p1/3th-gen>`           | `lenovo-thinkpad-p1-gen3`              |
+| [Lenovo ThinkPad P1 Gen 5 (Nvidia)](lenovo/thinkpad/p1/gen5/nvidia)               | `<nixos-hardware/lenovo/thinkpad/p1/gen5/nvidia>`       | `lenovo-thinkpad-p1-gen5-nvidia`       |
 | [Lenovo ThinkPad P14s AMD Gen 1](lenovo/thinkpad/p14s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen1>`        | `lenovo-thinkpad-p14s-amd-gen1`        |
 | [Lenovo ThinkPad P14s AMD Gen 2](lenovo/thinkpad/p14s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen2>`        | `lenovo-thinkpad-p14s-amd-gen2`        |
 | [Lenovo ThinkPad P14s AMD Gen 3](lenovo/thinkpad/p14s/amd/gen3)                   | `<nixos-hardware/lenovo/thinkpad/p14s/amd/gen3>`        | `lenovo-thinkpad-p14s-amd-gen3`        |

--- a/flake.nix
+++ b/flake.nix
@@ -262,6 +262,7 @@
           lenovo-thinkpad-l480 = import ./lenovo/thinkpad/l480;
           lenovo-thinkpad-p1 = import ./lenovo/thinkpad/p1;
           lenovo-thinkpad-p1-gen3 = import ./lenovo/thinkpad/p1/3th-gen;
+          lenovo-thinkpad-p1-gen5 = import ./lenovo/thinkpad/p1/gen5;
           lenovo-thinkpad-p1-gen5-nvidia = import ./lenovo/thinkpad/p1/gen5/nvidia;
           lenovo-thinkpad-p14s-amd-gen1 = import ./lenovo/thinkpad/p14s/amd/gen1;
           lenovo-thinkpad-p14s-amd-gen2 = import ./lenovo/thinkpad/p14s/amd/gen2;

--- a/flake.nix
+++ b/flake.nix
@@ -262,6 +262,7 @@
           lenovo-thinkpad-l480 = import ./lenovo/thinkpad/l480;
           lenovo-thinkpad-p1 = import ./lenovo/thinkpad/p1;
           lenovo-thinkpad-p1-gen3 = import ./lenovo/thinkpad/p1/3th-gen;
+          lenovo-thinkpad-p1-gen5-nvidia = import ./lenovo/thinkpad/p1/gen5/nvidia;
           lenovo-thinkpad-p14s-amd-gen1 = import ./lenovo/thinkpad/p14s/amd/gen1;
           lenovo-thinkpad-p14s-amd-gen2 = import ./lenovo/thinkpad/p14s/amd/gen2;
           lenovo-thinkpad-p14s-amd-gen3 = import ./lenovo/thinkpad/p14s/amd/gen3;

--- a/lenovo/thinkpad/p1/default.nix
+++ b/lenovo/thinkpad/p1/default.nix
@@ -1,9 +1,6 @@
 {
   imports = [
     ../../../common/cpu/intel
-    # might need nvidia module but we don't know the PCI ids:
-    # https://github.com/NixOS/nixos-hardware/pull/274#discussion_r650483740
-    #../../../common/gpu/nvidia/prime.nix
     ../../../common/pc/ssd
   ];
 

--- a/lenovo/thinkpad/p1/gen5/README.md
+++ b/lenovo/thinkpad/p1/gen5/README.md
@@ -1,0 +1,55 @@
+# Lenovo ThinkPad P1 Gen 5
+
+https://www.lenovo.com/us/en/p/laptops/thinkpad/thinkpadp/thinkpad-p1-gen-5-16-inch-intel/len101t0033
+
+Tested on a P1 Gen 5 with Intel Iris Xe (Alder Lake) graphics and an
+NVIDIA GeForce RTX 3080 Ti Mobile (Ampere) discrete GPU.
+
+- `lenovo-thinkpad-p1-gen5` — Alder Lake base; use on iGPU-only units.
+- `lenovo-thinkpad-p1-gen5-nvidia` — adds NVIDIA PRIME **offload**. Run a
+  program on the discrete GPU with `nvidia-offload <command>`.
+
+## Tested Hardware
+
+```shell
+lspci -nn
+00:00.0 Host bridge [0600]: Intel Corporation 12th Gen Core Processor Host Bridge/DRAM Registers [8086:4641] (rev 02)
+00:01.0 PCI bridge [0604]: Intel Corporation 12th Gen Core Processor PCI Express x16 Controller #1 [8086:460d] (rev 02)
+00:02.0 VGA compatible controller [0300]: Intel Corporation Alder Lake-P GT2 [Iris Xe Graphics] [8086:46a6] (rev 0c)
+00:04.0 Signal processing controller [1180]: Intel Corporation Alder Lake Innovation Platform Framework Processor Participant [8086:461d] (rev 02)
+00:06.0 PCI bridge [0604]: Intel Corporation 12th Gen Core Processor PCI Express x4 Controller #0 [8086:464d] (rev 02)
+00:08.0 System peripheral [0880]: Intel Corporation 12th Gen Core Processor Gaussian & Neural Accelerator [8086:464f] (rev 02)
+00:0a.0 Signal processing controller [1180]: Intel Corporation Platform Monitoring Technology [8086:467d] (rev 01)
+00:14.0 USB controller [0c03]: Intel Corporation Alder Lake PCH USB 3.2 xHCI Host Controller [8086:51ed] (rev 01)
+00:14.2 RAM memory [0500]: Intel Corporation Alder Lake PCH Shared SRAM [8086:51ef] (rev 01)
+00:14.3 Network controller [0280]: Intel Corporation Alder Lake-P PCH CNVi WiFi [8086:51f0] (rev 01)
+00:15.0 Serial bus controller [0c80]: Intel Corporation Alder Lake PCH Serial IO I2C Controller #0 [8086:51e8] (rev 01)
+00:16.0 Communication controller [0780]: Intel Corporation Alder Lake PCH HECI Controller [8086:51e0] (rev 01)
+00:16.3 Serial controller [0700]: Intel Corporation Alder Lake AMT SOL Redirection [8086:51e3] (rev 01)
+00:1c.0 PCI bridge [0604]: Intel Corporation Device [8086:51b8] (rev 01)
+00:1c.7 PCI bridge [0604]: Intel Corporation Alder Lake PCH-P PCI Express Root Port #9 [8086:51bf] (rev 01)
+00:1d.0 PCI bridge [0604]: Intel Corporation Alder Lake PCI Express Root Port #9 [8086:51b0] (rev 01)
+00:1f.0 ISA bridge [0601]: Intel Corporation Alder Lake PCH eSPI Controller [8086:5182] (rev 01)
+00:1f.3 Multimedia audio controller [0401]: Intel Corporation Alder Lake PCH-P High Definition Audio Controller [8086:51c8] (rev 01)
+00:1f.4 SMBus [0c05]: Intel Corporation Alder Lake PCH-P SMBus Host Controller [8086:51a3] (rev 01)
+00:1f.5 Serial bus controller [0c80]: Intel Corporation Alder Lake-P PCH SPI Controller [8086:51a4] (rev 01)
+01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GA103M [GeForce RTX 3080 Ti Mobile] [10de:2420] (rev a1)
+01:00.1 Audio device [0403]: NVIDIA Corporation Device [10de:2288] (rev a1)
+04:00.0 Non-Volatile memory controller [0108]: SK hynix Gold P31/BC711/PC711 NVMe Solid State Drive [1c5c:174a]
+0a:00.0 Unassigned class [ff00]: Realtek Semiconductor Co., Ltd. RTS5261 PCIe SD Express Card Reader controller [10ec:5261] (rev 01)
+20:00.0 PCI bridge [0604]: Intel Corporation Thunderbolt 4 Bridge [Maple Ridge 4C 2020] [8086:1136] (rev 02)
+21:00.0 PCI bridge [0604]: Intel Corporation Thunderbolt 4 Bridge [Maple Ridge 4C 2020] [8086:1136] (rev 02)
+21:01.0 PCI bridge [0604]: Intel Corporation Thunderbolt 4 Bridge [Maple Ridge 4C 2020] [8086:1136] (rev 02)
+21:02.0 PCI bridge [0604]: Intel Corporation Thunderbolt 4 Bridge [Maple Ridge 4C 2020] [8086:1136] (rev 02)
+21:03.0 PCI bridge [0604]: Intel Corporation Thunderbolt 4 Bridge [Maple Ridge 4C 2020] [8086:1136] (rev 02)
+22:00.0 USB controller [0c03]: Intel Corporation Thunderbolt 4 NHI [Maple Ridge 4C 2020] [8086:1137]
+56:00.0 USB controller [0c03]: Intel Corporation Thunderbolt 4 USB Controller [Maple Ridge 4C 2020] [8086:1138]
+
+nix-info -m
+ - system: `"x86_64-linux"`
+ - host os: `Linux 7.0.11, NixOS, 26.05 (Yarara), 26.05.20260603.6b31628`
+ - multi-user?: `yes`
+ - sandbox: `yes`
+ - version: `nix-env (Nix) 2.34.7`
+ - nixpkgs: `/nix/store/snzg7swkp0vsd2qch9izsbmxnyb13ca0-source`
+```

--- a/lenovo/thinkpad/p1/gen5/README.md
+++ b/lenovo/thinkpad/p1/gen5/README.md
@@ -9,6 +9,19 @@ NVIDIA GeForce RTX 3080 Ti Mobile (Ampere) discrete GPU.
 - `lenovo-thinkpad-p1-gen5-nvidia` — adds NVIDIA PRIME **offload**. Run a
   program on the discrete GPU with `nvidia-offload <command>`.
 
+## Power management
+
+The `-nvidia` profile enables PRIME **offload** but does not turn on fine-grained
+runtime power management, so the discrete GPU stays powered even when idle —
+noticeable battery drain on a laptop. That setting is experimental and depends on
+the GPU + firmware supporting PCIe Runtime D3 (RTD3), so it is left to the user.
+If your unit supports it, let the dGPU suspend when unused by adding to your own
+configuration:
+
+```nix
+hardware.nvidia.powerManagement.finegrained = true;
+```
+
 ## Tested Hardware
 
 ```shell

--- a/lenovo/thinkpad/p1/gen5/default.nix
+++ b/lenovo/thinkpad/p1/gen5/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  imports = [
+    ../.
+    ../../../../common/cpu/intel/alder-lake # P1 Gen 5 is 12th-gen Alder Lake
+  ];
+}

--- a/lenovo/thinkpad/p1/gen5/nvidia/default.nix
+++ b/lenovo/thinkpad/p1/gen5/nvidia/default.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   imports = [
-    ../../.
+    ../.
     ../../../../../common/gpu/nvidia/ampere
     ../../../../../common/gpu/nvidia/prime.nix
   ];

--- a/lenovo/thinkpad/p1/gen5/nvidia/default.nix
+++ b/lenovo/thinkpad/p1/gen5/nvidia/default.nix
@@ -12,6 +12,8 @@
       enable32Bit = lib.mkDefault true;
     };
     nvidia = {
+      # "Wayland requires kernel mode setting (KMS) to be enabled (Highly
+      # Recommended)" per https://wiki.nixos.org/wiki/NVIDIA#Requirements.
       modesetting.enable = lib.mkDefault true;
       prime = {
         # Bus ID of the Intel GPU.

--- a/lenovo/thinkpad/p1/gen5/nvidia/default.nix
+++ b/lenovo/thinkpad/p1/gen5/nvidia/default.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+{
+  imports = [
+    ../../.
+    ../../../../../common/gpu/nvidia/ampere
+    ../../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  hardware = {
+    graphics = {
+      enable = lib.mkDefault true;
+      enable32Bit = lib.mkDefault true;
+    };
+    nvidia = {
+      modesetting.enable = lib.mkDefault true;
+      prime = {
+        # Bus ID of the Intel GPU.
+        intelBusId = lib.mkDefault "PCI:0:2:0";
+        # Bus ID of the NVIDIA GPU.
+        nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Added support for Lenovo ThinkPad Gen 5 with opt-in Nvidia GPU. Notably set defaults for bus ID's for dual Intel and Nvidia GPUs which addresses https://github.com/NixOS/nixos-hardware/pull/274 for this gen.

###### Things done

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

```shell
sudo nixos-rebuild test --flake /etc/nixos
warning: Git tree '/etc/nixos' is dirty
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
Checking switch inhibitors... done
stopping the following units: systemd-tmpfiles-resetup.service
activating the configuration...
setting up /etc...
reloading user units for stovepipe...
restarting the following user units: nixos-activation.service
restarting sysinit-reactivation.target
starting the following units: systemd-tmpfiles-resetup.service
the following new units were started: NetworkManager-dispatcher.service
Done. The new configuration is /nix/store/942w2i8zrp3bdgli17qjfail94j85h6s-nixos-system-marvin-26.05.20260603.6b31628
```

```shell
sudo nixos-rebuild switch --flake /etc/nixos
warning: Git tree '/etc/nixos' is dirty
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
Checking switch inhibitors... done
activating the configuration...
setting up /etc...
reloading user units for stovepipe...
restarting the following user units: nixos-activation.service
restarting sysinit-reactivation.target
the following new units were started: NetworkManager-dispatcher.service
Done. The new configuration is /nix/store/x3q9hjnn82sqpgshivdmsw4d2w6yxvsw-nixos-system-marvin-26.05.20260603.6b31628
```

<https://codeberg.org/kraker/nix-config/src/commit/8d24e22658063c1050fe4f849702093ae585dfd2/flake.nix#L8>
