### PR TITLE
raspberry-pi/common/kernel: fix preempt config on kernel >=6.18

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -72,11 +72,18 @@ in
       NLS_CODEPAGE_437 = lib.mkForce yes;
       FB_SIMPLE = yes;
     }
-    # arm64 vendor defconfigs (bcm2711, bcm2712) use full preempt;
-    # arm32 ones (bcmrpi, bcm2709) use voluntary preempt (nixpkgs default)
+    # nixpkgs defaults to lazy preempt on kernel version >=6.18
+    # arm64 vendor defconfigs (bcm2711, bcm2712) use full preempt
     // lib.optionalAttrs (rpiVersion >= 3) {
       PREEMPT = lib.mkForce yes;
+      PREEMPT_LAZY = lib.mkForce no;
       PREEMPT_VOLUNTARY = lib.mkForce no;
+    }
+    # arm32 ones (bcmrpi, bcm2709) use voluntary preempt
+    // lib.optionalAttrs (rpiVersion < 3) {
+      PREEMPT = lib.mkForce no;
+      PREEMPT_LAZY = lib.mkForce no;
+      PREEMPT_VOLUNTARY = lib.mkForce yes;
     };
 
     extraMeta =


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Resolves the collision of kernel `PREEMPT*` configs for raspberry pi kernels >=6.18 introduced in NixOS/nixpkgs/pull/531605.
- `rpiVersion >= 3` enforces `PREEMPT`
- `rpiVersion < 3` enforces `PREEMPT_VOLUNTARY`

Fixes #1920 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

Tested on a Pi 4. I haven't been able to test on older Pis, since I don't own the hardware.

