### PR TITLE
raspberry-pi: update kernel and wireless firmware

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -10,8 +10,8 @@
 
 let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.12.75";
-  hash = "sha256-qrljd20n4tj/7C7gzNnxw7JIyEF2Ppf1PWm2a7vxh1w=";
+  modDirVersion = "6.18.33";
+  hash = "sha256-XGL2SgPws+c1yAZDmNC9jQdi23qQPZKucQUr9+eD8MM=";
   inherit (lib.kernel) freeform yes no;
 in
 (buildLinux (
@@ -24,8 +24,8 @@ in
     src = fetchFromGitHub {
       owner = "raspberrypi";
       repo = "linux";
-      # https://github.com/RPi-Distro/linux-packaging/raw/refs/tags/pios/1%256.12.75-1+rpt1/debian/changelog
-      rev = "89050b1059997d38d55462b323b099a6436dc10d";
+      # https://github.com/RPi-Distro/linux-packaging/raw/refs/tags/pios/1%256.18.33-1+rpt1/debian/changelog
+      rev = "95b85bebbedcaedfa7ca79116ed38b7376fba412";
       inherit hash;
     };
 
@@ -52,7 +52,7 @@ in
     ];
 
     # Override nixpkgs common-config.nix defaults that conflict with the RPi vendor defconfigs.
-    # See: https://github.com/raspberrypi/linux/tree/rpi-6.12.y/arch/arm64/configs
+    # See: https://github.com/raspberrypi/linux/tree/rpi-6.18.y/arch/arm64/configs
     structuredExtraConfig = {
       # RPi has 4 cores; nixpkgs common-config sets 384
       NR_CPUS = lib.mkForce (freeform "4");
@@ -110,7 +110,7 @@ in
         dtbDir=${if stdenv.hostPlatform.isAarch64 then "$out/dtbs/broadcom" else "$out/dtbs"}
         rm $dtbDir/bcm283*.dtb
         copyDTB() {
-          cp -v "$dtbDir/$1" "$dtbDir/$2"
+          cp "$dtbDir/$1" "$dtbDir/$2"
         }
       ''
       + lib.optionalString (rpiVersion == 1) ''

--- a/raspberry-pi/common/raspberry-pi-wireless-firmware.nix
+++ b/raspberry-pi/common/raspberry-pi-wireless-firmware.nix
@@ -6,22 +6,22 @@
 
 stdenvNoCC.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "0-unstable-2025-04-08";
+  version = "0-unstable-2026-03-21";
 
   srcs = [
     (fetchFromGitHub {
       name = "bluez-firmware";
       owner = "RPi-Distro";
       repo = "bluez-firmware";
-      rev = "2bbfb8438e824f5f61dae3f6ebb367a6129a4d63";
-      hash = "sha256-t+D4VUfEIov83KV4wiKp6TqXTHXGkxg/mANi4GW7QHs=";
+      rev = "cdf61dc691a49ff01a124752bd04194907f0f9cd";
+      hash = "sha256-35pnbQV/zcikz9Vic+2a1QAS72riruKklV8JHboL9NY=";
     })
     (fetchFromGitHub {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "c9d3ae6584ab79d19a4f94ccf701e888f9f87a53";
-      hash = "sha256-5ywIPs3lpmqVOVP3B75H577fYkkucDqB7htY2U1DW8U=";
+      rev = "9794282eb9f4a2de1f23b41a738926740e975d83";
+      hash = "sha256-OtA8yHvfusGP/ucf8Exzi+nSUmNoYp10u+luC2gbNZc=";
     })
   ];
 
@@ -36,19 +36,16 @@ stdenvNoCC.mkDerivation {
     mkdir -p "$out/lib/firmware/brcm"
 
     # Wifi firmware
-    cp -rv "$NIX_BUILD_TOP/firmware-nonfree/debian/config/brcm80211/." "$out/lib/firmware/"
+    cp -r "firmware-nonfree/debian/config/brcm80211/." "$out/lib/firmware/"
 
     # Bluetooth firmware
-    cp -rv "$NIX_BUILD_TOP/bluez-firmware/debian/firmware/broadcom/." "$out/lib/firmware/brcm"
+    cp -r "bluez-firmware/debian/firmware/broadcom/." "$out/lib/firmware/brcm"
 
-    # brcmfmac43455-sdio.bin is a symlink to the non-existent path: ../cypress/cyfmac43455-sdio.bin.
+    # The brcmfmac43455-sdio.raspberrypi,*.bin board firmwares (Pi 3A+/3B+/CM4/4B/500/CM5/5B)
+    # symlink to ../cypress/cyfmac43455-sdio.bin, which RPi-Distro ships only as the
+    # cyfmac43455-sdio-standard.bin variant. Create the missing target so they resolve.
     # See https://github.com/RPi-Distro/firmware-nonfree/issues/26
     ln -s "./cyfmac43455-sdio-standard.bin" "$out/lib/firmware/cypress/cyfmac43455-sdio.bin"
-
-    pushd $out/lib/firmware/brcm &>/dev/null
-    # Symlinks for Zero 2W
-    ln -s "./brcmfmac43436-sdio.clm_blob" "$out/lib/firmware/brcm/brcmfmac43430b0-sdio.clm_blob"
-    popd &>/dev/null
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

Version updates:

- linux-rpi: 6.12.75-1+rpt1 -> 6.18.33-1+rpt1
- firmware-nonfree: 1:20240709-2~bpo12+1+rpt3 -> 1:20250410-2+rpt1
- bluez-firmware: 1.2-9+rpt3 -> 1.2-13+rpt2

Also drop the redundant Zero 2W clm_blob symlink (upstream now ships the board specific file)

Closes #1887

###### Things done

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

