### PR TITLE
framework/16-inch: fix screen tearing

### DIFF
--- a/framework/16-inch/common/amd.nix
+++ b/framework/16-inch/common/amd.nix
@@ -12,7 +12,13 @@
     #
     # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
     # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
-    "amdgpu.dcdebugmask=0x10"
+    #
+    # Even with 0x10 I still had issues with screen tearing, so I tried this conservative value that fixed it.
+    # It disables the following features
+    # * DC_DISABLE_CLOCK_GATING
+    # * DC_DISABLE_PSR
+    # * DC_DISABLE_REPLAY
+    "amdgpu.dcdebugmask=0x418"
   ]
   # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
   ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Fixes screen tearing on framework 16.

###### Things done
Changed kernel value to disable more features still causing screen tearing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

