### PR TITLE
raspberry-pi/common/kernel: 6.18.33-1+rpt1 -> 6.18.34-stable_20260609

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -10,23 +10,22 @@
 
 let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.18.33";
-  hash = "sha256-XGL2SgPws+c1yAZDmNC9jQdi23qQPZKucQUr9+eD8MM=";
+  modDirVersion = "6.18.34";
+  tag = "stable_20260609";
+  hash = "sha256-ok++36dh9o4e7AC5RErW00/r23rGxufe0PYXz5Dzy5U=";
   inherit (lib.kernel) freeform yes no;
 in
 (buildLinux (
   args
   // {
-    version = "${modDirVersion}-1+rpt1";
+    version = "${modDirVersion}-${tag}";
     inherit modDirVersion;
     pname = "linux-rpi";
 
     src = fetchFromGitHub {
       owner = "raspberrypi";
       repo = "linux";
-      # https://github.com/RPi-Distro/linux-packaging/raw/refs/tags/pios/1%256.18.33-1+rpt1/debian/changelog
-      rev = "95b85bebbedcaedfa7ca79116ed38b7376fba412";
-      inherit hash;
+      inherit tag hash;
     };
 
     defconfig =


### PR DESCRIPTION
raspberrypi/linux GitHub repo starts getting tagged again, so use that.

<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

