### PR TITLE
dell/inspiron/13-7353: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ See code for all available configurations.
 | [Dell Inspiron 14 5420](dell/inspiron/14-5420)                                    | `<nixos-hardware/dell/inspiron/14-5420>`                | `dell-inspiron-14-5420`                |
 | [Dell Inspiron 5509](dell/inspiron/5509)                                          | `<nixos-hardware/dell/inspiron/5509>`                   | `dell-inspiron-5509`                   |
 | [Dell Inspiron 5515](dell/inspiron/5515)                                          | `<nixos-hardware/dell/inspiron/5515>`                   | `dell-inspiron-5515`                   |
+| [Dell Inspiron 13-7353](dell/inspiron/13-7353)                                    | `<nixos-hardware/dell/inspiron/13-7353>`                | `dell-inspiron-13-7353`                |
 | [Dell Inspiron 7405](dell/inspiron/7405)                                          | `<nixos-hardware/dell/inspiron/7405>`                   | `dell-inspiron-7405`                   |
 | [Dell Inspiron 7460](dell/inspiron/7460)                                          | `<nixos-hardware/dell/inspiron/7460>`                   | `dell-inspiron-7460`                   |
 | [Dell Inspiron 7559](dell/inspiron/7559)                                          | `<nixos-hardware/dell/inspiron/7559>`                   | `dell-inspiron-7559`                   |

--- a/dell/inspiron/13-7353/README.md
+++ b/dell/inspiron/13-7353/README.md
@@ -1,0 +1,22 @@
+# Dell Inspiron 13-7353
+
+13" 2-in-1 convertible from the Inspiron 7000 series: Intel Core
+i7-6500U / i5-6200U (Skylake) with HD 520 graphics, Intel Wireless 3165,
+SATA M.2 storage, and an Elan touchpad/touchscreen.
+
+Everything works with mainline kernels via UEFI. The Skylake module this
+profile imports configures GuC (`i915.enable_guc=2`), the legacy
+`intel-vaapi-driver` with hybrid codec support, and the legacy
+`intel-compute-runtime` appropriate for Gen9 graphics.
+
+## Known issues
+
+Boot-time firmware noise from the stock BIOS — all harmless:
+
+- `DMAR: [Firmware Bug]: ... bad RMRR`
+- `tpm_crb MSFT0101:00: [Firmware Bug]: ACPI region does not cover the
+  entire command/response buffer`
+- `ACPI Warning: \_SB.IETM._ART: Return Package type mismatch` /
+  `_ART package 0 is invalid, ignored`
+- `psmouse serio1: elantech: elantech_send_cmd query 0x02 failed` (the
+  touchpad still works via I2C)

--- a/dell/inspiron/13-7353/default.nix
+++ b/dell/inspiron/13-7353/default.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/cpu/intel/skylake
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  services = {
+    fwupd.enable = lib.mkDefault true;
+    thermald.enable = lib.mkDefault true;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
           dell-inspiron-14-5420 = import ./dell/inspiron/14-5420;
           dell-inspiron-5509 = import ./dell/inspiron/5509;
           dell-inspiron-5515 = import ./dell/inspiron/5515;
+          dell-inspiron-13-7353 = import ./dell/inspiron/13-7353;
           dell-inspiron-7405 = import ./dell/inspiron/7405;
           dell-inspiron-7460 = import ./dell/inspiron/7460;
           dell-inspiron-7559 = import ./dell/inspiron/7559;


### PR DESCRIPTION
###### Description of changes

Add a profile for the Dell Inspiron 13-7353, the 13" 2-in-1 convertible from the Inspiron 7000 series: Intel Core i7-6500U / i5-6200U (Skylake) with HD 520 graphics, Intel Wireless 3165, and SATA M.2 storage.

The profile follows the pattern of the existing `dell/inspiron/` siblings: `common/cpu/intel/skylake` + `common/pc/laptop` + `common/pc/ssd`, redistributable firmware, and `fwupd`/`thermald` enabled by default. The Skylake common module supplies the meaningful hardware configuration (GuC, legacy `intel-vaapi-driver` with hybrid codec, legacy `intel-compute-runtime` for Gen9). The README documents the stock BIOS's harmless boot noise (DMAR RMRR, TPM CRB buffer, `_ART` package, elantech query warnings).

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tested on an Inspiron 13-7353 (i7-6500U) running NixOS 26.05: profile imported as a flake input from this fork, deployed with `switch-to-configuration switch` and rebooted onto the new generation — GuC/HuC firmware loads, the legacy i965 VA-API driver is installed (iHD correctly absent for Gen9), and thermald/TLP are active.

**AI Transparency**
LLMs were used in the development of this PR