### PR TITLE
bee-link/eq14: add profile for Bee Link EQ14 (Intel N150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See code for all available configurations.
 | [Asus Zenbook Pro 17 UM6702](asus/zenbook/um6702/)                                | `<nixos-hardware/asus/zenbook/um6702>`                  | `asus-zenbook-um6702`                  |
 | [Asrock Rack ALTRAD8UD-1L2T](asrock-rack/altrad8ud-1l2t)                          | `<nixos-hardware/asrock-rack/altrad8ud-1l2t>`           | `asrock-rack-altrad8ud-1l2t`           |
 | [BeagleBoard PocketBeagle](beagleboard/pocketbeagle)                              | `<nixos-hardware/beagleboard/pocketbeagle>`             | `beagleboard-pocketbeagle`             |
+| [Bee Link EQ14](bee-link/eq14)                                                    | `<nixos-hardware/bee-link/eq14>`                        | `bee-link-eq14`                        |
 | [Chuwi MiniBook X](chuwi/minibook-x)                                              | `<nixos-hardware/chuwi/minibook-x>`                     | `chuwi-minibook-x`                     |
 | [Deciso DEC series](deciso/dec)                                                   | `<nixos-hardware/deciso/dec>`                           | `deciso-dec`                           |
 | [Dell G3 3779](dell/g3/3779)                                                      | `<nixos-hardware/dell/g3/3779>`                         | `dell-g3-3779`                         |

--- a/bee-link/eq14/default.nix
+++ b/bee-link/eq14/default.nix
@@ -1,0 +1,26 @@
+/*
+  `bee-link-eq14`:
+
+  Product page:
+  <https://www.bee-link.com/collections/mini-pc/products/beelink-eq14>
+
+  This profile configures the Intel
+  Twin Lake N150 CPU and integrated
+  graphics for this mini-PC. fstrim is also
+  enabled for the SSD. As is expected from
+  Intel NUC-like systems, it provides
+  a solid "out-of-the-box" experience. No
+  special quirks are apparent.
+
+  We import the Alder Lake modules since Twin
+  Lake is just a refreshed version of the
+  Alder Lake-N series. Re-using those seems
+  to be fine for this purpose.
+*/
+{
+  imports = [
+    ../../common/cpu/intel/alder-lake
+    ../../common/gpu/intel/alder-lake
+    ../../common/pc/ssd
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,7 @@
           asus-zephyrus-gu605cw = import ./asus/zephyrus/gu605cw;
           asus-zephyrus-gu605my = import ./asus/zephyrus/gu605my;
           beagleboard-pocketbeagle = import ./beagleboard/pocketbeagle;
+          bee-link-eq14 = import ./bee-link/eq14;
           chuwi-minibook-x = import ./chuwi/minibook-x;
           deciso-dec = import ./deciso/dec;
           dell-e7240 = deprecated "1326" "dell-e7240" (import ./dell/e7240);


### PR DESCRIPTION
This PR adds support for the Bee Link EQ14 mini PC, which features the Intel Processor N150 (Twin Lake) quad-core CPU with 24EU UHD graphics.

The profile follows the same pattern as  which also uses the N150:
- Imports the common Intel Alder Lake CPU module
- Imports the common Intel Alder Lake GPU module  
- Imports the common SSD/trim module

No special quirks are needed; the hardware works out of the box with these standard modules.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>