### PR TITLE
radxa/x4: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ See code for all available configurations.
 | [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        | `rock-5b`                              |
 | [Radxa ROCK Pi 4](radxa/rock-pi-4)                                                | `<nixos-hardware/radxa/rock-pi-4>`                      | `rock-pi-4`                            |
 | [Radxa ROCK Pi E](radxa/rock-pi-e)                                                | `<nixos-hardware/radxa/rock-pi-e>`                      | `rock-pi-e`                            |
+| [Radxa X4](radxa/x4)                                                              | `<nixos-hardware/radxa/x4>`                             | `radxa-x4`                             |
 | [Razer Blade 14 (RZ09-0530)](razer/blade/14/RZ09-0530)                            | `<nixos-hardware/razer/blade/14/RZ09-0530>`             | `razer-blade-14-RZ09-0530`             |
 | [Raspberry Pi 2](raspberry-pi/2)                                                  | `<nixos-hardware/raspberry-pi/2>`                       | `raspberry-pi-2`                       |
 | [Raspberry Pi 3](raspberry-pi/3)                                                  | `<nixos-hardware/raspberry-pi/3>`                       | `raspberry-pi-3`                       |

--- a/flake.nix
+++ b/flake.nix
@@ -414,6 +414,7 @@
           raspberry-pi-4 = import ./raspberry-pi/4;
           raspberry-pi-5 = import ./raspberry-pi/5;
           radxa-rock-3c = import ./radxa/rock-3c;
+          radxa-x4 = import ./radxa/x4;
           rock-4c-plus = import ./radxa/rock-4c-plus;
           rock-5b = import ./radxa/rock-5b;
           rock-pi-4 = import ./radxa/rock-pi-4;

--- a/radxa/x4/README.md
+++ b/radxa/x4/README.md
@@ -1,0 +1,39 @@
+# Radxa X4
+
+The [Radxa X4](https://radxa.com/products/x/x4/) is a credit-card-sized x86
+SBC based on the Intel N100 (Alder Lake-N), with an Intel I226-V 2.5 GbE NIC,
+a Realtek RTL8852BE WiFi 6 / Bluetooth 5.2 module, an M.2 2230 slot for NVMe
+storage, optional onboard eMMC, and a Raspberry Pi RP2040 microcontroller
+wired to the GPIO header.
+
+The board boots mainline kernels via UEFI; no out-of-tree drivers are
+required. This profile does not choose a bootloader — both systemd-boot and
+GRUB (EFI) work.
+
+## Ethernet (Intel I226-V)
+
+The I226-V has a widely reported firmware/hardware bug where the link stalls
+or flaps (repeated `Link Down` / `Link is Up` cycles in dmesg) when the NIC
+enters PCIe ASPM low-power states or Energy-Efficient Ethernet idle. This
+profile applies the two standard mitigations:
+
+- `pcie_aspm=off` on the kernel command line
+- a udev rule that disables EEE on `igc` interfaces via ethtool
+
+If you need ASPM for the rest of the system, override `boot.kernelParams`
+and disable ASPM for the NIC's root port only (e.g. via `setpci`).
+
+References:
+
+- https://bugzilla.kernel.org/show_bug.cgi?id=216045
+- https://lore.kernel.org/intel-wired-lan/
+
+## Known issues
+
+- **ACPI errors at boot** (`\_SB.PC00.TXHC.RHUB...` / `\_SB.UBTC.RUCC`
+  `AE_NOT_FOUND`): bugs in the stock BIOS tables; harmless.
+- **`intel_ish_ipc ... Timed out waiting for FW-initiated reset`**: the
+  Integrated Sensor Hub has no firmware on this board. Harmless; silence it
+  with `boot.blacklistedKernelModules = [ "intel_ish_ipc" ];` if desired.
+- The RP2040 enumerates on USB and is flashed with `picotool`; nothing
+  NixOS-specific is required.

--- a/radxa/x4/default.nix
+++ b/radxa/x4/default.nix
@@ -1,0 +1,23 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../common/cpu/intel/alder-lake
+    ../../common/pc
+    ../../common/pc/ssd
+  ];
+
+  # i915 GuC/DMC blobs and the Realtek RTL8852BE (rtw89) WiFi firmware
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+  # The onboard Intel I226-V (igc) is widely reported to stall or flap
+  # (repeated Link Down/Up cycles) when the link enters PCIe ASPM low-power
+  # states. See README.md for details and references.
+  boot.kernelParams = [ "pcie_aspm=off" ];
+
+  # The other half of the same issue: disable Energy-Efficient Ethernet.
+  # Matching on the driver keeps the rule independent of the interface name.
+  services.udev.extraRules = ''
+    ACTION=="add", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="igc", RUN+="${pkgs.ethtool}/bin/ethtool --set-eee %k eee off"
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Add a profile for the [Radxa X4](https://radxa.com/products/x/x4/), an x86 SBC based on the Intel N100 (Alder Lake-N) with an Intel I226-V 2.5 GbE NIC and a Realtek RTL8852BE WiFi module.

The profile composes `common/cpu/intel/alder-lake` + `common/pc` + `common/pc/ssd`, enables redistributable firmware (rtw89 + i915 GuC/DMC blobs), and carries the two standard mitigations for the widely reported I226-V link-flapping bug: `pcie_aspm=off` and a udev rule that disables Energy-Efficient Ethernet on `igc` interfaces (keyed on the driver, so it is independent of interface naming). The README documents the NIC issue with references plus the board's harmless ACPI/ISH boot noise.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tested on a Radxa X4 8 GB (N100, NVMe boot, NixOS 26.05, kernel 6.18) running as a k3s node: profile imported as a flake input from this fork, activated via `switch-to-configuration`, EEE-disable rule and ASPM behavior verified against the running NIC with ethtool.

**AI Transparency**
LLMs were used in the development of this PR