### PR TITLE
asus/*: drop supergfx{ctl,d}

### DIFF
--- a/asus/fa506ic/default.nix
+++ b/asus/fa506ic/default.nix
@@ -27,6 +27,5 @@
     asusd = {
       enable = lib.mkDefault true;
     };
-    supergfxd.enable = lib.mkDefault true;
   };
 }

--- a/asus/fa506nc/README.md
+++ b/asus/fa506nc/README.md
@@ -1,6 +1,5 @@
 # ASUS TUF A15 FA506NC
 
-- GPU switching to the nvidia card works fine through supergfxd.
 - Power profiles autoswitch through asusctl in tandem with power-profiles-daemon.
 - The batter charge limit configuration through ../battery.nix did not work,
   setting a limit through asusd works.

--- a/asus/fa506nc/default.nix
+++ b/asus/fa506nc/default.nix
@@ -27,6 +27,5 @@
   services = {
     # https://asus-linux.org/manual/asusctl-manual/
     asusd.enable = lib.mkDefault true;
-    supergfxd.enable = lib.mkDefault true;
   };
 }

--- a/asus/fa706ic/default.nix
+++ b/asus/fa706ic/default.nix
@@ -22,6 +22,5 @@
 
   services = {
     asusd.enable = lib.mkDefault true;
-    supergfxd.enable = lib.mkDefault true;
   };
 }

--- a/asus/flow/gv302x/shared.nix
+++ b/asus/flow/gv302x/shared.nix
@@ -62,8 +62,6 @@ in
           enable = mkDefault true;
         };
 
-        supergfxd.enable = mkDefault true;
-
         udev = {
           extraHwdb = ''
             # Fixes mic mute button

--- a/asus/flow/gz301vu/default.nix
+++ b/asus/flow/gz301vu/default.nix
@@ -40,9 +40,6 @@ in
         asusd = {
           enable = mkDefault true;
         };
-
-        supergfxd.enable = mkDefault true;
-
       };
 
       #flow devices are 2 in 1 laptops

--- a/asus/zephyrus/ga402x/shared.nix
+++ b/asus/zephyrus/ga402x/shared.nix
@@ -61,8 +61,6 @@ in
           enable = mkDefault true;
         };
 
-        supergfxd.enable = mkDefault true;
-
         udev = {
           extraHwdb = ''
             # Fixes mic mute button


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Drop supergfxctl everywhere since it is deprecated, archived upstream and its usage no longer recommended (OGC / formerly Asus Linux Discord, [Arch Wiki](https://wiki.archlinux.org/title/Supergfxctl)).

I've been running `mkForce`'d without for a while now since ive noticed regressions a few months ago, although they couldve been specific to my model. 

A [successor](https://github.com/OpenGamingCollective/cardwire) is available but not yet packaged in nixpkgs as of this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

