### PR TITLE
raspberry-pi/common: enable UART by default for U-Boot

### DIFF
--- a/raspberry-pi/common/config-txt-defaults.nix
+++ b/raspberry-pi/common/config-txt-defaults.nix
@@ -18,6 +18,14 @@
       arm_boost = lib.mkDefault true;
       dtparam = lib.mkDefault [ "audio=on" ];
       dtoverlay = lib.mkDefault [ "vc4-kms-v3d" ];
+      # U-Boot needs the UART enabled to boot (see arch/arm/mach-bcm283x/Kconfig
+      # in the U-Boot tree). Without it U-Boot hangs on the Pi 4.
+      enable_uart = lib.mkDefault true;
+    };
+    # The Pi 5 has a dedicated debug UART. Leaving the mini UART on feeds ghost
+    # input into boot, so turn it back off.
+    pi5 = {
+      enable_uart = lib.mkDefault false;
     };
     cm4 = {
       otg_mode = lib.mkDefault true;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

U-Boot needs `enable_uart=1` in `config.txt` to boot, even if you only use the HDMI/USB console. It's documented in `arch/arm/mach-bcm283x/Kconfig`[^1] in U-Boot, and nixpkgs' `sd-image-aarch64.nix`[^2] already sets it. `config-txt-defaults.nix` didn't, so a Pi booting through U-Boot hangs at early boot.

This adds it to the defaults, with `enable_uart=0` on the Pi 5, whose dedicated debug UART picks up ghost input otherwise. Matches the sd-image.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

[^1]: https://github.com/u-boot/u-boot/blob/913fedc816570c07bfc7f9c4046dc2a3a55e4099/arch/arm/mach-bcm283x/Kconfig#L184-L189
[^2]: https://github.com/NixOS/nixpkgs/blob/b86de243c90576400d7d954c494921d35aa1186b/nixos/modules/installer/sd-card/sd-image-aarch64.nix#L39-L42