### PR TITLE
lattepanda/sigma: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See code for all available configurations.
 | [Intel NUC 8i7BEH](intel/nuc/8i7beh/)                                             | `<nixos-hardware/intel/nuc/8i7beh>`                     | `intel-nuc-8i7beh`                     |
 | [Intel NUC 12WSHi7](intel/nuc/12wshi7/)                                           | `<nixos-hardware/intel/nuc/12wshi7>`                    | `intel-nuc-12wshi7`                    |
 | [Kobol Helios4](kobol/helios4)                                                    | `<nixos-hardware/kobol/helios4>`                        | `kobol-helios-4`                       |
+| [LattePanda Sigma](lattepanda/sigma)                                              | `<nixos-hardware/lattepanda/sigma>`                     | `lattepanda-sigma`                     |
 | [Lenovo IdeaCentre K330](lenovo/ideacentre/k330)                                  | `<nixos-hardware/lenovo/ideacentre/k330>`               | `lenovo-ideacentre-k330`               |
 | [Lenovo IdeaPad 3 15alc6](lenovo/ideapad/15alc6)                                  | `<nixos-hardware/lenovo/ideapad/15alc6>`                | `lenovo-ideapad-15alc6`                |
 | [Lenovo IdeaPad Gaming 3 15arh05](lenovo/ideapad/15arh05)                         | `<nixos-hardware/lenovo/ideapad/15arh05>`               | `lenovo-ideapad-15arh05`               |

--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,7 @@
           intel-nuc-7i3bnb = import ./intel/nuc/7i3bnb;
           intel-nuc-8i7beh = import ./intel/nuc/8i7beh;
           intel-nuc-12wshi7 = import ./intel/nuc/12wshi7;
+          lattepanda-sigma = import ./lattepanda/sigma;
           lenovo-ideacentre-k330 = import ./lenovo/ideacentre/k330;
           lenovo-ideapad-14imh9 = import ./lenovo/ideapad/14imh9;
           lenovo-ideapad-15alc6 = import ./lenovo/ideapad/15alc6;

--- a/lattepanda/sigma/README.md
+++ b/lattepanda/sigma/README.md
@@ -1,0 +1,24 @@
+# LattePanda Sigma
+
+The [LattePanda Sigma](https://www.lattepanda.com/lattepanda-sigma) is a
+high-performance x86 SBC built around the Intel Core i5-1340P (Raptor
+Lake-P) with Iris Xe graphics, dual Intel I225-V 2.5 GbE NICs, two
+Thunderbolt 4 ports, M.2 NVMe storage, and an M.2 E-key slot for WiFi
+(ships with an Intel AX210/AX211).
+
+Everything works with mainline kernels via UEFI; no out-of-tree drivers are
+required. This profile does not choose a bootloader — both systemd-boot and
+GRUB (EFI) work.
+
+## Known issues
+
+- **Goodix touchscreen probe errors at boot**
+  (`Goodix-TS i2c-GDIX1001:00 ... I2C communication failure: -121`): the
+  BIOS exposes a touch controller for an optional eDP touch display; when no
+  display is attached the probe fails. Harmless.
+- **`intel-hid INTC1078:00: failed to enable HID power button`**: harmless
+  BIOS quirk.
+- The dual I225-V NICs use the `igc` driver. If you see link flapping under
+  low-power idle (a known issue on some igc parts), disable PCIe ASPM
+  (`boot.kernelParams = [ "pcie_aspm=off" ];`) and Energy-Efficient Ethernet
+  (`ethtool --set-eee <iface> eee off`).

--- a/lattepanda/sigma/default.nix
+++ b/lattepanda/sigma/default.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../common/cpu/intel/raptor-lake
+    ../../common/pc
+    ../../common/pc/ssd
+  ];
+
+  # Intel AX210 WiFi, Intel Bluetooth, and i915 GuC/DMC firmware
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  # Expose package/core temperature sensors
+  boot.kernelModules = [ "coretemp" ];
+}


### PR DESCRIPTION
###### Description of changes

Add a profile for the [LattePanda Sigma](https://www.lattepanda.com/lattepanda-sigma), a high-performance x86 SBC built around the Intel Core i5-1340P (Raptor Lake-P) with Iris Xe graphics, dual Intel I225-V 2.5 GbE NICs, two Thunderbolt 4 ports, and an M.2 E-key WiFi slot (ships with an Intel AX210/AX211).

This establishes the `lattepanda/` manufacturer directory. The profile composes `common/cpu/intel/raptor-lake` + `common/pc` + `common/pc/ssd`, enables redistributable firmware (AX210 WiFi, Intel Bluetooth, i915 GuC/DMC), and loads `coretemp` for temperature sensors. The README documents known firmware quirks: harmless Goodix touch-controller probe failures (the BIOS exposes a controller for an optional eDP touch display), the `intel-hid` power-button warning, and pointers to igc EEE/ASPM mitigations should the dual I225-V NICs exhibit the known link-flapping behavior.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tested on a LattePanda Sigma (i5-1340P, 32 GB) running NixOS 26.05 as a desktop workstation: profile imported as a flake input from this fork and activated via `switch-to-configuration`; coretemp, AX210 WiFi/BT firmware, and Thunderbolt verified on the running system.

**AI Transparency**
LLMs were used in the development of this PR