### PR TITLE
hp/zbook/x/g1i: add profile for HP ZBook X G1i

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ See code for all available configurations.
 | [HP Laptop 15s-fq1xxx](hp/laptop/15s-fq1xxx)                                      | `<nixos-hardware/hp/laptop/15s-fq1xxx>`                 | `hp-laptop-15s-fq1xxx`                 |
 | [HP Notebook 14-df0023](hp/notebook/14-df0023)                                    | `<nixos-hardware/hp/notebook/14-df0023>`                | `hp-notebook-14-df0023`                |
 | [HP Probook 440G5](hp/probook/440G5)                                              | `<nixos-hardware/hp/probook/440G5>`                     | `hp-probook-440G5`                     |
+| [HP ZBook X G1i](hp/zbook/x/g1i)                                                   | `<nixos-hardware/hp/zbook/x/g1i>`                       | `hp-zbook-x-g1i`                       |
 | [HP Laptop 14s-dq2024nf](hp/laptop/14s-dq2024nf)                                  | `<nixos-hardware/hp/laptop/14s-dq2024nf>`               | `hp-laptop-14s-dq2024nf`               |
 | [HP Probook 460G11](hp/probook/460g11)                                            | `<nixos-hardware/hp/probook/460g11>`                    | `hp-probook-46011`                     |
 | [Huawei Matebook X Pro (2020)](huawei/machc-wa)                                   | `<nixos-hardware/huawei/machc-wa>`                      | `huawei-machc-wa`                      |

--- a/flake.nix
+++ b/flake.nix
@@ -207,6 +207,7 @@
           hp-elitebook-845g9 = import ./hp/elitebook/845/g9;
           hp-probook-440G5 = import ./hp/probook/440G5;
           hp-probook-460G11 = import ./hp/probook/460G11;
+          hp-zbook-x-g1i = import ./hp/zbook/x/g1i;
           hp-laptop-14s-dq2024nf = import ./hp/laptop/14s-dq2024nf;
           hp-laptop-15s-fq1xxx = import ./hp/laptop/15s-fq1xxx;
           huawei-machc-wa = import ./huawei/machc-wa;

--- a/hp/zbook/x/g1i/default.nix
+++ b/hp/zbook/x/g1i/default.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  imports = [
+    ../../../../common/cpu/intel
+    ../../../../common/pc
+    ../../../../common/pc/laptop
+    ../../../../common/pc/ssd
+  ];
+
+  hardware = {
+    enableRedistributableFirmware = lib.mkDefault true;
+    intelgpu.vaapiDriver = lib.mkDefault "intel-media-driver";
+  };
+
+  services = {
+    fwupd.enable = lib.mkDefault true;
+    hardware.bolt.enable = lib.mkDefault true;
+    thermald.enable = lib.mkDefault true;
+  };
+
+  # Arrow Lake support on this machine is still moving quickly upstream.
+  boot = {
+    kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.17") (
+      lib.mkDefault pkgs.linuxPackages_latest
+    );
+
+    # Enables ACPI platform profiles.
+    kernelModules = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.1") [ "hp-wmi" ];
+  };
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Added configuration for HP Zbook x g1i

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

