### PR TITLE
Adds NixOS hardware support for the Avnet MaaXBoard 8ULP platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ See code for all available configurations.
 | [MECHREVO Yilong15Pro](mechrevo/GM5HG0A)                                          | `<nixos-hardware/mechrevo/GM5HG0A>`                     | `mechrevo-gm5hg0a`                     |
 | [NXP iMX8 MPlus Evaluation Kit](nxp/imx8mp-evk)                                   | `<nixos-hardware/nxp/imx8mp-evk>`                       | `nxp-imx8mp-evk`                       |
 | [NXP iMX8 MQuad Evaluation Kit](nxp/imx8mq-evk)                                   | `<nixos-hardware/nxp/imx8mq-evk>`                       | `nxp-imx8mq-evk`                       |
+| [Avnet MaaXBoard 8ULP](nxp/maaxboard-8ulp)                                        | `<nixos-hardware/nxp/maaxboard-8ulp>`                   | `nxp-maaxboard-8ulp`                   |
 | [Hardkernel Odroid HC4](hardkernel/odroid-hc4/default.nix)                        | `<nixos-hardware/hardkernel/odroid-hc4>`                | `hardkernel-odroid-hc4`                |
 | [Hardkernel Odroid H3](hardkernel/odroid-h3/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h3>`                 | `hardkernel-odroid-h3`                 |
 | [Hardkernel Odroid H4](hardkernel/odroid-h4/default.nix)                          | `<nixos-hardware/hardkernel/odroid-h4>`                 | `hardkernel-odroid-h4`                 |

--- a/flake.nix
+++ b/flake.nix
@@ -387,6 +387,7 @@
           nxp-imx8mq-evk = import ./nxp/imx8mq-evk;
           nxp-imx8qm-mek = import ./nxp/imx8qm-mek;
           nxp-imx93-evk = import ./nxp/imx93-evk;
+          nxp-maaxboard-8ulp = import ./nxp/maaxboard-8ulp;
           ucm-imx95 = import ./compulab/ucm-imx95;
           hardkernel-odroid-hc4 = import ./hardkernel/odroid-hc4;
           hardkernel-odroid-h3 = import ./hardkernel/odroid-h3;
@@ -505,6 +506,8 @@
           # Boot images for NXP i.MX boards (aarch64-linux only)
           ucm-imx95-boot = (pkgs.callPackage ./compulab/ucm-imx95/bsp/ucm-imx95-boot.nix { }).imx95-boot;
           imx93-boot = (pkgs.callPackage ./nxp/imx93-evk/bsp/imx93-boot.nix { }).imx93-boot;
+          maaxboard-8ulp-boot =
+            (pkgs.callPackage ./nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix { }).maaxboard-8ulp-boot;
           imx8mp-boot = (pkgs.callPackage ./nxp/imx8mp-evk/bsp/imx8mp-boot.nix { }).imx8m-boot;
           imx8mq-boot = (pkgs.callPackage ./nxp/imx8mq-evk/bsp/imx8mq-boot.nix { }).imx8m-boot;
           purism-librem-5r4-uboot = pkgs.callPackage ./purism/librem/5r4/u-boot { };

--- a/nxp/README.md
+++ b/nxp/README.md
@@ -3,6 +3,7 @@
 ## 1. Supported devices
  - [i.MX8QuadMax Multisensory Enablement Kit](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadmax-multisensory-enablement-kit-mek:MCIMX8QM-CPU) (**imx8qm-mek**) - device-specific U-boot and Linux kernel, nixos configuration example.
  - [i.MX8QuadXPlus Multisensory Enablement Kit](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-8quadxplus-multisensory-enablement-kit-mek:MCIMX8QXP-CPU) (**imx8qxp-mek**) - device-specific U-Boot and Linux kernel.
+ - [Avnet MaaXBoard 8ULP](https://www.avnet.com/w/development/avnet-boards-and-kits/maaxboard-8ulp/) (**maaxboard-8ulp**) - Avnet BSP (`linux-imx`, `uboot-imx`, `imx-mkimage`) for A2 silicon; device-specific U-Boot, Linux kernel, and `flash.bin`.
 
 ## 2. How to use
 
@@ -38,7 +39,26 @@ Code snippet example that enables 'imx8mp-evk/imx8mq-evk/imx93-evk' configuratio
 }
 ```
 
-### 2.3 Building Boot Images
+### 2.3 For maaxboard-8ulp
+
+BSP sources track [Avnet maaxboard-build-tools](https://github.com/Avnet/maaxboard-build-tools) branch `maaxboard_lf-6.1.22-2.0.0` (i.MX8ULP A2: AHAB, upower, M33, `REV=A2 flash_singleboot_m33`).
+
+U-Boot boots from a VFAT `/boot` partition (`Image`, `initrd`, DTB, `uEnv.txt`).
+
+Code snippet example that enables `maaxboard-8ulp` configuration:
+
+```
+{ nixos-hardware, }: {
+  system = "aarch64-linux";
+  modules = [
+    nixos-hardware.nixosModules.nxp-maaxboard-8ulp
+  ];
+}
+```
+
+Serial console: `ttyLP1` @ 115200.
+
+### 2.4 Building Boot Images
 
 Boot images for flashing to SD cards can be built directly from the flake:
 
@@ -52,17 +72,23 @@ nix build github:NixOS/nixos-hardware#packages.aarch64-linux.imx8mq-boot
 # Build boot image for i.MX93 EVK
 nix build github:NixOS/nixos-hardware#packages.aarch64-linux.imx93-boot
 
+# Build boot image for Avnet MaaXBoard 8ULP
+nix build github:NixOS/nixos-hardware#packages.aarch64-linux.maaxboard-8ulp-boot
+
 # Or from a local checkout
 nix build .#packages.aarch64-linux.imx8mp-boot
+nix build .#packages.aarch64-linux.maaxboard-8ulp-boot
 ```
 
 The boot image will be available at `./result/image/flash.bin`.
 
 **Note:** These packages target `aarch64-linux`. If you're on a different architecture (e.g., x86_64-linux), you'll need remote builders configured for aarch64-linux.
 
-### 2.4 Flashing to SD Card
+### 2.5 Flashing
 
-Once built, you can flash the boot image to an SD card:
+#### i.MX8MP / i.MX8MQ / i.MX93 (SD card)
+
+Once built, flash the boot image to an SD card:
 
 ```bash
 # For i.MX8MP and i.MX93 (32KB offset):
@@ -73,6 +99,26 @@ sudo dd if=./result/image/flash.bin of=/dev/sdX bs=1k seek=33 conv=fsync
 ```
 
 **Note:** Different i.MX processors require different offsets. i.MX8MP and i.MX93 use 32KB (seek=32), while i.MX8MQ uses 33KB (seek=33).
+
+#### MaaXBoard 8ULP
+
+```bash
+nix build .#packages.aarch64-linux.maaxboard-8ulp-boot
+```
+
+**SD card** (sector 66, Avnet/Yocto layout):
+
+```bash
+sudo dd if=./result/image/flash.bin of=/dev/sdX bs=512 seek=66 conv=fsync
+```
+
+**eMMC** (serial-download mode; `uuu` from nixpkgs `nxpmicro-mfgtools`):
+
+```bash
+sudo uuu -v -b spl ./result/image/flash.bin
+```
+
+**Note:** MaaXBoard 8ULP uses sector 66 at 512 bytes/sector (`33 KiB`), not the 32KB offset used by i.MX8MP/i.MX93.
 
 **Warning:** Double-check the device path to avoid overwriting the wrong disk!
 
@@ -86,4 +132,6 @@ sudo dd if=./result/image/flash.bin of=/dev/sdX bs=1k seek=33 conv=fsync
 
 ### Additional Resources
 - [NXP i.MX 8M Series TF-A Documentation](https://trustedfirmware-a.readthedocs.io/en/latest/plat/imx8m.html)
+- [Avnet maaxboard-build-tools](https://github.com/Avnet/maaxboard-build-tools)
+- [Avnet MaaXBoard 8ULP Linux user manual](https://www.avnet.com/w/development/avnet-boards-and-kits/maaxboard-8ulp/)
 

--- a/nxp/common/bsp/imx-uboot-builder.nix
+++ b/nxp/common/bsp/imx-uboot-builder.nix
@@ -26,6 +26,9 @@
   # Optional parameters
   extraConfig ? "",
   extraNativeBuildInputs ? [ ],
+  useImxCommonConfig ? true,
+  # i.MX8ULP uses CONFIG_ARM=y; maaxboard-build-tools passes ARCH=arm with aarch64 CROSS_COMPILE.
+  ubootArch ? null,
 }:
 let
   # Import common U-Boot configuration
@@ -37,7 +40,7 @@ let
   };
 
   # Combine common config with any platform-specific extra config
-  finalExtraConfig = commonConfig + extraConfig;
+  finalExtraConfig = (if useImxCommonConfig then commonConfig else "") + extraConfig;
 in
 stdenv.mkDerivation {
   inherit pname version src;
@@ -67,7 +70,8 @@ stdenv.mkDerivation {
   makeFlags = [
     "DTC=${lib.getExe buildPackages.dtc}"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-  ];
+  ]
+  ++ lib.optional (ubootArch != null) "ARCH=${ubootArch}";
 
   extraConfig = finalExtraConfig;
 
@@ -76,7 +80,7 @@ stdenv.mkDerivation {
   configurePhase = ''
     runHook preConfigure
 
-    make ${defconfig}
+    make ${lib.optionalString (ubootArch != null) "ARCH=${ubootArch} "}${defconfig}
     cat $extraConfigPath >> .config
 
     runHook postConfigure
@@ -86,8 +90,10 @@ stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out
+    cp ./u-boot.bin $out
     cp ./u-boot-nodtb.bin $out
     cp ./spl/u-boot-spl.bin $out
+    cp ./tools/mkimage $out/mkimage_uboot
     cp ${dtbPath} $out
     cp .config  $out
 

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-atf.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-atf.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchgit,
+  stdenv,
+  buildPackages,
+  pkgsCross,
+  openssl,
+}:
+
+let
+  target-board = "imx8ulp";
+in
+stdenv.mkDerivation rec {
+  pname = "maaxboard-8ulp-atf";
+  version = "2.8";
+  platform = target-board;
+  enableParallelBuilding = true;
+
+  src = fetchgit {
+    url = "https://github.com/Avnet/imx-atf.git";
+    rev = "f79eb120d7b08ee02b935b47e934b9ce232cb603";
+    sha256 = "sha256-r7c42GaOU+NHN24681KeS07py+QyIFAG/6tE9syYemA=";
+  };
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ pkgsCross.aarch64-embedded.stdenv.cc ];
+
+  buildInputs = [ openssl ];
+
+  makeFlags = [
+    "HOSTCC=$(CC_FOR_BUILD)"
+    "CROSS_COMPILE=${pkgsCross.aarch64-embedded.stdenv.cc.targetPrefix}"
+    "PLAT=${platform}"
+    "bl31"
+    "LDFLAGS=-no-warn-rwx-segments"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp build/${target-board}/release/bl31.bin $out
+    runHook postInstall
+  '';
+
+  hardeningDisable = [ "all" ];
+  dontStrip = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/Avnet/imx-atf";
+    description = "ARM Trusted Firmware for Avnet MaaXBoard 8ULP (i.MX8ULP)";
+    license = [ licenses.bsd3 ];
+    maintainers = with maintainers; [ govindsi ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-atf.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-atf.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-r7c42GaOU+NHN24681KeS07py+QyIFAG/6tE9syYemA=";
   };
 
+  # maaxboard-build-tools: PLAT=imx8ulp bl31
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkgsCross.aarch64-embedded.stdenv.cc ];
 

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix
@@ -44,7 +44,7 @@ in
       make bin
       make SOC=iMX8ULP mkimage_imx8
 
-      # Match Avnet maaxboard-build-tools imx-mkimage staging (REV=A2 silicon).
+      # Avnet maaxboard-build-tools imx-mkimage staging (REV=A2 silicon).
       install -m 0644 ${maaxboard-8ulp-uboot}/u-boot.bin ./iMX8ULP/u-boot.bin
       install -m 0644 ${maaxboard-8ulp-uboot}/u-boot-nodtb.bin ./iMX8ULP/u-boot-nodtb.bin
       install -m 0644 ${maaxboard-8ulp-uboot}/u-boot-spl.bin ./iMX8ULP/u-boot-spl.bin

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix
@@ -1,0 +1,68 @@
+{
+  pkgs,
+}:
+with pkgs;
+let
+  maaxboard-8ulp-atf = pkgs.callPackage ./maaxboard-8ulp-atf.nix { };
+  maaxboard-8ulp-firmware = pkgs.callPackage ./maaxboard-8ulp-firmware.nix { };
+  maaxboard-8ulp-uboot = pkgs.callPackage ./maaxboard-8ulp-uboot.nix { };
+  src = pkgs.fetchgit {
+    url = "https://github.com/Avnet/imx-mkimage.git";
+    rev = "5cfd218012e080fb907d9cc301fbb4ece9bc17a9";
+    sha256 = "sha256-u6+pGk0Uw/foRmVqSep/Q3mRywxctlmzoOpNxBNJBo8=";
+  };
+  shortRev = builtins.substring 0 8 src.rev;
+in
+{
+  maaxboard-8ulp-boot = pkgs.stdenv.mkDerivation rec {
+    inherit src;
+    name = "maaxboard-8ulp-mkimage";
+    version = "lf-6.1.22-2.0.0";
+
+    postPatch = ''
+      substituteInPlace Makefile \
+          --replace 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
+      substituteInPlace Makefile \
+          --replace 'CC = gcc' 'CC = clang'
+      patchShebangs scripts
+    '';
+
+    nativeBuildInputs = [
+      clang
+      git
+      dtc
+    ];
+
+    buildInputs = [
+      git
+      glibc.static
+      zlib
+      zlib.static
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      make bin
+      make SOC=iMX8ULP mkimage_imx8
+
+      install -m 0644 ${maaxboard-8ulp-uboot}/u-boot-spl.bin ./iMX8ULP/u-boot-spl.bin
+      cat ${maaxboard-8ulp-uboot}/u-boot-nodtb.bin ${maaxboard-8ulp-uboot}/maaxboard-8ulp.dtb > ./iMX8ULP/u-boot.bin
+      install -m 0644 ${maaxboard-8ulp-atf}/bl31.bin ./iMX8ULP/bl31.bin
+      install -m 0644 ${maaxboard-8ulp-firmware}/mx8ulpa0-ahab-container.img ./iMX8ULP/mx8ulpa0-ahab-container.img
+      install -m 0644 ${maaxboard-8ulp-firmware}/upower.bin ./iMX8ULP/upower.bin
+      install -m 0644 ${maaxboard-8ulp-firmware}/m33_image.bin ./iMX8ULP/m33_image.bin
+
+      make SOC=iMX8ULP REV=A0 flash_singleboot_m33
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/image
+      install -m 0644 ./iMX8ULP/flash.bin $out/image
+      runHook postInstall
+    '';
+  };
+}

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-boot.nix
@@ -22,13 +22,11 @@ in
     postPatch = ''
       substituteInPlace Makefile \
           --replace 'git rev-parse --short=8 HEAD' 'echo ${shortRev}'
-      substituteInPlace Makefile \
-          --replace 'CC = gcc' 'CC = clang'
       patchShebangs scripts
     '';
 
     nativeBuildInputs = [
-      clang
+      stdenv.cc
       git
       dtc
     ];
@@ -46,14 +44,18 @@ in
       make bin
       make SOC=iMX8ULP mkimage_imx8
 
+      # Match Avnet maaxboard-build-tools imx-mkimage staging (REV=A2 silicon).
+      install -m 0644 ${maaxboard-8ulp-uboot}/u-boot.bin ./iMX8ULP/u-boot.bin
+      install -m 0644 ${maaxboard-8ulp-uboot}/u-boot-nodtb.bin ./iMX8ULP/u-boot-nodtb.bin
       install -m 0644 ${maaxboard-8ulp-uboot}/u-boot-spl.bin ./iMX8ULP/u-boot-spl.bin
-      cat ${maaxboard-8ulp-uboot}/u-boot-nodtb.bin ${maaxboard-8ulp-uboot}/maaxboard-8ulp.dtb > ./iMX8ULP/u-boot.bin
+      install -m 0644 ${maaxboard-8ulp-uboot}/maaxboard-8ulp.dtb ./iMX8ULP/imx8ulp-evk.dtb
+      install -m 0755 ${maaxboard-8ulp-uboot}/mkimage_uboot ./iMX8ULP/mkimage_uboot
       install -m 0644 ${maaxboard-8ulp-atf}/bl31.bin ./iMX8ULP/bl31.bin
-      install -m 0644 ${maaxboard-8ulp-firmware}/mx8ulpa0-ahab-container.img ./iMX8ULP/mx8ulpa0-ahab-container.img
+      install -m 0644 ${maaxboard-8ulp-firmware}/mx8ulpa2-ahab-container.img ./iMX8ULP/mx8ulpa2-ahab-container.img
       install -m 0644 ${maaxboard-8ulp-firmware}/upower.bin ./iMX8ULP/upower.bin
       install -m 0644 ${maaxboard-8ulp-firmware}/m33_image.bin ./iMX8ULP/m33_image.bin
 
-      make SOC=iMX8ULP REV=A0 flash_singleboot_m33
+      make SOC=iMX8ULP REV=A2 flash_singleboot_m33
 
       runHook postBuild
     '';

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-firmware.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-firmware.nix
@@ -1,0 +1,56 @@
+{ pkgs, fetchgit }:
+
+with pkgs;
+let
+  # https://github.com/Avnet/meta-maaxboard/tree/langdale/recipes-bsp/imx-mkimage/imx-boot
+  metaMaaxboard = fetchgit {
+    url = "https://github.com/Avnet/meta-maaxboard.git";
+    rev = "cab913d1d7afbae060b0c7bf5d92831c441939a6";
+    sha256 = "sha256-Htxa7xcaNTBJIlZSps46BYNMvj4G/0uUvKcQD3/z8T0=";
+    sparseCheckout = [ "recipes-bsp/imx-mkimage/imx-boot" ];
+  };
+
+  imxBoot = "${metaMaaxboard}/recipes-bsp/imx-mkimage/imx-boot";
+
+  upowerInstaller = fetchurl {
+    url = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-upower-1.3.1.bin";
+    sha256 = "sha256-HfOgPWn+s4pFDuY6vHcT14z2M5mIR25Mn5Xrv2N5D2Y=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "maaxboard-8ulp-firmware";
+  version = "meta-maaxboard-langdale";
+
+  nativeBuildInputs = [
+    coreutils
+    bash
+  ];
+
+  dontUnpack = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+
+    cp ${imxBoot}/mx8ulpa0-ahab-container.img $out/
+    cp ${imxBoot}/maaxboard_8ulp_m33_image.bin $out/m33_image.bin
+
+    cp ${upowerInstaller} ./firmware-upower-1.3.1.bin
+    chmod +x firmware-upower-1.3.1.bin
+    ./firmware-upower-1.3.1.bin --auto-accept
+
+    if [ -f firmware-upower-1.3.1/upower_a0.bin ]; then
+      cp firmware-upower-1.3.1/upower_a0.bin $out/upower.bin
+    elif [ -f firmware-upower-1.3.1/upower_a1.bin ]; then
+      cp firmware-upower-1.3.1/upower_a1.bin $out/upower.bin
+    else
+      echo "No upower firmware found in installer" >&2
+      exit 1
+    fi
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Avnet/meta-maaxboard/tree/langdale/recipes-bsp/imx-mkimage/imx-boot";
+    description = "MaaXBoard 8ULP boot firmware (Avnet meta-maaxboard imx-boot + meta-imx firmware-upower)";
+  };
+}

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-firmware.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-firmware.nix
@@ -1,25 +1,23 @@
-{ pkgs, fetchgit }:
+{ pkgs }:
 
 with pkgs;
 let
-  # https://github.com/Avnet/meta-maaxboard/tree/langdale/recipes-bsp/imx-mkimage/imx-boot
-  metaMaaxboard = fetchgit {
-    url = "https://github.com/Avnet/meta-maaxboard.git";
-    rev = "cab913d1d7afbae060b0c7bf5d92831c441939a6";
-    sha256 = "sha256-Htxa7xcaNTBJIlZSps46BYNMvj4G/0uUvKcQD3/z8T0=";
-    sparseCheckout = [ "recipes-bsp/imx-mkimage/imx-boot" ];
+  maaxboard-8ulp-m33 = callPackage ./maaxboard-8ulp-m33.nix { };
+
+  # maaxboard-build-tools export_fmver() for BSP lf-6.1.22-2.0.0 (6.1.22).
+  sentinelInstaller = fetchurl {
+    url = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-sentinel-0.10.bin";
+    sha256 = "sha256-voYrYshJUQzOCOwkwd31PYJkWOMm5afwnEs1CS1vmVA=";
   };
 
-  imxBoot = "${metaMaaxboard}/recipes-bsp/imx-mkimage/imx-boot";
-
   upowerInstaller = fetchurl {
-    url = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-upower-1.3.1.bin";
-    sha256 = "sha256-HfOgPWn+s4pFDuY6vHcT14z2M5mIR25Mn5Xrv2N5D2Y=";
+    url = "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-upower-1.3.0.bin";
+    sha256 = "sha256-9ScVEiRfuhlTb9CW7FR+TntVjlCfaZQQD9cBpi4zWI8=";
   };
 in
 stdenv.mkDerivation {
   pname = "maaxboard-8ulp-firmware";
-  version = "meta-maaxboard-langdale";
+  version = "lf-6.1.22-2.0.0";
 
   nativeBuildInputs = [
     coreutils
@@ -32,17 +30,22 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out
 
-    cp ${imxBoot}/mx8ulpa0-ahab-container.img $out/
-    cp ${imxBoot}/maaxboard_8ulp_m33_image.bin $out/m33_image.bin
+    cp ${maaxboard-8ulp-m33}/m33_image.bin $out/m33_image.bin
 
-    cp ${upowerInstaller} ./firmware-upower-1.3.1.bin
-    chmod +x firmware-upower-1.3.1.bin
-    ./firmware-upower-1.3.1.bin --auto-accept
+    cp ${sentinelInstaller} ./firmware-sentinel-0.10.bin
+    chmod +x firmware-sentinel-0.10.bin
+    ./firmware-sentinel-0.10.bin --auto-accept
+    cp firmware-sentinel-0.10/mx8ulpa2-ahab-container.img $out/
 
-    if [ -f firmware-upower-1.3.1/upower_a0.bin ]; then
-      cp firmware-upower-1.3.1/upower_a0.bin $out/upower.bin
-    elif [ -f firmware-upower-1.3.1/upower_a1.bin ]; then
-      cp firmware-upower-1.3.1/upower_a1.bin $out/upower.bin
+    cp ${upowerInstaller} ./firmware-upower-1.3.0.bin
+    chmod +x firmware-upower-1.3.0.bin
+    ./firmware-upower-1.3.0.bin --auto-accept
+
+    # A2 silicon uses upower_a1 (maaxboard-build-tools bootloader/build.sh, REV=A2).
+    if [ -f firmware-upower-1.3.0/upower_a1.bin ]; then
+      cp firmware-upower-1.3.0/upower_a1.bin $out/upower.bin
+    elif [ -f firmware-upower-1.3.0/upower_a0.bin ]; then
+      cp firmware-upower-1.3.0/upower_a0.bin $out/upower.bin
     else
       echo "No upower firmware found in installer" >&2
       exit 1
@@ -50,7 +53,9 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/Avnet/meta-maaxboard/tree/langdale/recipes-bsp/imx-mkimage/imx-boot";
-    description = "MaaXBoard 8ULP boot firmware (Avnet meta-maaxboard imx-boot + meta-imx firmware-upower)";
+    homepage = "https://github.com/Avnet/maaxboard-build-tools";
+    description = "MaaXBoard 8ULP boot firmware (sentinel A2 AHAB + upower + M33 from mcore_sdk_8ulp)";
+    maintainers = with maintainers; [ govindsi ];
+    platforms = [ "aarch64-linux" ];
   };
 }

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-linux.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-linux.nix
@@ -4,6 +4,10 @@ let
     pname = "maaxboard-8ulp-linux";
     version = "6.1.22";
 
+    # maaxboard-build-tools kernel/build.sh: make ${BOARD}_defconfig with board=maaxboard-8ulp
+    defconfig = "maaxboard-8ulp_defconfig";
+
+    # Avnet/linux-imx @ maaxboard_lf-6.1.22-2.0.0
     src = pkgs.fetchFromGitHub {
       owner = "Avnet";
       repo = "linux-imx";

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-linux.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-linux.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }@args:
+let
+  base = (pkgs.callPackage ../../common/bsp/imx-linux-builder.nix args) {
+    pname = "maaxboard-8ulp-linux";
+    version = "6.1.22";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "Avnet";
+      repo = "linux-imx";
+      rev = "78ce688d5a792c053827e1edd4a347807c63c06c";
+      sha256 = "sha256-Glm4Rcm+G8mEBF9ELQiD6IjwWAlCN12EoOttJIWwzBY=";
+    };
+
+    extraConfig = "";
+
+    ignoreConfigErrors = true;
+
+    extraMeta = {
+      maintainers = with pkgs.lib.maintainers; [ govindsi ];
+    };
+  };
+in
+base.overrideAttrs (prev: {
+  # Avnet linux-imx 6.1.22 Vivante driver vs GCC 15 -Werror=enum-int-mismatch
+  NIX_CFLAGS_COMPILE = (prev.NIX_CFLAGS_COMPILE or "") + " -Wno-error=enum-int-mismatch";
+})

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-linux.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-linux.nix
@@ -11,7 +11,10 @@ let
       sha256 = "sha256-Glm4Rcm+G8mEBF9ELQiD6IjwWAlCN12EoOttJIWwzBY=";
     };
 
-    extraConfig = "";
+    extraConfig = ''
+      # Avnet linux-imx 6.1.22: DEVICE_THERMAL duplicates devfreq_cooling symbols
+      DEVICE_THERMAL n
+    '';
 
     ignoreConfigErrors = true;
 
@@ -21,6 +24,9 @@ let
   };
 in
 base.overrideAttrs (prev: {
-  # Avnet linux-imx 6.1.22 Vivante driver vs GCC 15 -Werror=enum-int-mismatch
-  NIX_CFLAGS_COMPILE = (prev.NIX_CFLAGS_COMPILE or "") + " -Wno-error=enum-int-mismatch";
+  # Avnet linux-imx 6.1.22 Vivante driver vs GCC 15 -Werror=enum-int-mismatch.
+  # NIX_CFLAGS_COMPILE is ignored by Kbuild; pass via KCFLAGS in makeFlags.
+  makeFlags = prev.makeFlags ++ [
+    "KCFLAGS=-Wno-error=enum-int-mismatch -Wno-enum-int-mismatch"
+  ];
 })

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-m33.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-m33.nix
@@ -26,25 +26,25 @@ stdenv.mkDerivation rec {
 
   # boards/evkmimx8ulp/multicore_examples/rpmsg_lite_str_echo_rtos/armgcc/build_release.sh
   buildPhase = ''
-    runHook preBuild
+        runHook preBuild
 
-    cd boards/evkmimx8ulp/multicore_examples/rpmsg_lite_str_echo_rtos/armgcc
-    cat > ../version.h <<EOF
-#define SDK_VERSION "v2.14.0"
-#define GIT_VERSION "g${lib.substring 0 12 src.rev}"
-EOF
+        cd boards/evkmimx8ulp/multicore_examples/rpmsg_lite_str_echo_rtos/armgcc
+        cat > ../version.h <<EOF
+    #define SDK_VERSION "v2.14.0"
+    #define GIT_VERSION "g${lib.substring 0 12 src.rev}"
+    EOF
 
-    export ARMGCC_DIR=${gcc-arm-embedded}
-    cmake \
-      -DCMAKE_TOOLCHAIN_FILE="../../../../../tools/cmake_toolchain_files/armgcc.cmake" \
-      -G "Unix Makefiles" \
-      -DCMAKE_BUILD_TYPE=release \
-      .
-    make -j$NIX_BUILD_CORES
-    test -f release/rpmsg_lite_str_echo_rtos_imxcm33.elf
-    cp release/rpmsg_lite_str_echo_rtos_imxcm33.elf $NIX_BUILD_TOP/m33.elf
+        export ARMGCC_DIR=${gcc-arm-embedded}
+        cmake \
+          -DCMAKE_TOOLCHAIN_FILE="../../../../../tools/cmake_toolchain_files/armgcc.cmake" \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=release \
+          .
+        make -j$NIX_BUILD_CORES
+        test -f release/rpmsg_lite_str_echo_rtos_imxcm33.elf
+        cp release/rpmsg_lite_str_echo_rtos_imxcm33.elf $NIX_BUILD_TOP/m33.elf
 
-    runHook postBuild
+        runHook postBuild
   '';
 
   installPhase = ''

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-m33.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-m33.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  gcc-arm-embedded,
+  cmake,
+}:
+
+# Cortex-M33 firmware for i.MX8ULP boot (maaxboard-build-tools build_cortexM()).
+stdenv.mkDerivation rec {
+  pname = "maaxboard-8ulp-m33";
+  version = "lf-6.1.22-2.0.0";
+
+  src = fetchgit {
+    url = "https://github.com/Avnet/mcore_sdk_8ulp.git";
+    rev = "f6b1bcceab9e8510a06355c05dfe55c5f87bb9fd";
+    sha256 = "sha256-B2mdxwMxNUnow7iBdSq2AcpO12+8MqZ36DLme5GYkgk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gcc-arm-embedded
+  ];
+
+  dontConfigure = true;
+
+  # boards/evkmimx8ulp/multicore_examples/rpmsg_lite_str_echo_rtos/armgcc/build_release.sh
+  buildPhase = ''
+    runHook preBuild
+
+    cd boards/evkmimx8ulp/multicore_examples/rpmsg_lite_str_echo_rtos/armgcc
+    cat > ../version.h <<EOF
+#define SDK_VERSION "v2.14.0"
+#define GIT_VERSION "g${lib.substring 0 12 src.rev}"
+EOF
+
+    export ARMGCC_DIR=${gcc-arm-embedded}
+    cmake \
+      -DCMAKE_TOOLCHAIN_FILE="../../../../../tools/cmake_toolchain_files/armgcc.cmake" \
+      -G "Unix Makefiles" \
+      -DCMAKE_BUILD_TYPE=release \
+      .
+    make -j$NIX_BUILD_CORES
+    test -f release/rpmsg_lite_str_echo_rtos_imxcm33.elf
+    cp release/rpmsg_lite_str_echo_rtos_imxcm33.elf $NIX_BUILD_TOP/m33.elf
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    ${gcc-arm-embedded}/bin/arm-none-eabi-objcopy -Obinary \
+      $NIX_BUILD_TOP/m33.elf \
+      $out/m33_image.bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Avnet/mcore_sdk_8ulp";
+    description = "MaaXBoard 8ULP Cortex-M33 firmware (rpmsg_lite_str_echo_rtos)";
+    license = [ licenses.bsd3 ];
+    maintainers = with maintainers; [ govindsi ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-uboot.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-uboot.nix
@@ -3,14 +3,23 @@ pkgs.callPackage ../../common/bsp/imx-uboot-builder.nix {
   pname = "maaxboard-8ulp-uboot";
   version = "2022.04";
 
+  # Avnet/uboot-imx @ maaxboard_lf-6.1.22-2.0.0
   src = fetchgit {
     url = "https://github.com/Avnet/uboot-imx.git";
     rev = "2d5adab3314a240be9f23cff80841117849209fd";
     sha256 = "sha256-gLJWsmRN0wi5lAeehWO+Qur9GMjAY/jHRgKK7DydcKc=";
   };
 
+  # maaxboard-build-tools: make ${BOARD}_defconfig with board=maaxboard-8ulp
   defconfig = "maaxboard-8ulp_defconfig";
   ramdiskAddr = "0x85000000";
   fdtAddr = "0x84000000";
   dtbPath = "./arch/arm/dts/maaxboard-8ulp.dtb";
+
+  # Keep Avnet defconfig as-is (incl. fastboot + bsp_bootcmd). imxCommon adds EFI
+  # options that change u-boot.bin and break the imx-mkimage SPL handoff.
+  useImxCommonConfig = false;
+
+  # maaxboard-build-tools: make ARCH=arm maaxboard-8ulp_defconfig && make ARCH=arm
+  ubootArch = "arm";
 }

--- a/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-uboot.nix
+++ b/nxp/maaxboard-8ulp/bsp/maaxboard-8ulp-uboot.nix
@@ -1,0 +1,16 @@
+{ pkgs, fetchgit }:
+pkgs.callPackage ../../common/bsp/imx-uboot-builder.nix {
+  pname = "maaxboard-8ulp-uboot";
+  version = "2022.04";
+
+  src = fetchgit {
+    url = "https://github.com/Avnet/uboot-imx.git";
+    rev = "2d5adab3314a240be9f23cff80841117849209fd";
+    sha256 = "sha256-gLJWsmRN0wi5lAeehWO+Qur9GMjAY/jHRgKK7DydcKc=";
+  };
+
+  defconfig = "maaxboard-8ulp_defconfig";
+  ramdiskAddr = "0x85000000";
+  fdtAddr = "0x84000000";
+  dtbPath = "./arch/arm/dts/maaxboard-8ulp.dtb";
+}

--- a/nxp/maaxboard-8ulp/default.nix
+++ b/nxp/maaxboard-8ulp/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  nixpkgs.overlays = [
+    (import ./overlay.nix)
+  ];
+
+  imports = [
+    ./modules.nix
+  ];
+
+  boot.loader.grub.extraFiles = {
+    "maaxboard-8ulp.dtb" = "${
+      pkgs.callPackage ./bsp/maaxboard-8ulp-linux.nix { }
+    }/dtbs/freescale/maaxboard-8ulp.dtb";
+  };
+
+  hardware.deviceTree = {
+    filter = "maaxboard-*.dtb";
+    name = "maaxboard-8ulp.dtb";
+  };
+}

--- a/nxp/maaxboard-8ulp/modules.nix
+++ b/nxp/maaxboard-8ulp/modules.nix
@@ -1,0 +1,17 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  nixpkgs.hostPlatform.system = "aarch64-linux";
+
+  boot = {
+    kernelPackages = pkgs.linuxPackagesFor (pkgs.callPackage ./bsp/maaxboard-8ulp-linux.nix { });
+    initrd.includeDefaultModules = lib.mkForce false;
+  };
+
+  disabledModules = [ "profiles/all-hardware.nix" ];
+
+  hardware.deviceTree.enable = true;
+}

--- a/nxp/maaxboard-8ulp/overlay.nix
+++ b/nxp/maaxboard-8ulp/overlay.nix
@@ -1,0 +1,3 @@
+final: _prev: {
+  inherit (final.callPackage ./bsp/maaxboard-8ulp-boot.nix { pkgs = final; }) maaxboard-8ulp-boot;
+}

--- a/tests/nixos-tests.nix
+++ b/tests/nixos-tests.nix
@@ -26,6 +26,7 @@ let
     "nxp-imx8qm-mek"
     "nxp-imx93-evk"
     "ucm-imx95"
+    "maaxboard-8ulp"
   ];
 
   matchArch =


### PR DESCRIPTION
###### Description of changes
Adds NixOS hardware support for the **Avnet MaaXBoard 8ULP** (i.MX8ULP, A2 silicon).
### BSP packages
Aligned with [Avnet maaxboard-build-tools](https://github.com/Avnet/maaxboard-build-tools) branch `maaxboard_lf-6.1.22-2.0.0`:
- Linux (`linux-imx`), U-Boot (`uboot-imx`), ATF, Cortex-M33 firmware, and imx-mkimage `flash.bin`
- A2-specific firmware: AHAB container, upower, M33 image, `REV=A2 flash_singleboot_m33`
- U-Boot built with `ARCH=arm` and Avnet defconfig unchanged (`useImxCommonConfig = false`) so imx-mkimage produces a working boot image
### NixOS module
- `nixos-hardware.nixosModules.nxp-maaxboard-8ulp`
- Device tree, kernel, and BSP overlay
### Flake outputs
- `packages.aarch64-linux.maaxboard-8ulp-boot` → `flash.bin` (equivalent to Avnet’s `u-boot-maaxboard-8ulp.imx`)
### Documentation
- `nxp/README.md`: module usage, build commands, SD flashing at sector 66, and UUU `spl` for eMMC bootloader programming

###### Things done

- [x] Tested the changes in your own NixOS Configuration
<img width="701" height="517" alt="image" src="https://github.com/user-attachments/assets/bf9ac315-0eaf-4761-ad68-008cefce1202" />

- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

