### PR TITLE
lenovo/p14s: remove acpi.ec_no_wakeup=1 on gen 6 amd

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen6/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen6/default.nix
@@ -5,8 +5,4 @@
     ../.
     ../../../../../common/cpu/amd/pstate.nix
   ];
-
-  # Embedded controller wake-ups drain battery in s2idle on this device
-  # See https://lore.kernel.org/all/ZnFYpWHJ5Ml724Nv@ohnotp/
-  boot.kernelParams = [ "acpi.ec_no_wakeup=1" ];
 }


### PR DESCRIPTION
###### Description of changes

The referenced lore.kernel.org thread refers to a T14 Gen 5 and I am unable to reproduce the problem on my machine as measured by amd-s2idle:

    BIOS R2XET37W (1.17, 2025-11-07)   EC firmware 1.9

    config              duration   hw sleep   wake interrupt
    ec_no_wakeup=1      0:00:22    77.27%     ACPI SCI
    ec_no_wakeup=0      0:00:23    73.91%     ACPI SCI

The original report shows a difference of 60 percentage points.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Booted into kernels with ec_no_wakeup=0 and =1 and ran amd-s2idle on both
- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

