### PR TITLE
apple/t2: 7.0 -> 7.2; replace t2-better-audio with ucm config

### DIFF
--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -85,7 +85,7 @@ in
           if t2Cfg.kernelChannel == "stable" then ./pkgs/linux-t2 else ./pkgs/linux-t2/latest.nix
         ) { }
       );
-      boot.initrd.kernelModules = [ "apple-bce" ];
+      boot.initrd.kernelModules = [ "t2bce-vhci" ];
 
       services.udev.packages = [ audioFilesUdevRules ];
 

--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -8,34 +8,47 @@
 let
   inherit (lib) types;
 
-  audioFiles = pkgs.fetchFromGitHub {
-    owner = "kekrby";
-    repo = "t2-better-audio";
-    rev = "e46839a28963e2f7d364020518b9dac98236bcae";
-    hash = "sha256-x7K0qa++P1e1vuCGxnsFxL1d9+nwMtZUJ6Kd9e27TFs=";
+  t2bce-alsa-ucm = pkgs.stdenvNoCC.mkDerivation (_: {
+    name = "t2bce-alsa-ucm";
+    src = pkgs.fetchFromGitHub {
+      owner = "deqrocks";
+      repo = "t2bce";
+      rev = "967465dc67d3a9b1e48dea620f7258baa526f4f2";
+      hash = "sha256-EVUvNg30bFhJCtcyPAGbWjGX0+CORs4nWG5Bpvbr590=";
+    };
+
+    meta = {
+      description = "ALSA Usage Configuration Manager configuration for T2 Macs";
+      license = lib.licenses.mit;
+    };
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      cd ./t2bce_audio-alsa-ucm-conf
+      mkdir -p "$out/share/alsa/"
+      cp -vR ./ucm2 "$out/share/alsa/"
+
+      runHook postInstall
+    '';
+  });
+
+  patched-alsa-ucm = pkgs.symlinkJoin {
+    inherit (t2bce-alsa-ucm) src meta;
+    name = "t2bce-alsa-ucm-patched";
+    paths = [
+      pkgs.alsa-ucm-conf
+      t2bce-alsa-ucm
+    ];
   };
 
-  audioFilesUdevRules = pkgs.runCommand "audio-files-udev-rules" { } ''
-    mkdir -p $out/lib/udev/rules.d
-    cp ${audioFiles}/files/*.rules $out/lib/udev/rules.d
-    substituteInPlace $out/lib/udev/rules.d/*.rules --replace "/usr/bin/sed" "${pkgs.gnused}/bin/sed"
-  '';
-
-  overrideAudioFiles =
-    package: pluginsPath:
-    package.overrideAttrs (
-      _new: old: {
-        preConfigurePhases = old.preConfigurePhases or [ ] ++ [ "postPatchPhase" ];
-        postPatchPhase = ''
-          cp -r ${audioFiles}/files/{profile-sets,paths} ${pluginsPath}/alsa/mixer/
-        '';
-      }
-    );
-
-  pipewirePackage = overrideAudioFiles pkgs.pipewire "spa/plugins/";
+  patchedAudioAlsaEnv = lib.genAttrs [ "pipewire" "wireplumber" "pulseaudio" ] (_: {
+    environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+  });
 
   t2Cfg = config.hardware.apple-t2;
-
 in
 {
   imports = [
@@ -87,8 +100,6 @@ in
       );
       boot.initrd.kernelModules = [ "t2bce-vhci" ];
 
-      services.udev.packages = [ audioFilesUdevRules ];
-
       # For audio and suspend
       boot.kernelParams = [
         "intel_iommu=on"
@@ -96,17 +107,17 @@ in
         "pm_async=off"
       ];
 
-      services.pipewire.package = pipewirePackage;
-      services.pipewire.wireplumber.package = pkgs.wireplumber.override {
-        pipewire = pipewirePackage;
+      # audio configuration
+      # https://github.com/nix-community/nixos-apple-silicon/blob/66d8dd2c27f99bd5420c99938b60695aac1785c4/apple-silicon-support/modules/sound/default.nix#L46
+      environment.variables.ALSA_CONFIG_UCM2 = "${patched-alsa-ucm}/share/alsa/ucm2";
+      # setting systemd.globalEnvironment is likely going to have unexpected side effects
+      systemd = {
+        services = patchedAudioAlsaEnv;
+        user.services = patchedAudioAlsaEnv;
       };
 
       # Make sure post-resume.service exists
       powerManagement.enable = true;
-    }
-
-    {
-      services.pulseaudio.package = overrideAudioFiles pkgs.pulseaudio "src/modules/";
     }
 
     (lib.mkIf t2Cfg.enableIGPU {

--- a/apple/t2/pkgs/linux-t2/generic.nix
+++ b/apple/t2/pkgs/linux-t2/generic.nix
@@ -35,14 +35,15 @@ kernel.override (
       BRCMFMAC = module;
       BT_BCM = module;
       BT_HCIBCM4377 = module;
-      BT_HCIUART_BCM = yes;
       BT_HCIUART = module;
+      BT_HCIUART_BCM = yes;
+      DRM_APPLETBDRM = module;
+      HID_APPLE = module;
       HID_APPLETB_BL = module;
       HID_APPLETB_KBD = module;
-      HID_APPLE = module;
       HID_MAGICMOUSE = module;
-      DRM_APPLETBDRM = module;
       HID_SENSOR_ALS = module;
+      SENSORS_APPLESMC = module;
       SND_PCM = module;
       STAGING = yes;
     };

--- a/apple/t2/pkgs/linux-t2/generic.nix
+++ b/apple/t2/pkgs/linux-t2/generic.nix
@@ -29,20 +29,24 @@ kernel.override (
     pname = "linux-t2";
 
     structuredExtraConfig = with lib.kernel; {
-      APPLE_BCE = module;
+      # APPLE_BCE = module;
+      T2BCE_CORE = module;
+      T2BCE_VHCI = module;
+      T2BCE_AUDIO = module;
       APPLE_GMUX = module;
       APFS_FS = module;
       BRCMFMAC = module;
       BT_BCM = module;
       BT_HCIBCM4377 = module;
-      BT_HCIUART_BCM = yes;
       BT_HCIUART = module;
+      BT_HCIUART_BCM = yes;
+      DRM_APPLETBDRM = module;
+      HID_APPLE = module;
       HID_APPLETB_BL = module;
       HID_APPLETB_KBD = module;
-      HID_APPLE = module;
       HID_MAGICMOUSE = module;
-      DRM_APPLETBDRM = module;
       HID_SENSOR_ALS = module;
+      SENSORS_APPLESMC = module;
       SND_PCM = module;
       STAGING = yes;
     };

--- a/apple/t2/pkgs/linux-t2/latest.json
+++ b/apple/t2/pkgs/linux-t2/latest.json
@@ -1,5 +1,5 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/7ee7d19c38e5df31a386b2a0c35ca8f064003960/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/ff59395cc61769dc255b5eab6faac27e8ce441f7/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
@@ -11,7 +11,7 @@
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
-      "hash": "sha256-S2osR1aSjqJiO7rNZP1sKt2+Uxyitwse/6BXMJvE9as="
+      "hash": "sha256-t/+objLhglQMz0E+qK5U1+Jyu+Sg17INWjBES6G+TYA="
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
@@ -55,7 +55,7 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-ANHSNoy5nK2b+rSAG0bJ8j6ZBmNqgeCddHXVS31KyDw="
+      "hash": "sha256-7UPdrAwVEXZqndHiA37oWf23hRHK17AXNvJvSZ5yF2s="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
@@ -79,7 +79,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-EbIbfkncp5Jax2suny/jlFt+cD9MyYMV2rWFJIbgbg4="
+      "hash": "sha256-PKJfU089ooNGTuTLZUoDq0TyU1/RNSCIRkI6Uz0YZyk="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",

--- a/apple/t2/pkgs/linux-t2/latest.json
+++ b/apple/t2/pkgs/linux-t2/latest.json
@@ -1,17 +1,17 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/7ee7d19c38e5df31a386b2a0c35ca8f064003960/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/17f815655f1a14f8d3e03453e4496ed517df3b11/",
   "patches": [
     {
-      "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-v/P3Ws3x+OPnmX3vSFLxARON0HNjjDRe7QJ+KP9tVsc="
+      "name": "1001-Add-t2bce-driver-stack.patch",
+      "hash": "sha256-UgE9AyACg4bMnCQC99QQeHLuBlAElfOcnilGsTkKBOs="
     },
     {
-      "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-rK1lQ3fjHJH//50n37xgWrUs4CZ8lmFw0iDpbq5zoaY="
+      "name": "1002-Integrate-t2bce-driver-stack.patch",
+      "hash": "sha256-+/bq+ojxUMmtwqtT/BzpP7uqwJ2bFcz55bjtOp+hHi8="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
-      "hash": "sha256-S2osR1aSjqJiO7rNZP1sKt2+Uxyitwse/6BXMJvE9as="
+      "hash": "sha256-gTYP7WHV/Qulobdi1nNdYsv1CWgkM8pGvsCFQ+rvhrw="
     },
     {
       "name": "2009-apple-gmux-allow-switching-to-igpu-at-probe.patch",
@@ -55,35 +55,43 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-ANHSNoy5nK2b+rSAG0bJ8j6ZBmNqgeCddHXVS31KyDw="
+      "hash": "sha256-RuYI0t+rMu29wSkVT4suYJgGzS1ZruN/HBZWkLivlDw="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
-      "hash": "sha256-T2tYcFLeWUdx6QawANe3ZNVSRxmo1IdPiSpGLQk4IDY="
+      "hash": "sha256-LLZzcysLTuQrSXWXbdq7AASxfMInQoqpWzRNZAKws9k="
     },
     {
       "name": "4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch",
-      "hash": "sha256-ubchCEv1BZ7t/zkI9DpHA4gUln9cdu4yHzVJI2TNlS0="
-    },
-    {
-      "name": "4005-HID-magicmouse-fix-regression-breaking-support-for-M.patch",
-      "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
+      "hash": "sha256-kUnbtl/54cihscirl9kP0Gsot7bdP0rYKlj6gQ10hk0="
     },
     {
       "name": "5001-HID-appletb-kbd-add-option-to-switch-default-layer-o.patch",
       "hash": "sha256-KV5DTjALzNugs92Jum6VUt0wgblK/6PG1KorovHcIX0="
     },
     {
+      "name": "6001-drm-amd-pm-Fix-boot-problems-in-5300.patch",
+      "hash": "sha256-l6pyVkpumURgoQ/f1kGfw47YhMuuMjpiHgjP6QN8dNE="
+    },
+    {
       "name": "7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch",
       "hash": "sha256-/EKN7JsAxcpAgfJFtPp2NLYaGqQ0kl8wjJEXifSzJpY="
     },
     {
+      "name": "7002-drm-amdgpu-reset-VI-ASIC-on-MacBookPro15-1.patch",
+      "hash": "sha256-lLruG4lJAI6fI94w2LzHmrbspXArrq+rbI/SJmhwXqo="
+    },
+    {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-EbIbfkncp5Jax2suny/jlFt+cD9MyYMV2rWFJIbgbg4="
+      "hash": "sha256-mowAbauLMzijKlktD+TzK0kZB1nZoiC/QKC71QKc2eg="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",
       "hash": "sha256-zCTetF2NPhMH2BknPumhPz2sf26X9Lcra7xCA3R2WMY="
+    },
+    {
+      "name": "9001-ACPI-x86-Apple-T2-systems-need-early-CPU-offlining.patch",
+      "hash": "sha256-camFPvnBQMErjVrbsdPPfsbyy59w0e0iPkVR1Juzv8o="
     }
   ]
 }

--- a/apple/t2/pkgs/linux-t2/latest.nix
+++ b/apple/t2/pkgs/linux-t2/latest.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_7_0, ... }@args:
+{ callPackage, linux_7_1, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_7_0;
+  kernel = linux_7_1;
   patchesFile = ./latest.json;
 }

--- a/apple/t2/pkgs/linux-t2/latest.nix
+++ b/apple/t2/pkgs/linux-t2/latest.nix
@@ -1,6 +1,6 @@
-{ callPackage, linux_7_0, ... }@args:
+{ callPackage, linux_7_2, ... }@args:
 
 callPackage ./generic.nix args {
-  kernel = linux_7_0;
+  kernel = linux_7_2;
   patchesFile = ./latest.json;
 }

--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,13 +1,13 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/facf1c778667c3ef62104949ef64c75ce7e43b0a/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/a5b759ac4557ed2dadce10eaabde82d99c001fdd/",
   "patches": [
     {
       "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-rrL3oVkYeq5ZslnjCQw4hcEK6knsm6U/wp1XnJmQTSA="
+      "hash": "sha256-w7OeAt6eGi4bthaC+EK1iHoBv5RiuiQbh/sQSfaZ3ZA="
     },
     {
       "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-deWROYcncl51sOmtvUHM61e5FM1beHbOJVp4iI31LHM="
+      "hash": "sha256-1EvLmEryhAlI+z30mFfmzx9G+HVg2I/tTe1l6Vs2irE="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
@@ -79,7 +79,7 @@
     },
     {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-2By3Zlg/i5rUUJDlWc6JoiqapUnbVplk2lHzDhvAhzI="
+      "hash": "sha256-g9lR6xsJJVbmzM5NZgCHhTy6tM8qOGSuqE8mXhjcMA8="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",

--- a/apple/t2/pkgs/linux-t2/stable.json
+++ b/apple/t2/pkgs/linux-t2/stable.json
@@ -1,13 +1,13 @@
 {
-  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/facf1c778667c3ef62104949ef64c75ce7e43b0a/",
+  "base_url": "https://raw.githubusercontent.com/t2linux/linux-t2-patches/3c35556ed0a06018ae074b7176d031409c41123c/",
   "patches": [
     {
-      "name": "1001-Add-apple-bce-driver.patch",
-      "hash": "sha256-rrL3oVkYeq5ZslnjCQw4hcEK6knsm6U/wp1XnJmQTSA="
+      "name": "1001-Add-t2bce-driver-stack.patch",
+      "hash": "sha256-+3/tyG7mdg+L6rpRVU7PqZjtdcLyS4GG0iBtq9yClu8="
     },
     {
-      "name": "1002-Put-apple-bce-in-drivers-staging.patch",
-      "hash": "sha256-deWROYcncl51sOmtvUHM61e5FM1beHbOJVp4iI31LHM="
+      "name": "1002-Integrate-t2bce-driver-stack.patch",
+      "hash": "sha256-a5WHFSXhFhKsxGI7NBjjPfKzjCD4XxtOkg9k+tgNZr8="
     },
     {
       "name": "2008-i915-4-lane-quirk-for-mbp15-1.patch",
@@ -55,19 +55,15 @@
     },
     {
       "name": "4001-asahi-trackpad.patch",
-      "hash": "sha256-+YXyIjtlVrLo8allTO3M1A+xold5FUXaZ8dwD2j5HDc="
+      "hash": "sha256-2h3TdPsX9HBXx5jkZ2S2GJkjFcdL8vKD1G69iqd9IWg="
     },
     {
       "name": "4003-HID-apple-ignore-the-trackpad-on-T2-Macs.patch",
-      "hash": "sha256-T2tYcFLeWUdx6QawANe3ZNVSRxmo1IdPiSpGLQk4IDY="
+      "hash": "sha256-LLZzcysLTuQrSXWXbdq7AASxfMInQoqpWzRNZAKws9k="
     },
     {
       "name": "4004-HID-magicmouse-Add-support-for-trackpads-found-on-T2.patch",
-      "hash": "sha256-ubchCEv1BZ7t/zkI9DpHA4gUln9cdu4yHzVJI2TNlS0="
-    },
-    {
-      "name": "4005-HID-magicmouse-fix-regression-breaking-support-for-M.patch",
-      "hash": "sha256-oT+3AeETnKfzblxtcTD18c61BKoD9yAsga0AL3R8u7k="
+      "hash": "sha256-kUnbtl/54cihscirl9kP0Gsot7bdP0rYKlj6gQ10hk0="
     },
     {
       "name": "5001-HID-appletb-kbd-add-option-to-switch-default-layer-o.patch",
@@ -78,8 +74,12 @@
       "hash": "sha256-/EKN7JsAxcpAgfJFtPp2NLYaGqQ0kl8wjJEXifSzJpY="
     },
     {
+      "name": "7002-drm-amdgpu-reset-VI-ASIC-on-MacBookPro15-1.patch",
+      "hash": "sha256-lLruG4lJAI6fI94w2LzHmrbspXArrq+rbI/SJmhwXqo="
+    },
+    {
       "name": "8001-Add-APFS-driver.patch",
-      "hash": "sha256-2By3Zlg/i5rUUJDlWc6JoiqapUnbVplk2lHzDhvAhzI="
+      "hash": "sha256-7yzAlrN5x4AG4C2xdnGOJ7dVips5BhvOQ99vZm4hajI="
     },
     {
       "name": "8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch",


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
update kernel version to 7.2.

closes #2027 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

