### PR TITLE
macbookpro-12-1 replace power up/down commands with systemd oneshot services

### DIFF
--- a/apple/macbook-pro/12-1/README.md
+++ b/apple/macbook-pro/12-1/README.md
@@ -3,12 +3,18 @@
 ## Wireless won't get reconnected after resume/hibernate
 
 The wifi driver is unloaded before suspend/hibernate to workaround driver issues.
-This means it might be required to restart your wifi deamon i.e. wpa_supplicant:
+This means it might be required to restart your wifi daemon i.e. wpa_supplicant:
 
 ```nix
-powerManagement.powerUpCommands = ''
-  ${pkgs.systemd}/bin/systemctl restart wpa_supplicant.service
-'';
+systemd.services.restart-wpa-supplicant-after-resume = {
+  description = "Restart wpa_supplicant after resume";
+  wantedBy = [ "sleep.target" ];
+  after = [ "sleep.target" ];
+  serviceConfig = {
+    Type = "oneshot";
+    ExecStart = "${pkgs.systemd}/bin/systemctl restart wpa_supplicant.service";
+  };
+};
 ```
 
 You can apply this to your network management software of choice.

--- a/apple/macbook-pro/12-1/default.nix
+++ b/apple/macbook-pro/12-1/default.nix
@@ -16,15 +16,39 @@
     # Enable gradually increasing/decreasing CPU frequency, rather than using
     # "powersave", which would keep CPU frequency at 0.8GHz.
     cpuFreqGovernor = lib.mkDefault "conservative";
+  };
 
-    # brcmfmac being loaded during hibernation would not let a successful resume
-    # https://bugzilla.kernel.org/show_bug.cgi?id=101681#c116.
-    # Also brcmfmac could randomly crash on resume from sleep.
-    powerUpCommands = lib.mkBefore "${pkgs.kmod}/bin/modprobe brcmfmac";
-    powerDownCommands = lib.mkBefore ''
-      ${pkgs.kmod}/bin/rmmod -f -v brcmfmac_wcc 2>/dev/null || true
-      ${pkgs.kmod}/bin/rmmod brcmfmac
-    '';
+  # brcmfmac being loaded during hibernation would not let a successful resume
+  # https://bugzilla.kernel.org/show_bug.cgi?id=101681#c116.
+  # Also brcmfmac could randomly crash on resume from sleep.
+  systemd.services = {
+    macbook-pro-12-1-brcmfmac-load = {
+      description = "Load brcmfmac wireless driver";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.kmod}/bin/modprobe brcmfmac";
+      };
+    };
+
+    macbook-pro-12-1-brcmfmac-sleep = {
+      description = "Unload brcmfmac wireless driver before sleep";
+      wantedBy = [ "sleep.target" ];
+      before = [ "sleep.target" ];
+      unitConfig = {
+        DefaultDependencies = false;
+        StopWhenUnneeded = true;
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = pkgs.writeShellScript "unload-brcmfmac" ''
+          ${pkgs.kmod}/bin/rmmod -f -v brcmfmac_wcc 2>/dev/null || true
+          ${pkgs.kmod}/bin/rmmod brcmfmac
+        '';
+        ExecStop = "${pkgs.kmod}/bin/modprobe brcmfmac";
+      };
+    };
   };
 
   # USB subsystem wakes up MBP right after suspend unless we disable it.


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

- updated `powerManagement.powerUpCommands` and `powerManagement.powerDownCommands` to systemd oneshort services (fixes #1794)
- updated the `powerManagement.powerUpCommands` in readme as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

