### PR TITLE
fydetab-duo: declare efiBootStub kernel feature

### DIFF
--- a/fydetab/duo/kernel.nix
+++ b/fydetab/duo/kernel.nix
@@ -14,5 +14,8 @@ linuxPackagesFor (linuxManualConfig rec {
   };
   configfile = ./config;
   config = import ./config.nix;
-  features.netfilterRPFilter = true;
+  features = {
+    efiBootStub = true;
+    netfilterRPFilter = true;
+  };
 })


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

The kernel config sets `CONFIG_EFI_STUB=y`, but https://github.com/NixOS/nixpkgs/pull/535309 made linuxManualConfig forward `features` into passthru, so the kernel stopped advertising `efiBootStub` and the systemd-boot assertion fails. Declaring it fixes the stable-fydetab-duo test (#1936 and #1937).

cc: @RossComputerGuy 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

