### PR TITLE
spacemit/k3-pico-itx: move to mainline kernel

### DIFF
--- a/spacemit/k3-pico-itx/README.md
+++ b/spacemit/k3-pico-itx/README.md
@@ -79,44 +79,16 @@ hardware. I can't guarantee its availability, nor that everything is already
 built on it. The Hydra infrastructure is still being deployed, so please be
 lenient in that regard.
 
-## HMP configuration
+## X100 vs A100
 
-The X100 and A100 clusters have different vector widths (`VLENB=32` vs `VLENB=128`).
+Here are the notable differences between the X100 and the A100.
 
-You can configure HMP at runtime:
-
-`echo strict > /sys/kernel/spacemit_hmp/mode` (default)
-
-or
-
-`echo permissive > /sys/kernel/spacemit_hmp/mode`
-
-Permissive mode lets you use the 8 A100 cores in addition to the X100 cores.
-However, I deliberately apply a segmentation between the two clusters because of a
-VLEN issue.
-
-If you force tasks across both clusters anyway (e.g. via `taskset`), it will cause
-crypto corruption.
-
-I also made a small module for this:
-
-```nix
-hardware.spacemit.hmp = {
-  enable = true;
-  mode = "permissive"; # or "strict"
-};
-```
-
-- **`strict`** (default): uses the X100 cores only.
-- **`permissive`**: uses both the X100 and A100 cores, but with a segmentation
-  between the clusters.
-
-An alternative is still available to use all 16 cores without segmentation, with
-this:
-
-```nix
-environment.variables.OPENSSL_riscvcap = "RV64GC";
-```
+| | X100 (cpu 0-7) | A100 (cpu 8-15) |
+|---|---|---|
+| Hypervisor extension (`h`) | yes (`rv64imafdcvh`) | no (`rv64imafdcv`) |
+| Vector width | `VLENB=32` (VLEN 256-bit) | `VLENB=128` (VLEN 1024-bit) |
+| L2 cache | 4 MB per cluster (8 MB total) | 1 MB per cluster (2 MB total) |
+| L1 cache | 64 KB I + 64 KB D per core | identical |
 
 ## UEFI
 

--- a/spacemit/k3-pico-itx/default.nix
+++ b/spacemit/k3-pico-itx/default.nix
@@ -21,12 +21,14 @@
 
     kernelParams = [
       "earlycon=sbi"
+      "console=ttyS0,115200"
       "keep_bootcon"
       "systemd.journald.forward_to_console=1"
       "systemd.log_target=kmsg"
       "systemd.log_level=info"
       "clk_ignore_unused"
       "pd_ignore_unused"
+      "regulator_ignore_unused"
       "root=PARTLABEL=nixos-rootfs"
       "rootwait"
       "rootfstype=ext4"
@@ -62,6 +64,10 @@
     name = lib.mkDefault "spacemit/k3-pico-itx.dtb";
   };
 
+  boot.supportedFilesystems = lib.mkForce [
+    "ext4"
+    "vfat"
+  ];
   boot.initrd.systemd.enable = lib.mkDefault true;
   system.nixos-init.enable = lib.mkDefault true;
   system.etc.overlay.enable = lib.mkDefault true;

--- a/spacemit/k3-pico-itx/linux.nix
+++ b/spacemit/k3-pico-itx/linux.nix
@@ -1,98 +1,208 @@
 {
   buildLinux,
   fetchFromGitHub,
-  kernelPatches,
   lib,
   ...
-}
-
-@args:
+}@args:
 
 let
-  modDirVersion = "6.18.3";
+  modDirVersion = "7.2.0";
 in
-
 buildLinux (
   args
   // {
-    inherit kernelPatches modDirVersion;
-    version = "${modDirVersion}-spacemit-k3";
+    inherit modDirVersion;
+    version = "7.2-spacemit-k3";
 
     src = fetchFromGitHub {
-      owner = "liberodark";
-      repo = "spacemit-linux-6.18";
-      rev = "3709ed51967962fd02d6b4e5a80234719693931f";
-      hash = "sha256-itqxXJCogLHbGucVHCDVwGkoqunQjJs0i1ZfvkuUtP4=";
+      owner = "torvalds";
+      repo = "linux";
+      tag = "v7.2";
+      hash = "sha256-GAjLGXXJiU42En31XWWx31IRT63G2pNsDN4ifNGtHis=";
     };
 
-    defconfig = "k3_bianbu_defconfig";
+    defconfig = "defconfig";
 
-    postPatch = ''
-      sed -i '/CONFIG_INITRAMFS_SOURCE=/d' arch/riscv/configs/k3_bianbu_defconfig
-    '';
-
-    structuredExtraConfig =
-      let
-        inherit (lib.kernel) yes no;
-      in
+    kernelPatches = [
       {
-        CGROUPS = yes;
-        MEMCG = yes;
-        CGROUP_BPF = yes;
-        BPF = yes;
-        BPF_SYSCALL = yes;
-        BPF_JIT = yes;
-        NAMESPACES = yes;
-        USER_NS = yes;
-        SECCOMP = yes;
-        SECCOMP_FILTER = yes;
-        DEVTMPFS = yes;
-        DEVTMPFS_MOUNT = yes;
-        AUTOFS_FS = yes;
-        FANOTIFY = yes;
-        TMPFS_POSIX_ACL = yes;
-        TMPFS_XATTR = yes;
-        MODULES = yes;
-        MODULE_UNLOAD = yes;
-        RD_GZIP = yes;
-        RD_BZIP2 = yes;
-        RD_LZMA = yes;
-        RD_XZ = yes;
-        RD_LZO = yes;
-        RD_LZ4 = yes;
-        RD_ZSTD = yes;
-        # Disable
-        PSTORE_BLK = no;
-        PSTORE_BLK_BLKDEV = no;
-        RTL8852BS = no;
-        CORESIGHT = no;
-        ETHERCAT = no;
-        HWSPINLOCK_SPACEMIT = no;
-        DRM_AMDGPU = no;
-        DRM_RADEON = no;
-        DRM_NOUVEAU = no;
-        SPACEMIT_K1_CCU = no;
-        NVMEM_LAYOUT_ONIE_TLV = no;
-        DEBUG_VM = no;
-        DEBUG_VM_PGFLAGS = no;
-        DEBUG_VM_PGTABLE = no;
-        DEBUG_PAGEALLOC = no;
-        DEBUG_PAGEALLOC_ENABLE_DEFAULT = no;
-        PAGE_EXTENSION = lib.mkForce no;
-        PAGE_OWNER = no;
-        KASAN = no;
-        KMEMLEAK = no;
-        DEBUG_KMEMLEAK = no;
-        SLUB_DEBUG_ON = no;
-        MEM_ALLOC_PROFILING = lib.mkForce no;
-        MEM_ALLOC_PROFILING_ENABLED_BY_DEFAULT = lib.mkForce no;
-        NO_HZ_FULL = lib.mkForce no;
-        SLAB_FREELIST_HARDENED = lib.mkForce no;
-        SLAB_FREELIST_RANDOM = lib.mkForce no;
-        KFENCE = lib.mkForce no;
-      };
+        name = "k3-pcie-01-phy-dt-bindings";
+        patch = ./patches/0001-phy-dt-bindings-k3-comb-phy.patch;
+      }
+      {
+        name = "k3-pcie-02-phy-combphy-driver";
+        patch = ./patches/0002-phy-k3-combphy-driver.patch;
+      }
+      {
+        name = "k3-pcie-03-pci-k1-device-data";
+        patch = ./patches/0003-pci-k1-device-data.patch;
+      }
+      {
+        name = "k3-pcie-04-pci-k1-multiple-phy-handles";
+        patch = ./patches/0004-pci-k1-multiple-phy-handles.patch;
+      }
+      {
+        name = "k3-pcie-05-dt-bindings-dw-pcie-msi-parent";
+        patch = ./patches/0005-dt-bindings-dw-pcie-msi-parent.patch;
+      }
+      {
+        name = "k3-pcie-06-dt-bindings-k3-pcie-host";
+        patch = ./patches/0006-dt-bindings-k3-pcie-host.patch;
+      }
+      {
+        name = "k3-pcie-07-pci-k3-host-controller";
+        patch = ./patches/0007-pci-k3-host-controller.patch;
+      }
+      {
+        name = "k3-08-serial-8250-gate-clock";
+        patch = ./patches/0008-serial-8250_of-gate-clock.patch;
+      }
+      {
+        name = "k3-09-dts-uart0-gate-clock";
+        patch = ./patches/0009-dts-k3-uart0-gate-clock.patch;
+      }
+      {
+        name = "k3-09-dts-k3-add-pcie-combphy";
+        patch = ./patches/0010-dts-k3-add-pcie-combphy.patch;
+      }
+      {
+        name = "k3-11-dts-reserved-memory";
+        patch = ./patches/0011-dts-k3-reserved-memory.patch;
+      }
+      {
+        name = "k3-12-thermal-spacemit-k3";
+        patch = ./patches/0012-thermal-spacemit-k3.patch;
+      }
+      {
+        name = "k3-13-riscv-cpuinfo-model-name";
+        patch = ./patches/0013-riscv-cpuinfo-model-name.patch;
+      }
+      {
+        name = "k3-14-cpufreq-spacemit-k3";
+        patch = ./patches/0014-cpufreq-spacemit-k3.patch;
+      }
+      # SM10 Support
+      #{
+      #  name = "k3-15-dts-com260-pcie";
+      #  patch = ./patches/0015-dts-k3-com260-pcie.patch;
+      #}
+      #{
+      #  name = "k3-16-remoteproc-rcpu";
+      #  patch = ./patches/0016-remoteproc-spacemit-k3-rcpu.patch;
+      #}
+    ];
 
-    extraMeta.branch = "k3-br-v1.0.y";
+    structuredExtraConfig = with lib.kernel; {
+      ARCH_SPACEMIT = option yes;
+      CPU_FREQ = option yes;
+      CPU_FREQ_GOV_PERFORMANCE = option yes;
+      CPU_FREQ_GOV_SCHEDUTIL = option yes;
+      CPU_FREQ_DEFAULT_GOV_SCHEDUTIL = option yes;
+      CPUFREQ_DT = option yes;
+      CPUFREQ_DT_PLATDEV = option yes;
+      SPACEMIT_K3_CPUFREQ = option yes;
+      PM_OPP = option yes;
+      SPACEMIT_K3_THERMAL = option yes;
+      THERMAL = option yes;
+      THERMAL_HWMON = option yes;
+      HWMON = option yes;
+      # SM10
+      #MAILBOX = option yes;
+      #SPACEMIT_K3_MAILBOX = option yes;
+      #REMOTEPROC = option yes;
+      #SPACEMIT_K3_RPROC = option yes;
+      #RPMSG = option yes;
+      #RPMSG_VIRTIO = option yes;
+      SMP = option yes;
+      SPACEMIT_K3_CCU = option yes;
+      GPIO_SPACEMIT_K1 = option yes;
+      CMA = option yes;
+      DMA_CMA = option yes;
+      SPARSEMEM_MANUAL = option yes;
+      PCI = option yes;
+      PCIE_DW = option yes;
+      PCIE_DW_HOST = option yes;
+      PCIE_SPACEMIT_K1 = option yes;
+      PHY_SPACEMIT_K3_COMBO_PHY = option yes;
+      PHY_SPACEMIT_K3_COMMON_OPS = option yes;
+      # SM10
+      #PWM = option yes;
+      #PWM_PXA = option yes;
+      NVME_CORE = option yes;
+      BLK_DEV_NVME = option yes;
+      MMC = option yes;
+      MMC_SDHCI = option yes;
+      MMC_SDHCI_PLTFM = option yes;
+      MMC_SDHCI_OF_K1 = option yes;
+      SCSI = option yes;
+      STMMAC_ETH = option module;
+      USB = option yes;
+      USB_XHCI_HCD = option yes;
+      USB_EHCI_HCD = option yes;
+      SERIAL_8250 = option yes;
+      SERIAL_8250_CONSOLE = option yes;
+      SERIAL_OF_PLATFORM = option yes;
+      EFI = option yes;
+      EFI_STUB = option yes;
+      EFIVAR_FS = option yes;
+      CGROUPS = option yes;
+      MEMCG = option yes;
+      CGROUP_BPF = option yes;
+      BPF = option yes;
+      BPF_SYSCALL = option yes;
+      BPF_JIT = option yes;
+      NAMESPACES = option yes;
+      USER_NS = option yes;
+      SECCOMP = option yes;
+      SECCOMP_FILTER = option yes;
+      DEVTMPFS = option yes;
+      DEVTMPFS_MOUNT = option yes;
+      AUTOFS_FS = option yes;
+      FANOTIFY = option yes;
+      TMPFS_POSIX_ACL = option yes;
+      TMPFS_XATTR = option yes;
+      MODULES = option yes;
+      MODULE_UNLOAD = option yes;
+      RD_GZIP = option yes;
+      RD_BZIP2 = option yes;
+      RD_LZMA = option yes;
+      RD_XZ = option yes;
+      RD_LZO = option yes;
+      RD_LZ4 = option yes;
+      RD_ZSTD = option yes;
+      # Disable
+      PSTORE_BLK = no;
+      PSTORE_BLK_BLKDEV = no;
+      RTL8852BS = no;
+      CORESIGHT = no;
+      ETHERCAT = no;
+      HWSPINLOCK_SPACEMIT = no;
+      DRM_AMDGPU = no;
+      DRM_RADEON = no;
+      DRM_NOUVEAU = no;
+      SPACEMIT_K1_CCU = no;
+      NVMEM_LAYOUT_ONIE_TLV = no;
+      DEBUG_VM = no;
+      DEBUG_VM_PGFLAGS = no;
+      DEBUG_VM_PGTABLE = no;
+      DEBUG_PAGEALLOC = no;
+      DEBUG_PAGEALLOC_ENABLE_DEFAULT = no;
+      PAGE_EXTENSION = lib.mkForce no;
+      PAGE_OWNER = no;
+      KASAN = no;
+      KMEMLEAK = no;
+      DEBUG_KMEMLEAK = no;
+      SLUB_DEBUG_ON = no;
+      MEM_ALLOC_PROFILING = lib.mkForce no;
+      MEM_ALLOC_PROFILING_ENABLED_BY_DEFAULT = lib.mkForce no;
+      NO_HZ_FULL = lib.mkForce no;
+      SLAB_FREELIST_HARDENED = lib.mkForce no;
+      SLAB_FREELIST_RANDOM = lib.mkForce no;
+      KFENCE = lib.mkForce no;
+      DEBUG_INFO_BTF = lib.mkForce no;
+      DEBUG_INFO_BTF_MODULES = lib.mkForce no;
+    };
+
+    extraMeta.branch = "7.2";
   }
   // (args.argsOverride or { })
 )

--- a/spacemit/k3-pico-itx/patches/0001-phy-dt-bindings-k3-comb-phy.patch
+++ b/spacemit/k3-pico-itx/patches/0001-phy-dt-bindings-k3-comb-phy.patch
@@ -1,0 +1,92 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 1/2] dt-bindings: phy: Add Spacemit K3 USB3/PCIe comb phy
+ support
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Thu, 30 Apr 2026 10:28:40 +0800
+Message-Id: <20260430022843.1090138-2-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The USB3/PCIe comb PHY on the K3 is a complex PHY group that
+can provide multiple phy for both PCIe and USB controller.
+Its mux configuration is controlled by the APMU syscon device.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+---
+ .../bindings/phy/spacemit,k3-comb-phy.yaml    | 63 +++++++++++++++++++
+ 1 file changed, 63 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/phy/spacemit,k3-comb-phy.yaml
+
+diff --git a/Documentation/devicetree/bindings/phy/spacemit,k3-comb-phy.yaml b/Documentation/devicetree/bindings/phy/spacemit,k3-comb-phy.yaml
+new file mode 100644
+index 000000000000..7aa2cf9301b7
+--- /dev/null
++++ b/Documentation/devicetree/bindings/phy/spacemit,k3-comb-phy.yaml
+@@ -0,0 +1,63 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/phy/spacemit,k3-comb-phy.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Spacemit K3 PCIE/USB3 Comb PHY
++
++maintainers:
++  - Inochi Amaoto <inochiama@gmail.com>
++
++properties:
++  compatible:
++    const: spacemit,k3-comb-phy
++
++  reg:
++    maxItems: 1
++
++  "#phy-cells":
++    const: 2
++    description:
++      The first one is phy id, the second one is phy type.
++
++  spacemit,apb-spare:
++    $ref: /schemas/types.yaml#/definitions/phandle
++    description:
++      Phandle to APB SPARE system controller interface, used for
++      PHY calibration.
++
++  spacemit,apmu:
++    $ref: /schemas/types.yaml#/definitions/phandle-array
++    items:
++      - items:
++          - description: phandle of APMU syscon
++          - description: configuration of the PHY lanes
++    description: |
++      Phandle to control PHY mux configuration. The configuration
++      is described as follows:
++      bit 4: 0 - PCIe A x8 mode, 1 - PCIe lane share mode
++      bit 3: 0 - PCIe A x4 mode, 1 - PCIe A x2 and PCIe B x2 mode
++      bit 2: 0 - PCIe C lane 0 is PCIe mode , 1 - USB mode
++      bit 1: 0 - PCIe C lane 1 is PCIe mode , 1 - USB mode
++      bit 0: 0 - PCIe D lane is PCIe mode , 1 - USB mode
++
++      The bit[3:0] is only valid when bit 4 is 1.
++
++required:
++  - compatible
++  - "#phy-cells"
++  - spacemit,apb-spare
++  - spacemit,apmu
++
++additionalProperties: false
++
++examples:
++  - |
++    phy@81d00000 {
++      compatible = "spacemit,k3-comb-phy";
++      reg = <0x81d00000 0x600000>;
++      #phy-cells = <2>;
++      spacemit,apb-spare = <&apb_spare>;
++      spacemit,apmu = <&apmu 0x00>;
++    };
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0002-phy-k3-combphy-driver.patch
+++ b/spacemit/k3-pico-itx/patches/0002-phy-k3-combphy-driver.patch
@@ -1,0 +1,758 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 2/2] phy: spacemit: Add USB3/PCIe comb PHY driver for
+ Spacemit K3
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Thu, 30 Apr 2026 10:28:41 +0800
+Message-Id: <20260430022843.1090138-3-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+The comb PHY on K3 requires to configure a syscon device for the
+right mux configuration. And it requires calibration before any
+usage.
+
+Add USB3/PCIe comb PHY driver for Spacemit K3.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+---
+ drivers/phy/spacemit/Kconfig          |  16 ++
+ drivers/phy/spacemit/Makefile         |   2 +
+ drivers/phy/spacemit/phy-k3-combphy.c | 250 ++++++++++++++++
+ drivers/phy/spacemit/phy-k3-common.c  | 398 ++++++++++++++++++++++++++
+ drivers/phy/spacemit/phy-k3-common.h  |  27 ++
+ 5 files changed, 693 insertions(+)
+ create mode 100644 drivers/phy/spacemit/phy-k3-combphy.c
+ create mode 100644 drivers/phy/spacemit/phy-k3-common.c
+ create mode 100644 drivers/phy/spacemit/phy-k3-common.h
+
+diff --git a/drivers/phy/spacemit/Kconfig b/drivers/phy/spacemit/Kconfig
+index 50b0005acf66..5fdf18fce499 100644
+--- a/drivers/phy/spacemit/Kconfig
++++ b/drivers/phy/spacemit/Kconfig
+@@ -23,3 +23,19 @@ config PHY_SPACEMIT_K1_USB2
+ 	help
+ 	  Enable this to support K1 USB 2.0 PHY driver. This driver takes care of
+ 	  enabling and clock setup and will be used by K1 udc/ehci/otg/xhci driver.
++
++config PHY_SPACEMIT_K3_COMMON_OPS
++	tristate
++	select MFD_SYSCON
++	select GENERIC_PHY
++
++config PHY_SPACEMIT_K3_COMBO_PHY
++	tristate "SpacemiT K3 USB3/PCIe PHY support"
++	depends on (ARCH_SPACEMIT || COMPILE_TEST) && OF
++	depends on COMMON_CLK
++	select PHY_SPACEMIT_K3_COMMON_OPS
++	help
++	  Enable this to support K3 USB3/PCIe combo PHY driver. This
++	  driver takes care of enabling and clock setup and will be used
++	  by K3 dwc3 driver.
++	  If unsure, say N.
+diff --git a/drivers/phy/spacemit/Makefile b/drivers/phy/spacemit/Makefile
+index a821a21d6142..41be7b0388da 100644
+--- a/drivers/phy/spacemit/Makefile
++++ b/drivers/phy/spacemit/Makefile
+@@ -1,3 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+ obj-$(CONFIG_PHY_SPACEMIT_K1_PCIE)		+= phy-k1-pcie.o
+ obj-$(CONFIG_PHY_SPACEMIT_K1_USB2)		+= phy-k1-usb2.o
++obj-$(CONFIG_PHY_SPACEMIT_K3_COMBO_PHY)		+= phy-k3-combphy.o
++obj-$(CONFIG_PHY_SPACEMIT_K3_COMMON_OPS)	+= phy-k3-common.o
+diff --git a/drivers/phy/spacemit/phy-k3-combphy.c b/drivers/phy/spacemit/phy-k3-combphy.c
+new file mode 100644
+index 000000000000..66fa6330ad6e
+--- /dev/null
++++ b/drivers/phy/spacemit/phy-k3-combphy.c
+@@ -0,0 +1,250 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * phy-k3-usb3.c - SpacemiT K3 Type-C Orientation Switch Driver
++ *
++ * Copyright (c) 2025 SpacemiT Technology Co. Ltd
++ */
++
++#include <linux/bitfield.h>
++#include <linux/io.h>
++#include <linux/module.h>
++#include <linux/mfd/syscon.h>
++#include <linux/iopoll.h>
++#include <linux/of.h>
++#include <linux/platform_device.h>
++#include <linux/regmap.h>
++#include <linux/phy/phy.h>
++
++#include <dt-bindings/phy/phy.h>
++
++#include "phy-k3-common.h"
++
++/*
++ * The PCIE/USB Subsystem on SpacemiT K3 have 3 single lane PIPE3 PHYs
++ * (PHY2/3/4) shared by PCIE PortC/D and USB3 PortB/C/D.
++ *
++ * PMUA_PCIE_SUBSYS_MGMT[4:0]
++ *
++ *   bit4 = 0 : PCIe A X8 mode, all 8 lanes dedicated to PCIe Port A
++ *          1 : PHY lanes shared between PCIe or USB according to [3:0]
++ *
++ * All PHY matrix combinations according to [4:0]:
++ *
++ *   0x0X : PCIe-A X8
++ *   0x10 : PCIe-C x2 (PHY2+PHY3) + PCIe-D x1 (PHY4)
++ *   0x11 : PCIe-C x2 (PHY2+PHY3) + USB-D (PHY4)
++ *   0x12 : PCIe-C x1 (PHY2)      + USB-C (PHY3)
++ *   0x13 : PCIe-C x1 (PHY2)      + USB-C (PHY3) + USB-D (PHY4)
++ *   0x14 : PCIe-C x1 (PHY3)      + USB-B (PHY2)
++ *   0x15 : PCIe-C x1 (PHY3)      + USB-B (PHY2) + USB-D (PHY4)
++ *   0x16 : USB-B (PHY2) + USB-C (PHY3) + PCIe D x1 (PHY4)
++ *   0x17 : USB-B (PHY2) + USB-C (PHY3) + USB-D (PHY4)
++ *
++ * So any USB Port B/C/D operation requires PCIe A X8 mode to be disabled.
++ */
++#define PMUA_PCIE_SUBSYS_MGMT		0x1d8
++#define PU_MATRIX_CONF_MASK		GENMASK(4, 0)
++
++#define COMBPHY_MAX_SUBPHYS		6
++
++struct k3_comb_phy {
++	struct device *dev;
++	struct k3_lane_group groups[COMBPHY_MAX_SUBPHYS];
++	void __iomem *base;
++	struct regmap *apb_spare;
++};
++
++static const struct k3_phy_lane_group_data k3_combphy_lane_group0 = {
++	.lanes		= 2,
++	.config		= 0x00,
++	.mask		= 0xff,
++	.offsets	= {
++		0x0, 0x400
++	},
++};
++
++static const struct k3_phy_lane_group_data k3_combphy_lane_group1 = {
++	.lanes		= 2,
++	.config		= 0x00,
++	.mask		= 0xff,
++	.offsets	= {
++		0x100000, 0x100400
++	},
++};
++
++static const struct k3_phy_lane_group_data k3_combphy_lane_group2 = {
++	.lanes		= 1,
++	.config		= 0x14,
++	.mask		= 0x14,
++	.offsets	= {
++		0x200000
++	},
++};
++
++static const struct k3_phy_lane_group_data k3_combphy_lane_group3 = {
++	.lanes		= 1,
++	.config		= 0x12,
++	.mask		= 0x12,
++	.offsets	= {
++		0x300000
++	},
++};
++
++static const struct k3_phy_lane_group_data k3_combphy_lane_group4 = {
++	.lanes		= 1,
++	.config		= 0x11,
++	.mask		= 0x11,
++	.offsets	= {
++		0x400000
++	},
++};
++
++static const struct k3_phy_lane_group_data k3_combphy_lane_group5 = {
++	.lanes		= 1,
++	.config		= 0x00,
++	.mask		= 0xff,
++	.offsets	= {
++		0x500000
++	},
++};
++
++static const struct k3_phy_lane_group_data *k3_combphy_lane_datas[] = {
++	&k3_combphy_lane_group0,
++	&k3_combphy_lane_group1,
++	&k3_combphy_lane_group2,
++	&k3_combphy_lane_group3,
++	&k3_combphy_lane_group4,
++	&k3_combphy_lane_group5,
++};
++
++static int k3_comb_phy_init_lanes(struct k3_comb_phy *phy, unsigned int config)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(k3_combphy_lane_datas); i++) {
++		const struct k3_phy_lane_group_data *data = k3_combphy_lane_datas[i];
++		struct k3_lane_group *lg = &phy->groups[i];
++		const struct phy_ops *ops;
++		bool is_usb;
++
++		is_usb = (data->mask & config) == data->config;
++		if (is_usb)
++			ops = &k3_usb3_phy_ops;
++		else
++			ops = &k3_pcie_phy_ops;
++
++		lg->phy = devm_phy_create(phy->dev, NULL, ops);
++		if (IS_ERR(lg->phy))
++			return PTR_ERR(lg->phy);
++
++		lg->is_pcie = !is_usb;
++		lg->data = data;
++		lg->base = phy->base;
++		phy_set_drvdata(lg->phy, lg);
++	}
++
++	return 0;
++}
++
++static int k3_comb_phy_update_config(struct regmap *apmu, unsigned int config)
++{
++	if (config & ~PU_MATRIX_CONF_MASK)
++		return -EINVAL;
++
++	return regmap_update_bits(apmu, PMUA_PCIE_SUBSYS_MGMT, PU_MATRIX_CONF_MASK, config);
++}
++
++static struct phy *k3_comb_phy_xlate(struct device *dev, const struct of_phandle_args *args)
++{
++	struct k3_comb_phy *phy = dev_get_drvdata(dev);
++	struct k3_lane_group *lg;
++
++	if (args->args_count != 2) {
++		dev_err(dev, "Invalid number of arguments\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	if (args->args[0] >= ARRAY_SIZE(k3_combphy_lane_datas)) {
++		dev_err(dev, "Invalid PHY id\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	lg = &phy->groups[args->args[0]];
++
++	if ((lg->is_pcie && args->args[1] != PHY_TYPE_PCIE) ||
++	    (!lg->is_pcie && args->args[1] != PHY_TYPE_USB3)) {
++		dev_err(dev, "Invalid PHY mode\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	return lg->phy;
++}
++
++static int k3_comb_phy_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct device_node *node = dev->of_node;
++	struct phy_provider *provider;
++	struct k3_comb_phy *phy;
++	struct regmap *apmu;
++	u32 config = 0;
++	int ret;
++
++	phy = devm_kzalloc(dev, sizeof(*phy), GFP_KERNEL);
++	if (!phy)
++		return -ENOMEM;
++
++	phy->base = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(phy->base))
++		return PTR_ERR(phy->base);
++
++	phy->apb_spare = syscon_regmap_lookup_by_phandle(node, "spacemit,apb-spare");
++	if (IS_ERR(phy->apb_spare))
++		return dev_err_probe(dev, PTR_ERR(phy->apb_spare),
++				     "Failed to fine APB SPARE syscon");
++
++	apmu = syscon_regmap_lookup_by_phandle_args(node, "spacemit,apmu", 1, &config);
++	if (IS_ERR(apmu))
++		return dev_err_probe(dev, PTR_ERR(phy->apb_spare),
++				     "Failed to fine APMU syscon");
++
++	ret = k3_comb_phy_update_config(apmu, config);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to set lane configuration");
++
++	phy->dev = dev;
++	platform_set_drvdata(pdev, phy);
++
++	ret = k3_phy_calibrate(phy->apb_spare);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to calibrate phy");
++
++	ret = k3_comb_phy_init_lanes(phy, config);
++	if (ret < 0)
++		return dev_err_probe(dev, ret, "Failed to init lanes");
++
++	provider = devm_of_phy_provider_register(dev, k3_comb_phy_xlate);
++	if (IS_ERR(provider))
++		return dev_err_probe(dev, PTR_ERR(provider),
++				     "Failed to register provider\n");
++
++	return 0;
++}
++
++static const struct of_device_id k3_comb_phy_of_match[] = {
++	{ .compatible = "spacemit,k3-comb-phy" },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, k3_comb_phy_of_match);
++
++static struct platform_driver k3_comb_phy_driver = {
++	.probe = k3_comb_phy_probe,
++	.driver = {
++		.name = "spacemit,k3-comb-phy",
++		.of_match_table = k3_comb_phy_of_match,
++	},
++};
++module_platform_driver(k3_comb_phy_driver);
++
++MODULE_DESCRIPTION("SpacemiT K3 USB3/PCIe comb PHY driver");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/phy/spacemit/phy-k3-common.c b/drivers/phy/spacemit/phy-k3-common.c
+new file mode 100644
+index 000000000000..77c4b4073b96
+--- /dev/null
++++ b/drivers/phy/spacemit/phy-k3-common.c
+@@ -0,0 +1,398 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++#include <linux/bitfield.h>
++#include <linux/cleanup.h>
++#include <linux/io.h>
++#include <linux/iopoll.h>
++#include <linux/module.h>
++#include <linux/regmap.h>
++#include <linux/usb.h>
++
++#include <dt-bindings/phy/phy.h>
++
++#include "phy-k3-common.h"
++
++/* PHY Registers */
++#define PHY_VERSION			0x0
++
++#define PHY_RESET_CFG			0x04
++
++#define PHY_RESET_RXBUF_RST		BIT(0)
++#define PHY_RESET_SOFT_RST_PCS		BIT(1)
++#define PHY_RESET_SOFT_RST_AHB		BIT(2)
++#define PHY_RESET_EN_SD_AFTER_LOCK	BIT(6)
++
++#define PHY_CLK_CFG			0x08
++
++#define PHY_CLK_PLL_READY		BIT(0)
++#define PHY_CLK_TXCLK_INV		BIT(2)
++#define PHY_CLK_RXCLK_EN		BIT(3)
++#define PHY_CLK_TXCLK_EN		BIT(4)
++#define PHY_CLK_PCLK_EN			BIT(5)
++#define PHY_CLK_PIPE_PCLK_EN		BIT(6)
++#define PHY_CLK_REFCLK_FREQ		GENMASK(10, 7)
++#define PHY_CLK_REFCLK_24M		2
++#define PHY_CLK_SW_INIT_DONE		BIT(11)
++#define PHY_CLK_PU_SSC_OUT		BIT(23)
++
++#define PHY_MODE_CFG			0x0C
++
++#define PHY_MODE_PCIE_INT_EN		BIT(0)
++#define PHY_MODE_LFPS_TPERIOD		GENMASK(9, 8)
++#define PHY_MODE_LFPS_TPERIOD_USB	3
++
++#define PHY_PU_SEL			0x40
++
++#define PHY_PU_CFG_STATUS		BIT(9)
++#define PHY_PU_OVRD_STATUS		BIT(10)
++
++#define PHY_PU_CK_REG			0x54
++
++#define PHY_PU_REFCLK_100		BIT(25)
++
++#define PHY_PLL_REG1			0x58
++
++#define PHY_PLL_FREF_SEL		GENMASK(15, 13)
++#define PHY_PLL_FREF_24M		0x1
++#define PHY_PLL_SSC_DEP_SEL		GENMASK(27, 24)
++#define PHY_PLL_SSC_5000PPM		0xa
++#define PHY_PLL_SSC_MODE		GENMASK(29, 28)
++#define PHY_PLL_SSC_MODE_CENTER_SPREAD	0
++#define PHY_PLL_SSC_MODE_UP_SPREAD	1
++#define PHY_PLL_SSC_MODE_DOWN_SPREAD	2
++#define PHY_PLL_SSC_MODE_DOWN_SPREAD1	3
++
++#define PHY_PLL_REG2			0x5c
++
++#define PHY_PLL_SEL_REF100		BIT(21)
++
++/* PHY RX Register Definitions */
++#define PHY_RX_REG_A			0x60
++
++#define PHY_RX_REG0_RLOAD		BIT(4)
++#define PHY_RX_REG1_RTERM		GENMASK(11, 8)
++#define PHY_RX_REG1_RC_CALI		GENMASK(15, 12)
++#define PHY_RX_REG2_CSEL		GENMASK(19, 16)
++#define PHY_RX_REG2_FORCE_CSEL		BIT(20)
++#define PHY_RX_REG2_PSEL		GENMASK(23, 21)
++#define PHY_RX_REG3_I_LOAD		GENMASK(26, 24)
++#define PHY_RX_REG3_SEL_CBOOST_CODE	BIT(27)
++#define PHY_RX_REG3_ADJ_BIAS		GENMASK(29, 28)
++#define PHY_RX_REG3_RDEG1		GENMASK(31, 30)
++
++#define PHY_RX_REG_B			0x64
++
++#define PHY_RX_REGB_MASK		GENMASK(23, 0)
++
++#define PHY_RX_REG4_RDEG2		GENMASK(2, 1)
++#define PHY_RX_REG4_ENVOS		BIT(4)
++#define PHY_RX_REG4_RTERM_SEL		BIT(5)
++#define PHY_RX_REG4_MANUAL_CFG		BIT(7)
++#define PHY_RX_REG5_RCELL_VCM		GENMASK(11, 8)
++#define PHY_RX_REG5_RCELL_BIAS		GENMASK(15, 12)
++#define PHY_RX_REG6_H1_REG		GENMASK(19, 16)
++#define PHY_RX_REG6_ADAPT_GAIN		GENMASK(21, 20)
++#define PHY_RX_REG6_BYPASS_ADPT		BIT(22)
++
++#define PHY_ADPT_CFG0			0x140
++#define PHY_ADPT_AFE_RST_OVRD_EN	BIT(1)
++#define PHY_ADPT_AFE_RST_OVRD_VAL	BIT(4)
++
++#define PHY_RXEQ_TIME			0xb4
++#define PHY_RXEQ_TIME_OVRD_POST_C_SOC	BIT(21)
++#define PHY_RXEQ_TIME_CFG_AMP_SOC	GENMASK(23, 22)
++#define PHY_RXEQ_TIME_AMP_SOC_650M	0
++#define PHY_RXEQ_TIME_AMP_SOC_800M	1
++#define PHY_RXEQ_TIME_AMP_SOC_870M	2
++#define PHY_RXEQ_TIME_AMP_SOC_900M	3
++#define PHY_RXEQ_TIME_OVRD_AMP_SOC	BIT(24)
++
++#define PCIE_PU_ADDR_CLK_CFG		0x0008
++#define PHY_CLK_PLL_READY		BIT(0)
++#define PCIE_INITAL_TIMER		GENMASK(6, 3)
++#define CFG_INTERNAL_TIMER_ADJ		GENMASK(10, 7)
++#define CFG_SW_PHY_INIT_DONE		BIT(11)
++
++/* Lane RX/TX configuration (per‑lane, at lane_base) */
++#define PCIE_RX_REG1			0x050
++#define PCIE_TX_REG1			0x064
++
++#define PCIE_PLL_TIMEOUT		500000
++#define PCIE_POLL_DELAY			500
++
++static int k3_usb3phy_init_single(struct k3_lane_group *lg, void __iomem *base)
++{
++	struct phy *phy = lg->phy;
++	u32 val, tmp;
++	int ret;
++
++	val = readl(base + PHY_PU_SEL);
++	val = u32_replace_bits(val, 0, PHY_PU_CFG_STATUS);
++	val |= PHY_PU_OVRD_STATUS;
++	writel(val, base + PHY_PU_SEL);
++
++	udelay(200);
++
++	/* Do not wait CDR lock before sampling data */
++	val = readl(base + PHY_RESET_CFG);
++	val = u32_replace_bits(val, 0, PHY_RESET_EN_SD_AFTER_LOCK);
++	writel(val, base + PHY_RESET_CFG);
++
++	/* Power down 100MHz refclk buffer */
++	val = readl(base + PHY_PU_CK_REG);
++	val = u32_replace_bits(val, 0, PHY_PU_REFCLK_100);
++	writel(val, base + PHY_PU_CK_REG);
++
++	/* Program PLL REG1 configure the SSC */
++	val = FIELD_PREP(PHY_PLL_SSC_MODE, PHY_PLL_SSC_MODE_DOWN_SPREAD1) |
++	      FIELD_PREP(PHY_PLL_SSC_DEP_SEL, PHY_PLL_SSC_5000PPM) |
++	      FIELD_PREP(PHY_PLL_FREF_SEL, PHY_PLL_FREF_24M);
++	writel(val, base + PHY_PLL_REG1);
++
++	/* Un-select 100MHz PLL reference */
++	val = readl(base + PHY_PLL_REG2);
++	val = u32_replace_bits(val, 0, PHY_PLL_SEL_REF100);
++	writel(val, base + PHY_PLL_REG2);
++
++	/* USB LFPS period configuration */
++	val = readl(base + PHY_MODE_CFG);
++	val = u32_replace_bits(val, PHY_MODE_LFPS_TPERIOD_USB, PHY_MODE_LFPS_TPERIOD);
++	writel(val, base + PHY_MODE_CFG);
++
++	/* Force AFE adaptation reset */
++	val = readl(base + PHY_ADPT_CFG0);
++	val |= PHY_ADPT_AFE_RST_OVRD_EN | PHY_ADPT_AFE_RST_OVRD_VAL;
++	writel(val, base + PHY_ADPT_CFG0);
++
++	/* Override driver amplitude value to 900m */
++	val = readl(base + PHY_RXEQ_TIME);
++	val |= PHY_RXEQ_TIME_OVRD_AMP_SOC;
++	val = u32_replace_bits(val, PHY_RXEQ_TIME_AMP_SOC_900M, PHY_RXEQ_TIME_CFG_AMP_SOC);
++	writel(val, base + PHY_RXEQ_TIME);
++
++	/* Configure RX parameters */
++	val = PHY_RX_REG0_RLOAD |
++		FIELD_PREP(PHY_RX_REG1_RTERM, 0x8) |
++		FIELD_PREP(PHY_RX_REG1_RC_CALI, 0x7) |
++		FIELD_PREP(PHY_RX_REG2_CSEL, 0x8) |
++		PHY_RX_REG2_FORCE_CSEL |
++		FIELD_PREP(PHY_RX_REG2_PSEL, 0x4) |
++		FIELD_PREP(PHY_RX_REG3_I_LOAD, 0x7) |
++		PHY_RX_REG3_SEL_CBOOST_CODE |
++		FIELD_PREP(PHY_RX_REG3_ADJ_BIAS, 0x1) |
++		FIELD_PREP(PHY_RX_REG3_RDEG1, 0x3);
++	writel(val, base + PHY_RX_REG_A);
++
++	val = readl(base + PHY_RX_REG_B);
++	tmp = FIELD_PREP(PHY_RX_REG4_RDEG2, 0x2) |
++		PHY_RX_REG4_ENVOS | PHY_RX_REG4_RTERM_SEL | PHY_RX_REG4_MANUAL_CFG |
++		FIELD_PREP(PHY_RX_REG5_RCELL_VCM, 0x8) |
++		FIELD_PREP(PHY_RX_REG5_RCELL_BIAS, 0x8) |
++		FIELD_PREP(PHY_RX_REG6_H1_REG, 0x8) |
++		FIELD_PREP(PHY_RX_REG6_ADAPT_GAIN, 0x2);
++	val = u32_replace_bits(val, tmp, PHY_RX_REGB_MASK);
++	writel(val, base + PHY_RX_REG_B);
++
++	/*
++	 * Inform PHY that all PLL-related configuration is done.
++	 * PLL will not start locking until PHY_CLK_SW_INIT_DONE is set.
++	 */
++	val = PHY_CLK_SW_INIT_DONE | PHY_CLK_PU_SSC_OUT |
++	      FIELD_PREP(PHY_CLK_REFCLK_FREQ, PHY_CLK_REFCLK_24M) |
++	      PHY_CLK_RXCLK_EN | PHY_CLK_TXCLK_EN |
++	      PHY_CLK_PCLK_EN | PHY_CLK_PIPE_PCLK_EN;
++	writel(val, base + PHY_CLK_CFG);
++
++	ret = readl_poll_timeout(base + PHY_CLK_CFG, val,
++				 (val & PHY_CLK_PLL_READY),
++				 PCIE_POLL_DELAY, PCIE_PLL_TIMEOUT);
++	if (ret) {
++		dev_err(&phy->dev, "PHY PLL polling timeout\n");
++		return ret;
++	}
++
++	return 0;
++}
++
++static int k3_usb3phy_init(struct phy *phy)
++{
++	struct k3_lane_group *lg = phy_get_drvdata(phy);
++	int ret, i;
++
++	for (i = 0; i < lg->data->lanes; i++) {
++		ret = k3_usb3phy_init_single(lg, lg->base + lg->data->offsets[i]);
++		if (ret < 0)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int k3_usb3phy_set_speed(struct phy *phy, int speed)
++{
++	struct k3_lane_group *lg = phy_get_drvdata(phy);
++	void __iomem *base = lg->base + lg->data->offsets[0];
++	u32 val;
++
++	if (speed == USB_SPEED_HIGH) {
++		val = readl(base + PHY_PU_SEL);
++		val = u32_replace_bits(val, 0, PHY_PU_CFG_STATUS);
++		val |= PHY_PU_OVRD_STATUS;
++		writel(val, base + PHY_PU_SEL);
++
++		udelay(200);
++	}
++
++	return 0;
++}
++
++const struct phy_ops k3_usb3_phy_ops = {
++	.init = k3_usb3phy_init,
++	.set_speed = k3_usb3phy_set_speed,
++	.owner = THIS_MODULE,
++};
++EXPORT_SYMBOL_GPL(k3_usb3_phy_ops);
++
++static int k3_pcie_phy_init(struct phy *phy)
++{
++	struct k3_lane_group *lg = phy_get_drvdata(phy);
++	void __iomem *phy_base = lg->base + lg->data->offsets[0];
++	u32 val;
++	int ret;
++	int i;
++
++	val = readl(phy_base + PHY_PLL_REG1);
++	val = u32_replace_bits(val, 0x2, GENMASK(15, 12));
++	writel(val, phy_base + PHY_PLL_REG1);
++
++	val = readl(phy_base + PHY_PLL_REG2);
++	val = u32_replace_bits(val, 0, BIT(21));
++	writel(val, phy_base + PHY_PLL_REG2);
++
++	for (i = 0; i < lg->data->lanes; i++) {
++		void __iomem *lane_base = lg->base + lg->data->offsets[i];
++
++		val = readl(lane_base + PCIE_RX_REG1);
++		val = u32_replace_bits(val, 0, 0x3);
++		writel(val, phy_base + PCIE_RX_REG1);
++	}
++
++	val = readl(phy_base + PHY_PLL_REG2);
++	val |= BIT(20);
++	writel(val, phy_base + PHY_PLL_REG2);
++
++	writel(0x00006505, phy_base + PCIE_RX_REG1);
++
++	/* pll_reg1 of lane0, disable SSC: pll_reg4[3:0] = 0 */
++	val = readl(phy_base + PHY_PLL_REG1);
++	val = u32_replace_bits(val, 0, GENMASK(27, 24));
++	writel(val, phy_base + PHY_PLL_REG1);
++
++	for (i = 0; i < lg->data->lanes; i++) {
++		void __iomem *lane_base = lg->base + lg->data->offsets[i];
++
++		/* set cfg_tx_send_dummy_data to be 1'b1 for disable dash data */
++		val = readl(lane_base + PHY_PU_SEL);
++		val = u32_replace_bits(val, 1, BIT(13));
++		writel(val, lane_base + PHY_PU_SEL);
++
++		/* disable en_sample_data_after_cdr_locked */
++		val = readl(lane_base + PHY_RESET_CFG);
++		val = u32_replace_bits(val, 0, BIT(6));
++		writel(val, lane_base + PHY_RESET_CFG);
++
++		/* Dynamic Lock */
++		val = readl(lane_base + PHY_MODE_CFG);
++		val = u32_replace_bits(val, 1, BIT(2));
++		writel(val, lane_base + PHY_MODE_CFG);
++
++		val = FIELD_PREP(GENMASK(7, 0), 0x10) |
++			FIELD_PREP(GENMASK(15, 8), 0x78) |
++			FIELD_PREP(GENMASK(23, 16), 0x98) |
++			FIELD_PREP(GENMASK(31, 24), 0xdf);
++		writel(val, lane_base + PHY_RX_REG_A);
++
++		val = readl(lane_base + PHY_RX_REG_B);
++		val &= ~PHY_RX_REGB_MASK;
++		val |= FIELD_PREP(GENMASK(7, 0), 0xb4) |
++			FIELD_PREP(GENMASK(15, 8), 0x88) |
++			FIELD_PREP(GENMASK(23, 16), 0x28);
++		writel(val, lane_base + PHY_RX_REG_B);
++
++		/* Set init done */
++		val = readl(lane_base + PCIE_PU_ADDR_CLK_CFG);
++		val = u32_replace_bits(val, 1, CFG_SW_PHY_INIT_DONE);
++		writel(val, lane_base + PCIE_PU_ADDR_CLK_CFG);
++	}
++
++	ret = readl_poll_timeout(phy_base + PCIE_PU_ADDR_CLK_CFG, val,
++				 (val & PHY_CLK_PLL_READY), PCIE_POLL_DELAY,
++				 PCIE_PLL_TIMEOUT);
++	if (ret) {
++		dev_err(&lg->phy->dev, "PHY PLL lock timeout\n");
++		return ret;
++	}
++
++	return 0;
++}
++
++const struct phy_ops k3_pcie_phy_ops = {
++	.init		= k3_pcie_phy_init,
++	.owner		= THIS_MODULE,
++};
++EXPORT_SYMBOL_GPL(k3_pcie_phy_ops);
++
++/* PHY rcal init requires APB_SPARE regmap access */
++
++#define APB_SPARE_PU_CAL		0x178
++#define PU_CAL				BIT(17)
++
++#define APB_SPARE_RCAL_HSIO		0x17c
++#define APB_SPARE_PU_CAL_DONE		BIT(8)
++#define RCAL_OVRD_PTRIM			GENMASK(23, 20)
++#define RCAL_OVRD_NTRIM			GENMASK(27, 24)
++#define RCAL_OVRD_PTRIM_EN		BIT(28)
++#define RCAL_OVRD_NTRIM_EN		BIT(29)
++#define RCAL_OVRD_STABLE_VAL		BIT(30)
++#define RCAL_OVRD_STABLE_EN		BIT(31)
++
++#define RCAL_OVRD_TRIM_EN		(RCAL_OVRD_NTRIM_EN | RCAL_OVRD_PTRIM_EN)
++#define RCAL_OVRD_TRIM_MASK		(RCAL_OVRD_NTRIM | RCAL_OVRD_PTRIM)
++
++#define PU_CAL_TIMEOUT 2000000
++
++static DEFINE_MUTEX(calibrate_lock);
++
++int k3_phy_calibrate(struct regmap *apb_spare)
++{
++	unsigned int val;
++	int ret;
++
++	guard(mutex)(&calibrate_lock);
++
++	regmap_read(apb_spare, APB_SPARE_RCAL_HSIO, &val);
++	if (val & APB_SPARE_PU_CAL_DONE)
++		return 0;
++
++	regmap_update_bits(apb_spare, APB_SPARE_PU_CAL, PU_CAL,
++			   PU_CAL);
++
++	ret = regmap_read_poll_timeout(apb_spare, APB_SPARE_RCAL_HSIO,
++				       val, (val & APB_SPARE_PU_CAL_DONE), PCIE_POLL_DELAY,
++				       PU_CAL_TIMEOUT);
++
++	if (ret)
++		regmap_update_bits(apb_spare, APB_SPARE_RCAL_HSIO,
++				   RCAL_OVRD_TRIM_EN | RCAL_OVRD_STABLE_VAL |
++				   RCAL_OVRD_TRIM_MASK | RCAL_OVRD_STABLE_EN,
++				   RCAL_OVRD_TRIM_EN | RCAL_OVRD_STABLE_VAL |
++				   FIELD_PREP(RCAL_OVRD_NTRIM, 0x6) |
++				   FIELD_PREP(RCAL_OVRD_PTRIM, 0xa) |
++				   RCAL_OVRD_STABLE_EN);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(k3_phy_calibrate);
++
++MODULE_DESCRIPTION("SpacemiT K3 PHY common ops");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/phy/spacemit/phy-k3-common.h b/drivers/phy/spacemit/phy-k3-common.h
+new file mode 100644
+index 000000000000..49009c3c313a
+--- /dev/null
++++ b/drivers/phy/spacemit/phy-k3-common.h
+@@ -0,0 +1,27 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++
++#ifndef _PHY_K3_COMMON_H
++#define _PHY_K3_COMMON_H
++
++#include <linux/phy/phy.h>
++
++struct k3_phy_lane_group_data {
++	u32 lanes;
++	u8 config;
++	u8 mask;
++	u32 offsets[] __counted_by(lanes);
++};
++
++struct k3_lane_group {
++	const struct k3_phy_lane_group_data *data;
++	void __iomem *base;
++	struct phy *phy;
++	bool is_pcie;
++};
++
++extern const struct phy_ops k3_pcie_phy_ops;
++extern const struct phy_ops k3_usb3_phy_ops;
++
++int k3_phy_calibrate(struct regmap *apb_spare);
++
++#endif
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0003-pci-k1-device-data.patch
+++ b/spacemit/k3-pico-itx/patches/0003-pci-k1-device-data.patch
@@ -1,0 +1,110 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 1/5] PCI: spacemit-k1: Add device data support
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Sat, 02 May 2026 18:13:14 +0800
+Message-Id: <20260502101319.2364052-2-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+To reuse the K1 PCIe driver logic for K3 PCIe controller, add device
+data to handle the K1 specific logic and make room for the incoming
+logic for K3.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+---
+ drivers/pci/controller/dwc/pcie-spacemit-k1.c | 35 ++++++++++++++++---
+ 1 file changed, 31 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pcie-spacemit-k1.c b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+index be20a520255b..cd3cd038ad2b 100644
+--- a/drivers/pci/controller/dwc/pcie-spacemit-k1.c
++++ b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+@@ -57,6 +57,13 @@ struct k1_pcie {
+ 	u32 pmu_off;
+ };
+ 
++struct k1_pcie_device_data {
++	const struct dw_pcie_host_ops *host_ops;
++	const struct dw_pcie_ops *ops;
++	int (*parse_port)(struct k1_pcie *k1);
++	int (*post_init)(struct k1_pcie *k1);
++};
++
+ #define to_k1_pcie(dw_pcie) \
+ 		platform_get_drvdata(to_platform_device((dw_pcie)->dev))
+ 
+@@ -278,10 +285,15 @@ static int k1_pcie_parse_port(struct k1_pcie *k1)
+ 
+ static int k1_pcie_probe(struct platform_device *pdev)
+ {
++	const struct k1_pcie_device_data *data;
+ 	struct device *dev = &pdev->dev;
+ 	struct k1_pcie *k1;
+ 	int ret;
+ 
++	data = device_get_match_data(dev);
++	if (!data)
++		return -ENODEV;
++
+ 	k1 = devm_kzalloc(dev, sizeof(*k1), GFP_KERNEL);
+ 	if (!k1)
+ 		return -ENOMEM;
+@@ -299,11 +311,11 @@ static int k1_pcie_probe(struct platform_device *pdev)
+ 				     "failed to map \"link\" registers\n");
+ 
+ 	k1->pci.dev = dev;
+-	k1->pci.ops = &k1_pcie_ops;
++	k1->pci.ops = data->ops;
+ 	k1->pci.pp.num_vectors = MAX_MSI_IRQS;
+ 	dw_pcie_cap_set(&k1->pci, REQ_RES);
+ 
+-	k1->pci.pp.ops = &k1_pcie_host_ops;
++	k1->pci.pp.ops = data->host_ops;
+ 
+ 	/* Hold the PHY in reset until we start the link */
+ 	regmap_set_bits(k1->pmu, k1->pmu_off + PCIE_CLK_RESET_CONTROL,
+@@ -320,7 +332,7 @@ static int k1_pcie_probe(struct platform_device *pdev)
+ 
+ 	platform_set_drvdata(pdev, k1);
+ 
+-	ret = k1_pcie_parse_port(k1);
++	ret = data->parse_port(k1);
+ 	if (ret)
+ 		return dev_err_probe(dev, ret, "failed to parse root port\n");
+ 
+@@ -328,6 +340,15 @@ static int k1_pcie_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		return dev_err_probe(dev, ret, "failed to initialize host\n");
+ 
++	if (data->post_init) {
++		ret = data->post_init(k1);
++		if (ret) {
++			dw_pcie_host_deinit(&k1->pci.pp);
++			return dev_err_probe(dev, ret,
++					     "Failed to post init\n");
++		}
++	}
++
+ 	return 0;
+ }
+ 
+@@ -338,8 +359,14 @@ static void k1_pcie_remove(struct platform_device *pdev)
+ 	dw_pcie_host_deinit(&k1->pci.pp);
+ }
+ 
++static const struct k1_pcie_device_data k1_pcie_device_data = {
++	.host_ops	= &k1_pcie_host_ops,
++	.ops		= &k1_pcie_ops,
++	.parse_port	= k1_pcie_parse_port,
++};
++
+ static const struct of_device_id k1_pcie_of_match_table[] = {
+-	{ .compatible = "spacemit,k1-pcie", },
++	{ .compatible = "spacemit,k1-pcie", .data = &k1_pcie_device_data},
+ 	{ }
+ };
+ 
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0004-pci-k1-multiple-phy-handles.patch
+++ b/spacemit/k3-pico-itx/patches/0004-pci-k1-multiple-phy-handles.patch
@@ -1,0 +1,74 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 2/5] PCI: spacemit-k1: Add multiple phy handles support
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Sat, 02 May 2026 18:13:15 +0800
+Message-Id: <20260502101319.2364052-3-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The PCIe controller on Spacemit K3 may use multiple phys at the
+same time. The feature is not support by the current driver.
+So extend the phy definition to support multiple phy handles.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+---
+ drivers/pci/controller/dwc/pcie-spacemit-k1.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/controller/dwc/pcie-spacemit-k1.c b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+index cd3cd038ad2b..f2a722e5edb5 100644
+--- a/drivers/pci/controller/dwc/pcie-spacemit-k1.c
++++ b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+@@ -51,7 +51,8 @@
+ 
+ struct k1_pcie {
+ 	struct dw_pcie pci;
+-	struct phy *phy;
++	struct phy **phy;
++	int phy_count;
+ 	void __iomem *link;
+ 	struct regmap *pmu;	/* Errors ignored; MMIO-backed regmap */
+ 	u32 pmu_off;
+@@ -172,7 +173,7 @@ static int k1_pcie_init(struct dw_pcie_rp *pp)
+ 	 */
+ 	regmap_set_bits(k1->pmu, reset_ctrl, DEVICE_TYPE_RC | PCIE_AUX_PWR_DET);
+ 
+-	ret = phy_init(k1->phy);
++	ret = phy_init(k1->phy[0]);
+ 	if (ret) {
+ 		k1_pcie_disable_resources(k1);
+ 
+@@ -192,12 +193,14 @@ static void k1_pcie_deinit(struct dw_pcie_rp *pp)
+ {
+ 	struct dw_pcie *pci = to_dw_pcie_from_pp(pp);
+ 	struct k1_pcie *k1 = to_k1_pcie(pci);
++	int i;
+ 
+ 	/* Assert fundamental reset (drive PERST# low) */
+ 	regmap_set_bits(k1->pmu, k1->pmu_off + PCIE_CLK_RESET_CONTROL,
+ 			PCIE_RC_PERST);
+ 
+-	phy_exit(k1->phy);
++	for (i = 0; i < k1->phy_count; i++)
++		phy_exit(k1->phy[i]);
+ 
+ 	k1_pcie_disable_resources(k1);
+ }
+@@ -278,7 +281,12 @@ static int k1_pcie_parse_port(struct k1_pcie *k1)
+ 	if (IS_ERR(phy))
+ 		return PTR_ERR(phy);
+ 
+-	k1->phy = phy;
++	k1->phy = devm_kmalloc_array(dev, sizeof(*k1->phy), 1, GFP_KERNEL);
++	if (IS_ERR(k1->phy))
++		return PTR_ERR(k1->phy);
++
++	k1->phy[0] = phy;
++	k1->phy_count = 1;
+ 
+ 	return 0;
+ }
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0005-dt-bindings-dw-pcie-msi-parent.patch
+++ b/spacemit/k3-pico-itx/patches/0005-dt-bindings-dw-pcie-msi-parent.patch
@@ -1,0 +1,44 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 3/5] dt-bindings: PCI: snps,dw-pcie: Add msi-parent for msi
+ handle check
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Sat, 02 May 2026 18:13:16 +0800
+Message-Id: <20260502101319.2364052-4-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The IMSIC device on RISC-V based system does not require ID
+remapping for MSI. So this device only needs "msi-parent"
+property for IMSIC-based SoC, and the "msi-map" is not a
+necessary property.
+
+Add new condition for msi handling on IMSIC based SoC.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+Acked-by: Rob Herring (Arm) <robh@kernel.org>
+---
+ Documentation/devicetree/bindings/pci/snps,dw-pcie.yaml | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/devicetree/bindings/pci/snps,dw-pcie.yaml b/Documentation/devicetree/bindings/pci/snps,dw-pcie.yaml
+index b3216141881c..6a595207fae1 100644
+--- a/Documentation/devicetree/bindings/pci/snps,dw-pcie.yaml
++++ b/Documentation/devicetree/bindings/pci/snps,dw-pcie.yaml
+@@ -27,8 +27,11 @@ allOf:
+   - $ref: /schemas/pci/snps,dw-pcie-common.yaml#
+   - if:
+       not:
+-        required:
+-          - msi-map
++        oneOf:
++          - required:
++              - msi-map
++          - required:
++              - msi-parent
+     then:
+       properties:
+         interrupt-names:
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0006-dt-bindings-k3-pcie-host.patch
+++ b/spacemit/k3-pico-itx/patches/0006-dt-bindings-k3-pcie-host.patch
@@ -1,0 +1,171 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 4/5] dt-bindings: pci: spacemit: Introduce Spacemit K3 PCIe
+ host controller
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Sat, 02 May 2026 18:13:17 +0800
+Message-Id: <20260502101319.2364052-5-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Add binding support for the PCIe controller on the SpacemiT K3 SoC.
+This controller is almost a standard Synopsys Designware PCIe IP,
+with some extra link and reset state control.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+---
+ .../bindings/pci/spacemit,k3-pcie-host.yaml   | 142 ++++++++++++++++++
+ 1 file changed, 142 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/pci/spacemit,k3-pcie-host.yaml
+
+diff --git a/Documentation/devicetree/bindings/pci/spacemit,k3-pcie-host.yaml b/Documentation/devicetree/bindings/pci/spacemit,k3-pcie-host.yaml
+new file mode 100644
+index 000000000000..be2641526b19
+--- /dev/null
++++ b/Documentation/devicetree/bindings/pci/spacemit,k3-pcie-host.yaml
+@@ -0,0 +1,142 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/pci/spacemit,k3-pcie-host.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: SpacemiT K3 PCI Express Host Controller
++
++maintainers:
++  - Inochi Amaoto <inochiama@gmail.com>
++
++description:
++  The SpacemiT K3 SoC PCIe host controller is based on the Synopsys
++  DesignWare PCIe IP.  The controller uses the external MSI interrupt
++  controller.
++
++allOf:
++  - $ref: /schemas/pci/pci-host-bridge.yaml#
++  - $ref: /schemas/pci/snps,dw-pcie.yaml#
++
++properties:
++  compatible:
++    const: spacemit,k3-pcie
++
++  reg:
++    items:
++      - description: DesignWare PCIe registers
++      - description: Data Bus Interface (DBI) shadow registers
++      - description: ATU address space
++      - description: PCIe configuration space
++      - description: Link control registers
++
++  reg-names:
++    items:
++      - const: dbi
++      - const: dbi2
++      - const: atu
++      - const: config
++      - const: link
++
++  clocks:
++    items:
++      - description: DWC PCIe Data Bus Interface (DBI) clock
++      - description: DWC PCIe application AXI-bus master interface clock
++      - description: DWC PCIe application AXI-bus slave interface clock
++
++  clock-names:
++    items:
++      - const: dbi
++      - const: mstr
++      - const: slv
++
++  resets:
++    items:
++      - description: DWC PCIe Data Bus Interface (DBI) reset
++      - description: DWC PCIe application AXI-bus master interface reset
++      - description: DWC PCIe application AXI-bus slave interface reset
++
++  reset-names:
++    items:
++      - const: dbi
++      - const: mstr
++      - const: slv
++
++  interrupts:
++    items:
++      - description: Interrupt used for port state
++
++  interrupt-names:
++    const: app
++
++  msi-parent: true
++
++  phys:
++    minItems: 1
++    maxItems: 6
++
++  phy-names:
++    minItems: 1
++    maxItems: 6
++
++  spacemit,apmu:
++    $ref: /schemas/types.yaml#/definitions/phandle-array
++    description:
++      A phandle that refers to the APMU system controller, whose regmap is
++      used in managing resets and link state, along with and offset of its
++      reset control register.
++    items:
++      - items:
++          - description: phandle to APMU system controller
++          - description: register offset
++
++required:
++  - clocks
++  - clock-names
++  - resets
++  - reset-names
++  - interrupts
++  - interrupt-names
++  - msi-parent
++  - spacemit,apmu
++
++unevaluatedProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/interrupt-controller/irq.h>
++
++    soc {
++      #address-cells = <2>;
++      #size-cells = <2>;
++
++      pcie@80000000 {
++        compatible = "spacemit,k3-pcie";
++        reg = <0x0  0x80000000 0x0 0x00001000>,
++              <0x0  0x80100000 0x0 0x00001000>,
++              <0x0  0x80300000 0x0 0x00003f20>,
++              <0x11 0x00000000 0x0 0x00010000>,
++              <0x0  0x82900000 0x0 0x00001000>;
++        reg-names = "dbi", "dbi2", "atu", "config", "link";
++        device_type = "pci";
++        #address-cells = <3>;
++        #size-cells = <2>;
++        clocks = <&syscon_apmu 89>,
++                 <&syscon_apmu 56>,
++                 <&syscon_apmu 57>;
++        clock-names = "dbi", "mstr", "slv";
++        interrupts = <141 IRQ_TYPE_LEVEL_HIGH>;
++        interrupt-names = "app";
++        msi-parent = <&simsic>;
++        ranges = <0x01000000 0x00 0x00010000 0x11 0x00010000 0x0 0x00100000>,
++                 <0x02000000 0x0  0x00110000 0x11 0x00110000 0x0 0x7fef0000>,
++                 <0x43000000 0x18 0x00000000 0x18 0x00000000 0x1 0x00000000>;
++        resets = <&syscon_apmu 76>,
++                 <&syscon_apmu 78>,
++                 <&syscon_apmu 77>;
++        reset-names = "dbi", "mstr", "slv";
++        linux,pci-domain = <0>;
++        spacemit,apmu = <&syscon_apmu 0x1f0>;
++      };
++    };
++
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0007-pci-k3-host-controller.patch
+++ b/spacemit/k3-pico-itx/patches/0007-pci-k3-host-controller.patch
@@ -1,0 +1,306 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH 5/5] PCI: spacemit-k1: Add Spacemit K3 PCIe host controller
+ support
+From: Inochi Amaoto <inochiama@gmail.com>
+Date: Sat, 02 May 2026 18:13:18 +0800
+Message-Id: <20260502101319.2364052-6-inochiama@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The PCIe controller on Spacemit K3 is almost a standard Synopsys
+Designware PCIe IP with extra link and reset control. Unlike
+the PCIe controller on K1, this controller supports external MSI
+interrupt controller and can use multiple phy at the same time.
+
+Add driver to support PCIe controller on Spacemit K3 PCIe.
+
+Signed-off-by: Inochi Amaoto <inochiama@gmail.com>
+---
+ drivers/pci/controller/dwc/pcie-spacemit-k1.c | 238 ++++++++++++++++++
+ 1 file changed, 238 insertions(+)
+
+diff --git a/drivers/pci/controller/dwc/pcie-spacemit-k1.c b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+index f2a722e5edb5..fa529ac18f2d 100644
+--- a/drivers/pci/controller/dwc/pcie-spacemit-k1.c
++++ b/drivers/pci/controller/dwc/pcie-spacemit-k1.c
+@@ -23,6 +23,7 @@
+ 
+ #define PCI_VENDOR_ID_SPACEMIT		0x201f
+ #define PCI_DEVICE_ID_SPACEMIT_K1	0x0001
++#define PCI_DEVICE_ID_SPACEMIT_K3	0x0002
+ 
+ /* Offsets and field definitions for link management registers */
+ #define K1_PHY_AHB_IRQ_EN			0x0000
+@@ -32,8 +33,27 @@
+ #define SMLH_LINK_UP			BIT(1)
+ #define RDLH_LINK_UP			BIT(12)
+ 
++#define INTR_STATUS				0x0010
++
+ #define INTR_ENABLE				0x0014
+ #define MSI_CTRL_INT			BIT(11)
++#define RDLH_LINK_UP_INT		BIT(20)
++
++#define K3_PHY_AHB_IRQSTATUS_INTX		0x0008
++
++#define K3_PHY_AHB_IRQENABLE_SET_INTX		0x000c
++#define LEG_EP_INTERRUPTS		(BIT(6) | BIT(7) | BIT(8) | BIT(9))
++
++#define K3_PHY_AHB_IRQENABLE_SET_MSI		0x0014
++/* MSI defined as BIT(11) in existing INTR_ENABLE, reusing */
++
++#define K3_ADDR_INTR_STATUS1			0x0018
++
++#define K3_ADDR_INTR_ENABLE1			0x001C
++#define MSI_INT				BIT(0)
++#define MSIX_INT			GENMASK(8, 1)
++
++#define K3_MAX_PHY_NUMBER		6
+ 
+ /* Some controls require APMU regmap access */
+ #define SYSCON_APMU			"spacemit,apmu"
+@@ -48,6 +68,9 @@
+ 
+ #define PCIE_CONTROL_LOGIC			0x0004
+ #define PCIE_SOFT_RESET			BIT(0)
++#define PCIE_PERSTN_OE			BIT(24)
++#define PCIE_PERSTN_OUT			BIT(25)
++#define PCIE_IGNORE_PERSTN		BIT(31)
+ 
+ struct k1_pcie {
+ 	struct dw_pcie pci;
+@@ -263,6 +286,213 @@ static const struct dw_pcie_ops k1_pcie_ops = {
+ 	.stop_link	= k1_pcie_stop_link,
+ };
+ 
++static int k3_pcie_enable_phy(struct k1_pcie *pcie)
++{
++	int i, ret;
++
++	for (i = 0; i < pcie->phy_count; i++) {
++		ret = phy_init(pcie->phy[i]);
++		if (ret)
++			goto err_phy;
++	}
++
++	return 0;
++
++err_phy:
++	while (--i >= 0)
++		phy_exit(pcie->phy[i]);
++
++	return ret;
++}
++
++static int k3_pcie_init(struct dw_pcie_rp *pp)
++{
++	struct dw_pcie *pci = to_dw_pcie_from_pp(pp);
++	struct k1_pcie *k1 = to_k1_pcie(pci);
++	u32 reset_ctrl = k1->pmu_off + PCIE_CLK_RESET_CONTROL;
++	u32 val;
++	int ret;
++
++	regmap_clear_bits(k1->pmu, reset_ctrl, LTSSM_EN);
++
++	k1_pcie_toggle_soft_reset(k1);
++
++	ret = k1_pcie_enable_resources(k1);
++	if (ret)
++		return ret;
++
++	regmap_set_bits(k1->pmu, reset_ctrl, PCIE_AUX_PWR_DET);
++	regmap_clear_bits(k1->pmu, reset_ctrl, APP_HOLD_PHY_RST);
++
++	ret = k3_pcie_enable_phy(k1);
++	if (ret)
++		return ret;
++
++	/* K3: Set IGNORE_PERSTN and drive PERSTN_OE high (assert reset) */
++	regmap_set_bits(k1->pmu, k1->pmu_off + PCIE_CONTROL_LOGIC,
++			PCIE_IGNORE_PERSTN | PCIE_PERSTN_OE | PCIE_PERSTN_OUT);
++	usleep_range(1000, 2000);
++	regmap_clear_bits(k1->pmu, k1->pmu_off + PCIE_CONTROL_LOGIC, PCIE_PERSTN_OUT);
++
++	mdelay(PCIE_T_PVPERL_MS);
++
++	/*
++	 * Put the controller in root complex mode, and indicate that
++	 * Vaux (3.3v) is present.
++	 */
++	regmap_set_bits(k1->pmu, k1->pmu_off + PCIE_CONTROL_LOGIC,
++			PCIE_PERSTN_OUT | PCIE_PERSTN_OE);
++
++	val = dw_pcie_readl_dbi(pci, GEN3_EQ_CONTROL_OFF);
++	val &= ~(0xffff << 8);
++	val |= ((0x1 << 4) << 8);
++	dw_pcie_writel_dbi(pci, GEN3_EQ_CONTROL_OFF, val);
++
++	/* Set the PCI vendor and device ID */
++	dw_pcie_dbi_ro_wr_en(pci);
++	dw_pcie_writew_dbi(pci, PCI_VENDOR_ID, PCI_VENDOR_ID_SPACEMIT);
++	dw_pcie_writew_dbi(pci, PCI_DEVICE_ID, PCI_DEVICE_ID_SPACEMIT_K3);
++	dw_pcie_dbi_ro_wr_dis(pci);
++
++	/* Finally, as a workaround, disable ASPM L1 */
++	k1_pcie_disable_aspm_l1(k1);
++
++	return 0;
++}
++
++static int k3_pcie_msi_host_init(struct dw_pcie_rp *pp)
++{
++	struct dw_pcie *pci = to_dw_pcie_from_pp(pp);
++	u32 val;
++
++	dw_pcie_dbi_ro_wr_en(pci);
++
++	val = dw_pcie_readl_dbi(pci, COHERENCY_CONTROL_3_OFF);
++	val |= (0xf << 11);
++	dw_pcie_writel_dbi(pci, COHERENCY_CONTROL_3_OFF, val);
++
++	dw_pcie_dbi_ro_wr_dis(pci);
++
++	return 0;
++}
++
++static const struct dw_pcie_host_ops k3_pcie_host_ops = {
++	.init		= k3_pcie_init,
++	.deinit		= k1_pcie_deinit,
++	.msi_init	= k3_pcie_msi_host_init,
++};
++
++static int k3_pcie_start_link(struct dw_pcie *pci)
++{
++	struct k1_pcie *k1 = to_k1_pcie(pci);
++	u32 val;
++
++	k1_pcie_start_link(pci);
++
++	/* Enable INTx */
++	val = readl_relaxed(k1->link + K3_PHY_AHB_IRQENABLE_SET_INTX);
++	val |= LEG_EP_INTERRUPTS;
++	writel_relaxed(val, k1->link + K3_PHY_AHB_IRQENABLE_SET_INTX);
++
++	/* Enable MSI/MSIX specific to K3 */
++	val = readl_relaxed(k1->link + K3_ADDR_INTR_ENABLE1);
++	val |= (MSI_INT | MSIX_INT);
++	writel_relaxed(val, k1->link + K3_ADDR_INTR_ENABLE1);
++
++	return 0;
++}
++
++static const struct dw_pcie_ops k3_pcie_ops = {
++	.link_up	= k1_pcie_link_up,
++	.start_link	= k3_pcie_start_link,
++	.stop_link	= k1_pcie_stop_link,
++};
++
++static void k3_pcie_clear_irq_status(struct k1_pcie *k1,
++				     u32 *status0, u32 *status1, u32 *status2)
++{
++	*status0 = readl_relaxed(k1->link + K3_PHY_AHB_IRQSTATUS_INTX);
++	*status1 = readl_relaxed(k1->link + INTR_STATUS);
++	*status2 = readl_relaxed(k1->link + K3_ADDR_INTR_STATUS1);
++
++	writel_relaxed(*status0, k1->link + K3_PHY_AHB_IRQSTATUS_INTX);
++	writel_relaxed(*status1, k1->link + INTR_STATUS);
++	writel_relaxed(*status2, k1->link + K3_ADDR_INTR_STATUS1);
++}
++
++static int k3_pcie_parse_port(struct k1_pcie *k1)
++{
++	struct device *dev = k1->pci.dev;
++	u32 status0, status1, status2;
++	int i;
++
++	k1->phy = devm_kmalloc_array(dev, sizeof(*k1->phy),
++				     K3_MAX_PHY_NUMBER, GFP_KERNEL);
++	if (IS_ERR(k1->phy))
++		return PTR_ERR(k1->phy);
++
++	for (i = 0; i < K3_MAX_PHY_NUMBER; i++) {
++		k1->phy[i] = devm_of_phy_get_by_index(dev, dev->of_node, i);
++		if (IS_ERR(k1->phy[i])) {
++			if (PTR_ERR(k1->phy[i]) == -ENODEV)
++				break;
++
++			return PTR_ERR(k1->phy[i]);
++		}
++	}
++
++	k1->phy_count = i;
++	if (k1->phy_count == 0)
++		return -EINVAL;
++
++	k3_pcie_clear_irq_status(k1, &status0, &status1, &status2);
++
++	return 0;
++}
++
++static irqreturn_t k3_pcie_irq_thread(int irq, void *data)
++{
++	struct k1_pcie *k1 = data;
++	struct dw_pcie_rp *pp = &k1->pci.pp;
++	struct device *dev = k1->pci.dev;
++	u32 status0, status1, status2;
++
++	k3_pcie_clear_irq_status(k1, &status0, &status1, &status2);
++
++	writel_relaxed(status0, k1->link + K3_PHY_AHB_IRQSTATUS_INTX);
++	writel_relaxed(status1, k1->link + INTR_STATUS);
++	writel_relaxed(status2, k1->link + K3_ADDR_INTR_STATUS1);
++
++	if (FIELD_GET(RDLH_LINK_UP_INT, status1)) {
++		msleep(PCIE_RESET_CONFIG_WAIT_MS);
++		/* Rescan the bus to enumerate endpoint devices */
++		pci_lock_rescan_remove();
++		pci_rescan_bus(pp->bridge->bus);
++		pci_unlock_rescan_remove();
++	} else if (!status0 && !status1 && !status2)
++		dev_WARN_ONCE(dev, true,
++			      "Received unknown event. status0=0x%08x status1=0x%08x status2=0x%08x\n",
++			      status0, status1, status2);
++
++	return IRQ_HANDLED;
++}
++
++static int k3_pcie_post_init(struct k1_pcie *k1)
++{
++	struct device *dev = k1->pci.dev;
++	struct platform_device *pdev = to_platform_device(dev);
++	int irq;
++
++	irq = platform_get_irq_byname_optional(pdev, "app");
++	if (irq > 0) {
++		return devm_request_threaded_irq(dev, irq, NULL,
++						 k3_pcie_irq_thread,
++						 IRQF_ONESHOT, NULL, k1);
++	}
++
++	return 0;
++}
++
+ static int k1_pcie_parse_port(struct k1_pcie *k1)
+ {
+ 	struct device *dev = k1->pci.dev;
+@@ -373,8 +603,16 @@ static const struct k1_pcie_device_data k1_pcie_device_data = {
+ 	.parse_port	= k1_pcie_parse_port,
+ };
+ 
++static const struct k1_pcie_device_data k3_pcie_device_data = {
++	.host_ops	= &k3_pcie_host_ops,
++	.ops		= &k3_pcie_ops,
++	.parse_port	= k3_pcie_parse_port,
++	.post_init	= k3_pcie_post_init,
++};
++
+ static const struct of_device_id k1_pcie_of_match_table[] = {
+ 	{ .compatible = "spacemit,k1-pcie", .data = &k1_pcie_device_data},
++	{ .compatible = "spacemit,k3-pcie", .data = &k3_pcie_device_data},
+ 	{ }
+ };
+ 
+-- 
+2.54.0
+

--- a/spacemit/k3-pico-itx/patches/0008-serial-8250_of-gate-clock.patch
+++ b/spacemit/k3-pico-itx/patches/0008-serial-8250_of-gate-clock.patch
@@ -1,0 +1,38 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] serial: 8250_of: support an optional gate clock
+
+Enable an optional "gate" clock so UARTs whose register access is
+gated by a separate clock (SpacemiT K3 CLK_MPMU_SLOW_UART) work.
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+diff --git a/drivers/tty/serial/8250/8250_of.c b/drivers/tty/serial/8250/8250_of.c
+index 81644d4..a288d2b 100644
+--- a/drivers/tty/serial/8250/8250_of.c
++++ b/drivers/tty/serial/8250/8250_of.c
+@@ -25,6 +25,7 @@
+ struct of_serial_info {
+ 	struct clk *clk;
+ 	struct clk *bus_clk;
++	struct clk *gate_clk;	/* Gate clock for register access (SpacemiT) */
+ 	struct reset_control *rst;
+ 	int type;
+ 	int line;
+@@ -132,6 +133,17 @@ static int of_platform_serial_setup(struct platform_device *ofdev,
+ 			goto err_pmruntime;
+ 		}
+ 
++		/*
++		 * Some platforms (e.g. SpacemiT K3) gate register access behind
++		 * an additional "gate" clock. Without it, MMIO access to the
++		 * UART stalls during port registration. Enable it if present.
++		 */
++		info->gate_clk = devm_clk_get_optional_enabled(dev, "gate");
++		if (IS_ERR(info->gate_clk)) {
++			ret = dev_err_probe(dev, PTR_ERR(info->gate_clk), "failed to get gate clock\n");
++			goto err_pmruntime;
++		}
++
+ 		/* If the bus clock is required, core clock must be named */
+ 		info->clk = devm_clk_get_enabled(dev, bus_clk ? "core" : NULL);
+ 		if (IS_ERR(info->clk)) {

--- a/spacemit/k3-pico-itx/patches/0009-dts-k3-uart0-gate-clock.patch
+++ b/spacemit/k3-pico-itx/patches/0009-dts-k3-uart0-gate-clock.patch
@@ -1,0 +1,21 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] riscv: dts: spacemit: k3: wire uart0 gate clock
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+diff --git a/arch/riscv/boot/dts/spacemit/k3.dtsi b/arch/riscv/boot/dts/spacemit/k3.dtsi
+index 19fc9b4..b0d5a6a 100644
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -682,8 +682,9 @@ uart0: serial@d4017000 {
+ 			reg-shift = <2>;
+ 			reg-io-width = <4>;
+ 			clocks = <&syscon_apbc CLK_APBC_UART0>,
+-				 <&syscon_apbc CLK_APBC_UART0_BUS>;
+-			clock-names = "core", "bus";
++				 <&syscon_apbc CLK_APBC_UART0_BUS>,
++				 <&syscon_mpmu CLK_MPMU_SLOW_UART>;
++			clock-names = "core", "bus", "gate";
+ 			resets = <&syscon_apbc RESET_APBC_UART0>;
+ 			interrupts = <42 IRQ_TYPE_LEVEL_HIGH>;
+ 			status = "disabled";

--- a/spacemit/k3-pico-itx/patches/0010-dts-k3-add-pcie-combphy.patch
+++ b/spacemit/k3-pico-itx/patches/0010-dts-k3-add-pcie-combphy.patch
@@ -1,0 +1,89 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] riscv: dts: spacemit: k3: add comb PHY and PCIe0 nodes
+
+Add combphy and pcie0 (port A x4, M.2 NVMe) nodes and enable them on
+the Pico-ITX. PHY lane config 0x14 = lane-share, A x4, C lane0 USB3.
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+diff --git a/arch/riscv/boot/dts/spacemit/k3-pico-itx.dts b/arch/riscv/boot/dts/spacemit/k3-pico-itx.dts
+index b89c152..56a769a 100644
+--- a/arch/riscv/boot/dts/spacemit/k3-pico-itx.dts
++++ b/arch/riscv/boot/dts/spacemit/k3-pico-itx.dts
+@@ -4,6 +4,7 @@
+  * Copyright (c) 2026 Guodong Xu <guodong@riscstar.com>
+  */
+ #include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/phy/phy.h>
+ 
+ #include "k3.dtsi"
+ #include "k3-pinctrl.dtsi"
+@@ -221,3 +222,14 @@ hub@1 {
+ &usb2_phy {
+ 	status = "okay";
+ };
++
++&combphy {
++	status = "okay";
++};
++
++&pcie0 {
++	phys = <&combphy 0 PHY_TYPE_PCIE>,
++	       <&combphy 1 PHY_TYPE_PCIE>;
++	phy-names = "phy0", "phy1";
++	status = "okay";
++};
+diff --git a/arch/riscv/boot/dts/spacemit/k3.dtsi b/arch/riscv/boot/dts/spacemit/k3.dtsi
+index 19fc9b4..da143aa 100644
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -1099,6 +1099,49 @@ pll: clock-controller@d4090000 {
+ 			#clock-cells = <1>;
+ 		};
+ 
++		combphy: phy@81d00000 {
++			compatible = "spacemit,k3-comb-phy";
++			reg = <0x0 0x81d00000 0x0 0x600000>;
++			#phy-cells = <2>;
++			spacemit,apb-spare = <&pll>;
++			spacemit,apmu = <&syscon_apmu 0x14>;
++			status = "disabled";
++		};
++
++		pcie0: pcie@80000000 {
++			compatible = "spacemit,k3-pcie";
++			reg = <0x0  0x80000000 0x0 0x00001000>,
++			      <0x0  0x80100000 0x0 0x00001000>,
++			      <0x0  0x80300000 0x0 0x00003f20>,
++			      <0x11 0x00000000 0x0 0x00010000>,
++			      <0x0  0x82900000 0x0 0x00001000>;
++			reg-names = "dbi", "dbi2", "atu", "config", "link";
++			device_type = "pci";
++			#address-cells = <3>;
++			#size-cells = <2>;
++			bus-range = <0x00 0xff>;
++			max-link-speed = <3>;
++			num-lanes = <4>;
++			linux,pci-domain = <0>;
++			clocks = <&syscon_apmu CLK_APMU_PCIE_PORTA_DBI>,
++				 <&syscon_apmu CLK_APMU_PCIE_PORTA_MSTE>,
++				 <&syscon_apmu CLK_APMU_PCIE_PORTA_SLV>;
++			clock-names = "dbi", "mstr", "slv";
++			resets = <&syscon_apmu RESET_APMU_PCIE_A_DBI>,
++				 <&syscon_apmu RESET_APMU_PCIE_A_MASTER>,
++				 <&syscon_apmu RESET_APMU_PCIE_A_SLAVE>;
++			reset-names = "dbi", "mstr", "slv";
++			interrupt-parent = <&saplic>;
++			interrupts = <141 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "app";
++			msi-parent = <&simsic>;
++			ranges = <0x01000000 0x00 0x00010000 0x11 0x00010000 0x0 0x00100000>,
++				 <0x02000000 0x0  0x00110000 0x11 0x00110000 0x0 0x7fef0000>,
++				 <0x43000000 0x18 0x00000000 0x18 0x00000000 0x1 0x00000000>;
++			spacemit,apmu = <&syscon_apmu 0x1f0>;
++			status = "disabled";
++		};
++
+ 		syscon_apmu: system-controller@d4282800 {
+ 			compatible = "spacemit,k3-syscon-apmu";
+ 			reg = <0x0 0xd4282800 0x0 0x400>;

--- a/spacemit/k3-pico-itx/patches/0011-dts-k3-reserved-memory.patch
+++ b/spacemit/k3-pico-itx/patches/0011-dts-k3-reserved-memory.patch
@@ -1,0 +1,129 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] riscv: dts: spacemit: k3: add reserved-memory regions
+
+The RCPUs and RPMI/DPU firmware use low RAM (0x100200000-0x101ffffff).
+Without these no-map reservations the kernel allocates there and the
+RCPUs corrupt it (random 0xdeadbeef crashes in early boot). Regions
+match the vendor 6.18 device tree.
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+diff --git a/arch/riscv/boot/dts/spacemit/k3.dtsi b/arch/riscv/boot/dts/spacemit/k3.dtsi
+index 19fc9b4..e41a6be 100644
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -16,6 +16,114 @@ / {
+ 	model = "SpacemiT K3";
+ 	compatible = "spacemit,k3";
+ 
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
++
++		/* RCPU0 (management core) code, data and bss */
++		rcpu0_pwr: rcpu0-pwr@100200000 {
++			reg = <0x1 0x200000 0x0 0x300000>;
++			no-map;
++		};
++
++		/* RCPU0 heap */
++		rcpu0_heap: rcpu0-heap@100500000 {
++			reg = <0x1 0x500000 0x0 0x200000>;
++			no-map;
++		};
++
++		/* RCPU0 vrings */
++		rcpu0_vdev0vring0: vdev0vring0@c0876000 {
++			reg = <0x0 0xc0876000 0x0 0x3000>;
++			no-map;
++		};
++
++		rcpu0_vdev0vring1: vdev0vring1@c0879000 {
++			reg = <0x0 0xc0879000 0x0 0x3000>;
++			no-map;
++		};
++
++		rcpu0_vdev0vring2: vdev0vring2@c087c000 {
++			reg = <0x0 0xc087c000 0x0 0x1000>;
++			no-map;
++		};
++
++		/* RCPU0 shared memory buffer */
++		rcpu0_vdev0buffer: vdev0buffer@100700000 {
++			compatible = "shared-dma-pool";
++			reg = <0x1 0x700000 0x0 0xfc000>;
++			no-map;
++		};
++
++		/* RCPU0 resource table */
++		rcpu0_rsc_table: rcpu0-rsc-table@1007fc000 {
++			reg = <0x1 0x7fc000 0x0 0x4000>;
++			no-map;
++		};
++
++		/* RPMI shared memory (mailbox with platform firmware) */
++		rpmi0: rpmi0@100800000 {
++			reg = <0x1 0x00800000 0x0 0x4000>;
++			no-map;
++		};
++
++		/* RCPU1 code, data and bss */
++		rcpu1_runtime: rcpu1-runtime@100804000 {
++			reg = <0x1 0x804000 0x0 0x300000>;
++			no-map;
++		};
++
++		/* RCPU1 heap */
++		rcpu1_heap: rcpu1-heap@100b04000 {
++			reg = <0x1 0xb04000 0x0 0x200000>;
++			no-map;
++		};
++
++		/* RCPU1 vrings */
++		rcpu1_vdev0vring0: vdev0vring0@c086c000 {
++			reg = <0x0 0xc086c000 0x0 0x3000>;
++			no-map;
++		};
++
++		rcpu1_vdev0vring1: vdev0vring1@c086f000 {
++			reg = <0x0 0xc086f000 0x0 0x3000>;
++			no-map;
++		};
++
++		/* RCPU1 shared memory buffer */
++		rcpu1_vdev0buffer: vdev0buffer@100d04000 {
++			compatible = "shared-dma-pool";
++			reg = <0x1 0xd04000 0x0 0xfc000>;
++			no-map;
++		};
++
++		/* RCPU1 resource table */
++		rcpu1_rsc_table: rcpu1-rsc-table@100e00000 {
++			reg = <0x1 0xe00000 0x0 0x4000>;
++			no-map;
++		};
++
++		/* RCPU DTB space */
++		rcpu_dtb_table: rcpu-dtb-table@100e04000 {
++			reg = <0x1 0xe04000 0x0 0x300000>;
++			no-map;
++		};
++
++		/* DPU: MMU table and command list */
++		dpu_resv0: dpu-reserved@101b00000 {
++			compatible = "shared-dma-pool";
++			reg = <0x1 0x01b00000 0x0 0x00280000>;
++			no-map;
++		};
++
++		dpu_resv1: dpu-reserved1@101d80000 {
++			compatible = "shared-dma-pool";
++			reg = <0x1 0x01d80000 0x0 0x00280000>;
++			no-map;
++		};
++	};
++
+ 	cpus: cpus {
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;

--- a/spacemit/k3-pico-itx/patches/0012-thermal-spacemit-k3.patch
+++ b/spacemit/k3-pico-itx/patches/0012-thermal-spacemit-k3.patch
@@ -1,0 +1,470 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] thermal: spacemit: k3: tsensor support (v2)
+
+Port of the SpacemiT K3 thermal sensor driver with devicetree zones
+(top/vpu/gpu/cluster, critical trip 115C).
+
+v2: review fixes :
+- switch both clocks to devm_clk_get_enabled() (enable results were
+  ignored and the clocks leaked on every probe error path)
+- check the sensor descriptor allocation and the init_sensors()
+  return (required DT properties: on failure the zone loop iterated
+  over an undefined sensor range)
+- check reset_control_deassert() and assert the reset through a devm
+  action so teardown runs in the correct order (zones unregistered
+  before clocks/reset), replacing the mis-ordered remove() callback
+- drop the commented-out IRQ block and reduce the debug bit-toggle
+  sequence to the plain register clear it amounted to
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -16,6 +16,64 @@
+ 	model = "SpacemiT K3";
+ 	compatible = "spacemit,k3";
+ 
++	thermal-zones {
++		top-thermal {
++			polling-delay = <1000>;
++			polling-delay-passive = <500>;
++			thermal-sensors = <&tsensor 0>;
++
++			trips {
++				top-crit {
++					temperature = <115000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
++		};
++
++		vpu-thermal {
++			polling-delay = <1000>;
++			polling-delay-passive = <500>;
++			thermal-sensors = <&tsensor 2>;
++
++			trips {
++				vpu-crit {
++					temperature = <115000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
++		};
++
++		gpu-thermal {
++			polling-delay = <1000>;
++			polling-delay-passive = <500>;
++			thermal-sensors = <&tsensor 3>;
++
++			trips {
++				gpu-crit {
++					temperature = <115000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
++		};
++
++		cluster-thermal {
++			polling-delay = <1000>;
++			polling-delay-passive = <500>;
++			thermal-sensors = <&tsensor 4>;
++
++			trips {
++				cluster-crit {
++					temperature = <115000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
++		};
++	};
++
+ 	reserved-memory {
+ 		#address-cells = <2>;
+ 		#size-cells = <2>;
+@@ -784,6 +842,22 @@
+ 			#reset-cells = <1>;
+ 		};
+ 
++		tsensor: thermal-sensor@d4018000 {
++			compatible = "spacemit,k3-tsensor";
++			reg = <0x0 0xd4018000 0x0 0x100>;
++			interrupt-parent = <&saplic>;
++			interrupts = <61 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "tsensor";
++			clocks = <&syscon_apbc CLK_APBC_TSEN>,
++				 <&syscon_apbc CLK_APBC_TSEN_BUS>;
++			clock-names = "func", "bus";
++			resets = <&syscon_apbc RESET_APBC_TSEN>;
++			sensor_range = <0x0 0x7>;
++			tsensor_map = <1 0 1 1 1 1 1 1>;
++			temperature_offset = <274>;
++			#thermal-sensor-cells = <1>;
++		};
++
+ 		uart0: serial@d4017000 {
+ 			compatible = "spacemit,k3-uart", "intel,xscale-uart";
+ 			reg = <0x0 0xd4017000 0x0 0x100>;
+--- a/drivers/thermal/Kconfig
++++ b/drivers/thermal/Kconfig
+@@ -306,6 +306,15 @@
+ 	  threshold values. The direction of the comparison is configurable
+ 	  (greater / lesser than).
+ 
++config SPACEMIT_K3_THERMAL
++	tristate "SpacemiT K3 thermal sensor support"
++	depends on ARCH_SPACEMIT || COMPILE_TEST
++	depends on OF && HAS_IOMEM
++	help
++	  Enable this to support the thermal sensor (tsensor) block on
++	  the SpacemiT K3 SoC. It exposes on-die temperature sensors as
++	  thermal zones and hwmon devices.
++
+ config K3_THERMAL
+ 	tristate "Texas Instruments K3 thermal support"
+ 	depends on ARCH_K3 || COMPILE_TEST
+--- a/drivers/thermal/Makefile
++++ b/drivers/thermal/Makefile
+@@ -35,6 +35,7 @@
+ thermal_sys-$(CONFIG_PCIE_THERMAL) += pcie_cooling.o
+ 
+ obj-$(CONFIG_K3_THERMAL)	+= k3_bandgap.o k3_j72xx_bandgap.o
++obj-$(CONFIG_SPACEMIT_K3_THERMAL)	+= spacemit-k3-thermal.o
+ # platform thermal drivers
+ obj-y				+= broadcom/
+ obj-$(CONFIG_THERMAL_MMIO)		+= thermal_mmio.o
+--- /dev/null
++++ b/drivers/thermal/spacemit-k3-thermal.c
+@@ -0,0 +1,268 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++#include <linux/cpufreq.h>
++#include <linux/delay.h>
++#include <linux/interrupt.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++#include <linux/io.h>
++#include <linux/of_device.h>
++#include <linux/thermal.h>
++#include <linux/reset.h>
++#include "thermal_hwmon.h"
++#include "thermal_core.h"
++#include "spacemit-k3-thermal.h"
++
++static int init_sensors(struct platform_device *pdev)
++{
++	int ret;
++	unsigned int val;
++	struct k3_thermal_sensor *s = platform_get_drvdata(pdev);
++
++	/* read the sensor range */
++	ret = of_property_read_u32_array(pdev->dev.of_node, "sensor_range", s->sr, 2);
++	if (ret < 0) {
++		dev_err(&pdev->dev, "get sensor range error\n");
++		return ret;
++	}
++
++	if (s->sr[1] >= MAX_SENSOR_NUMBER) {
++		dev_err(&pdev->dev, "un-fitable sensor range\n");
++		return -EINVAL;
++	}
++
++	ret = of_property_read_u32_array(pdev->dev.of_node, "tsensor_map",
++			s->tsen_enable_map, s->sr[1] - s->sr[0] + 1);
++	if (ret) {
++		dev_err(&pdev->dev, "Failed to get definition of tsensor_map\n");
++		return -EINVAL;
++	}
++
++	/* first: disable all the interrupts */
++        writel(0xffffffff, s->base + REG_TSEN_LITE_INT_CLR);
++        writel(0xffffffff, s->base + REG_TSEN_LITE_INT_ENB);
++
++        /* select clk div 26M/4 */
++        val = readl(s->base + REG_TSEN_LITE_CFG);
++        val &= ~BITS_D_CK_DIV_SEL;
++        val |= BITS_CK_DIV_SEL_DIV4;
++
++	/* vref calibration */
++	val &= ~BITS_D_REG_VREF_CTRL;
++	val |= ((CALIB_VREF_DEFAULT & 0xff) << BITS_D_REG_VREF_OFFSET);
++
++        writel(val, s->base + REG_TSEN_LITE_CFG);
++
++	return 0;
++}
++
++static void enable_sensors(struct platform_device *pdev)
++{
++	struct k3_thermal_sensor *s = platform_get_drvdata(pdev);
++
++	writel(readl(s->base + REG_TSEN_LITE_CFG) | BIT_TSEN_EN,
++			s->base + REG_TSEN_LITE_CFG);
++}
++
++static int k3_thermal_get_temp(struct thermal_zone_device *tz, int *temp)
++{
++	struct k3_thermal_sensor_desc *desc = (struct k3_thermal_sensor_desc *)tz->devdata;
++
++	mutex_lock(&desc->ks->lock);
++	/* select which sensor */
++	writel(desc->index, desc->base + REG_TSEN_LITE_CFG2);
++	msleep(1);
++	*temp = readl(desc->base + REG_TSEN_LITE_TEMP_DATA);
++	mutex_unlock(&desc->ks->lock);
++
++	*temp &= BITS_TEMP_DATA;
++	*temp /= TEMP_RAW_DATA_DIV;
++
++	*temp -= desc->temp_offset;
++
++	*temp *= 1000;
++
++	return 0;
++}
++
++/**
++ * static int k3_thermal_set_trips(struct thermal_zone_device *tz, int low, int high)
++ * {
++ *	int index;
++ *	unsigned int temp;
++ *	int over_thrsh = high;
++ *	int under_thrsh = low;
++ *	struct k3_thermal_sensor_desc *desc = (struct k3_thermal_sensor_desc *)tz->devdata;
++ *
++ *	index = desc - desc;
++ *	writel(index, desc->base + REG_TSEN_LITE_CFG2);
++ *
++ *	over_thrsh /= 1000;
++ *	over_thrsh += desc->temp_offset;
++ *	over_thrsh *= TEMP_RAW_DATA_DIV;
++ *
++ *	temp = readl(desc->base + REG_TSEN_LITE_TEMP_THRESH);
++ *	temp &= ~0xffff0000;
++ *	temp |= (over_thrsh << TSEN_HIGH_THRESH_OFFSET);
++ *	writel(temp, desc->base + REG_TSEN_LITE_TEMP_THRESH);
++ *
++ *	if (low < 0)
++ *		under_thrsh = 0;
++ *
++ *	under_thrsh /= 1000;
++ *	under_thrsh += desc->temp_offset;
++ *	under_thrsh *= TEMP_RAW_DATA_DIV;
++ *	temp = readl(desc->base + REG_TSEN_LITE_TEMP_THRESH);
++ *	temp &= ~0xffff;
++ *	temp |= (under_thrsh << TSEN_LOW_THRESH_OFFSET);
++ *	writel(temp, desc->base + REG_TSEN_LITE_TEMP_THRESH);
++ *
++ *	return 0;
++ * }
++ */
++static const struct thermal_zone_device_ops k3_of_thermal_ops = {
++	.get_temp = k3_thermal_get_temp,
++	/* .set_trips = k3_thermal_set_trips, */
++};
++
++/**
++ * static irqreturn_t k3_thermal_irq_thread(int irq, void *data)
++ * {
++ *	struct k3_thermal_sensor_desc *desc = (struct k3_thermal_sensor_desc *)data;
++ *
++ *	thermal_zone_device_update(desc->tzd, THERMAL_EVENT_UNSPECIFIED);
++ *
++ *	return IRQ_HANDLED;
++ * }
++ */
++
++static void k3_thermal_reset_assert(void *data)
++{
++	reset_control_assert(data);
++}
++
++static int k3_thermal_probe(struct platform_device *pdev)
++{
++	unsigned int value;
++	int ret, i;
++	struct resource *res;
++	struct k3_thermal_sensor *s;
++	struct device *dev = &pdev->dev;
++
++	s = devm_kzalloc(dev, sizeof(*s), GFP_KERNEL);
++	if (!s)
++		return -ENOMEM;
++
++	s->dev = dev;
++
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	s->base = devm_ioremap_resource(dev, res);
++	if (IS_ERR(s->base))
++		return PTR_ERR(s->base);
++
++	ret = of_property_read_u32(dev->of_node, "temperature_offset", &s->temp_offset);
++	if (ret) {
++		dev_err(dev, "Get temperature_offset failed\n");
++		return -EINVAL;
++	}
++
++	s->resets = devm_reset_control_get_optional(&pdev->dev, NULL);
++	if (IS_ERR(s->resets))
++		return PTR_ERR(s->resets);
++
++	ret = reset_control_deassert(s->resets);
++	if (ret)
++		return ret;
++
++	ret = devm_add_action_or_reset(dev, k3_thermal_reset_assert, s->resets);
++	if (ret)
++		return ret;
++
++	/*
++	 * devm teardown runs in reverse order: the thermal zones are
++	 * unregistered before the clocks are disabled and the reset is
++	 * asserted, so a late poll can never hit dead hardware.
++	 */
++	s->fclk = devm_clk_get_enabled(dev, "func");
++	if (IS_ERR(s->fclk))
++		return PTR_ERR(s->fclk);
++
++	s->bclk = devm_clk_get_enabled(dev, "bus");
++	if (IS_ERR(s->bclk))
++		return PTR_ERR(s->bclk);
++
++	mutex_init(&s->lock);
++
++	s->sdesc = devm_kcalloc(dev, MAX_SENSOR_NUMBER,
++				sizeof(struct k3_thermal_sensor_desc),
++				GFP_KERNEL);
++	if (!s->sdesc)
++		return -ENOMEM;
++
++	platform_set_drvdata(pdev, s);
++
++	/* initialize the sensors */
++	ret = init_sensors(pdev);
++	if (ret)
++		return ret;
++
++	/* enable the sensors & using auto mode */
++	enable_sensors(pdev);
++
++	/* clear d_en_autozero[25] and d_out_sel[26] */
++	value = readl(s->base);
++	value &= ~((1 << 25) | (1 << 26));
++	writel(value, s->base);
++
++	/* then register the thermal zone */
++	for (i = s->sr[0]; i <= s->sr[1]; ++i) {
++		if (s->tsen_enable_map[i] == 0)
++			continue;
++
++		s->sdesc[i].base = s->base;
++		s->sdesc[i].index = i;
++		s->sdesc[i].ks = s;
++		s->sdesc[i].temp_offset = s->temp_offset;
++		s->sdesc[i].tzd = devm_thermal_of_zone_register(dev,
++				i, s->sdesc + i, &k3_of_thermal_ops);
++		if (IS_ERR(s->sdesc[i].tzd)) {
++			ret = PTR_ERR(s->sdesc[i].tzd);
++			/*
++			 * No thermal zone described in DT for this sensor:
++			 * skip it instead of aborting the whole probe.
++			 */
++			if (ret == -ENODEV) {
++				s->sdesc[i].tzd = NULL;
++				continue;
++			}
++			dev_err(dev, "failed to register sensor id %d: %d\n",
++					i, ret);
++			return ret;
++		}
++
++		/* register the thermal sensor to hwmon */
++		if (devm_thermal_add_hwmon_sysfs(dev, s->sdesc[i].tzd))
++			dev_warn(dev, "Failed to add hwmon sysfs attributes\n");
++	}
++
++	return 0;
++}
++
++static const struct of_device_id of_k3_thermal_match[] = {
++	{
++		.compatible = "spacemit,k3-tsensor",
++	},
++	{ /* end */ }
++};
++
++MODULE_DEVICE_TABLE(of, of_k3_thermal_match);
++
++static struct platform_driver k3_thermal_driver = {
++	.driver = {
++		.name		= "k3_thermal",
++		.of_match_table = of_k3_thermal_match,
++	},
++	.probe	= k3_thermal_probe,
++};
++
++module_platform_driver(k3_thermal_driver);
+--- /dev/null
++++ b/drivers/thermal/spacemit-k3-thermal.h
+@@ -0,0 +1,58 @@
++#ifndef __k3_THERMAL_H__
++#define __k3_THERMAL_H__
++
++#define MAX_SENSOR_NUMBER		8
++#define CALIB_VREF_DEFAULT		(0x9A)
++#define BITS_D_REG_VREF_CTRL		BITS(7, 14)
++#define BITS_D_REG_VREF_OFFSET		(7)
++
++#define BITS(_start, _end) ((BIT(_end) - BIT(_start)) + BIT(_end))
++
++#define MAX_SENSOR_NUMBER		8
++#define TEMPERATURE_OFFSET		278
++
++#define REG_TSEN_LITE_CFG		0x00
++#define REG_TSEN_LITE_CFG2		0x04
++#define REG_TSEN_LITE_INT_ENB		0x08
++#define REG_TSEN_LITE_INT_ST		0x0C
++#define REG_TSEN_LITE_INT_CLR		0x10
++#define REG_TSEN_REBOOT_THRESH		0x14
++#define REG_TSEN_LITE_TEMP_DATA		0x18
++#define REG_TSEN_LITE_VREF_EFFUSE	0x1C
++#define REG_TSEN_LITE_TEMP_THRESH	0x20
++#define REG_TSEN_LITE_ECO_INTVL		0x24
++#define REG_TSEN_LITE_LP_FIX_BYPASS	0x28
++
++#define BITS_D_CK_DIV_SEL		BITS(2, 3)
++#define BITS_TEMP_DATA			BITS(0, 11)
++#define BITS_CK_DIV_SEL_DIV4		(0 << 2)
++#define BIT_TSEN_EN			BIT(0)
++
++#define TSEN_HIGH_THRESH_OFFSET		(0)
++#define TSEN_LOW_THRESH_OFFSET		(16)
++
++#define TEMP_RAW_DATA_DIV		(8)
++
++struct k3_thermal_sensor_desc {
++	void __iomem *base;
++	int temp_offset;
++	int index;
++	struct k3_thermal_sensor *ks;
++	struct thermal_zone_device *tzd;
++};
++
++struct k3_thermal_sensor {
++	int irq;
++	int temp_offset;
++	void __iomem *base;
++	struct clk *fclk, *bclk;
++	struct reset_control *resets;
++	struct device *dev;
++	struct mutex lock;
++	/* sensor range */
++	unsigned int sr[2];
++	struct k3_thermal_sensor_desc *sdesc;
++	unsigned int tsen_enable_map[MAX_SENSOR_NUMBER];
++};
++
++#endif

--- a/spacemit/k3-pico-itx/patches/0013-riscv-cpuinfo-model-name.patch
+++ b/spacemit/k3-pico-itx/patches/0013-riscv-cpuinfo-model-name.patch
@@ -1,0 +1,93 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] riscv: cpuinfo: expose DT cpu model as model name
+
+Lets tools like btop show "Spacemit(R) X100".
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+diff --git a/arch/riscv/boot/dts/spacemit/k3.dtsi b/arch/riscv/boot/dts/spacemit/k3.dtsi
+index 19fc9b4..f776f49 100644
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -23,6 +23,7 @@ cpus: cpus {
+ 
+ 		cpu_0: cpu@0 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <0>;
+ 			riscv,isa-base = "rv64i";
+@@ -64,6 +65,7 @@ cpu0_intc: interrupt-controller {
+ 
+ 		cpu_1: cpu@1 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <1>;
+ 			riscv,isa-base = "rv64i";
+@@ -105,6 +107,7 @@ cpu1_intc: interrupt-controller {
+ 
+ 		cpu_2: cpu@2 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <2>;
+ 			riscv,isa-base = "rv64i";
+@@ -146,6 +149,7 @@ cpu2_intc: interrupt-controller {
+ 
+ 		cpu_3: cpu@3 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <3>;
+ 			riscv,isa-base = "rv64i";
+@@ -187,6 +191,7 @@ cpu3_intc: interrupt-controller {
+ 
+ 		cpu_4: cpu@4 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <4>;
+ 			riscv,isa-base = "rv64i";
+@@ -228,6 +233,7 @@ cpu4_intc: interrupt-controller {
+ 
+ 		cpu_5: cpu@5 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <5>;
+ 			riscv,isa-base = "rv64i";
+@@ -269,6 +275,7 @@ cpu5_intc: interrupt-controller {
+ 
+ 		cpu_6: cpu@6 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <6>;
+ 			riscv,isa-base = "rv64i";
+@@ -310,6 +317,7 @@ cpu6_intc: interrupt-controller {
+ 
+ 		cpu_7: cpu@7 {
+ 			compatible = "spacemit,x100", "riscv";
++			model = "Spacemit(R) X100";
+ 			device_type = "cpu";
+ 			reg = <7>;
+ 			riscv,isa-base = "rv64i";
+diff --git a/arch/riscv/kernel/cpu.c b/arch/riscv/kernel/cpu.c
+index 3dbc8cc..ed0a429 100644
+--- a/arch/riscv/kernel/cpu.c
++++ b/arch/riscv/kernel/cpu.c
+@@ -347,8 +347,13 @@ static int c_show(struct seq_file *m, void *v)
+ 	print_mmu(m);
+ 
+ 	if (acpi_disabled) {
++		const char *model;
++
+ 		node = of_get_cpu_node(cpu_id, NULL);
+ 
++		if (!of_property_read_string(node, "model", &model))
++			seq_printf(m, "model name\t: %s\n", model);
++
+ 		if (!of_property_read_string(node, "compatible", &compat) &&
+ 		    strcmp(compat, "riscv"))
+ 			seq_printf(m, "uarch\t\t: %s\n", compat);

--- a/spacemit/k3-pico-itx/patches/0014-cpufreq-spacemit-k3.patch
+++ b/spacemit/k3-pico-itx/patches/0014-cpufreq-spacemit-k3.patch
@@ -1,0 +1,686 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] cpufreq: spacemit: k3: per-cluster DVFS via cpufreq-dt (v4)
+
+Multi-clock OPP support for the K3 X100 clusters (PLL3/PLL4 switching,
+614 MHz - 2.4 GHz) hooked into cpufreq-dt.
+
+v4: review fixes :
+- cache the PLL clock handles at first transition instead of
+  of_clk_get_by_name() on every frequency change (reference +
+  memory leak in the hot path), drop the dead opp-hz/microvolt scan
+  and its leaked of_node reference
+- serialize the cross-cluster PLL manipulation with a mutex (two
+  policies can transition concurrently)
+- policy notifier: only act on CPUFREQ_CREATE_POLICY, check
+  _find_opp_table() result, drop the opp_table reference
+- fold the redundant nested turbo condition
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -187,9 +187,135 @@
+ 		#size-cells = <0>;
+ 		timebase-frequency = <24000000>;
+ 
++		clst_core_opp_table0_x100: opp_table0_x100 {
++			compatible = "operating-points-v2";
++			opp-shared;
++
++			clocks = <&pll CLK_PLL3>, <&pll CLK_PLL4>, <&pll CLK_PLL3_D1>;
++			clock-names = "pll_clst0", "pll_clst1", "pll_src";
++
++			opp2400000000 {
++				opp-hz = /bits/ 64 <2400000000>, /bits/ 64 <2400000000>;
++				opp-microvolt = <1000000 1000000 1004000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp2300000000 {
++				opp-hz = /bits/ 64 <2300000000>, /bits/ 64 <2300000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp2200000000 {
++				opp-hz = /bits/ 64 <2200000000>, /bits/ 64 <2200000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp2150000000 {
++				opp-hz = /bits/ 64 <2150000000>, /bits/ 64 <2150000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp2100000000 {
++				opp-hz = /bits/ 64 <2100000000>, /bits/ 64 <2100000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp2000000000 {
++				opp-hz = /bits/ 64 <2000000000>, /bits/ 64 <2000000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1900000000 {
++				opp-hz = /bits/ 64 <1900000000>, /bits/ 64 <1900000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1850000000 {
++				opp-hz = /bits/ 64 <1850000000>, /bits/ 64 <1850000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1800000000 {
++				opp-hz = /bits/ 64 <1800000000>, /bits/ 64 <1800000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1700000000 {
++				opp-hz = /bits/ 64 <1700000000>, /bits/ 64 <1700000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1600000000 {
++				opp-hz = /bits/ 64 <1600000000>, /bits/ 64 <1600000000>;
++				opp-microvolt = <880000 880000 884000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1500000000 {
++				opp-hz = /bits/ 64 <1500000000>, /bits/ 64 <1500000000>;
++				opp-microvolt = <850000 850000 854000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1400000000 {
++				opp-hz = /bits/ 64 <1400000000>, /bits/ 64 <1400000000>;
++				opp-microvolt = <850000 850000 854000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1300000000 {
++				opp-hz = /bits/ 64 <1300000000>, /bits/ 64 <1300000000>;
++				opp-microvolt = <850000 850000 854000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1200000000 {
++				opp-hz = /bits/ 64 <1200000000>, /bits/ 64 <1200000000>;
++				opp-microvolt = <850000 850000 854000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1100000000 {
++				opp-hz = /bits/ 64 <1100000000>, /bits/ 64 <1100000000>;
++				opp-microvolt = <850000 850000 854000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp1000000000 {
++				opp-hz = /bits/ 64 <1000000000>, /bits/ 64 <1000000000>;
++				opp-microvolt = <800000 800000 804000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp819000000 {
++				opp-hz = /bits/ 64 <819200000>, /bits/ 64 <819200000>;
++				opp-microvolt = <800000 800000 804000>;
++				clock-latency-ns = <200000>;
++			};
++
++			opp614400000 {
++				opp-hz = /bits/ 64 <614400000>, /bits/ 64 <614400000>;
++				opp-microvolt = <800000 800000 804000>;
++				clock-latency-ns = <200000>;
++			};
++		};
++
+ 		cpu_0: cpu@0 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <0>;
+ 			riscv,isa-base = "rv64i";
+@@ -232,6 +358,10 @@
+ 		cpu_1: cpu@1 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <1>;
+ 			riscv,isa-base = "rv64i";
+@@ -274,6 +404,10 @@
+ 		cpu_2: cpu@2 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <2>;
+ 			riscv,isa-base = "rv64i";
+@@ -316,6 +450,10 @@
+ 		cpu_3: cpu@3 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <3>;
+ 			riscv,isa-base = "rv64i";
+@@ -358,6 +496,10 @@
+ 		cpu_4: cpu@4 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <4>;
+ 			riscv,isa-base = "rv64i";
+@@ -400,6 +542,10 @@
+ 		cpu_5: cpu@5 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <5>;
+ 			riscv,isa-base = "rv64i";
+@@ -442,6 +588,10 @@
+ 		cpu_6: cpu@6 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <6>;
+ 			riscv,isa-base = "rv64i";
+@@ -484,6 +634,10 @@
+ 		cpu_7: cpu@7 {
+ 			compatible = "spacemit,x100", "riscv";
+ 			model = "Spacemit(R) X100";
++			clocks = <&syscon_apmu CLK_APMU_CPU_C0_CORE>,
++				 <&syscon_apmu CLK_APMU_CPU_C1_CORE>;
++			clock-names = "cls0", "cls1";
++			operating-points-v2 = <&clst_core_opp_table0_x100>;
+ 			device_type = "cpu";
+ 			reg = <7>;
+ 			riscv,isa-base = "rv64i";
+--- a/drivers/cpufreq/cpufreq-dt.c
++++ b/drivers/cpufreq/cpufreq-dt.c
+@@ -24,6 +24,7 @@
+ 
+ #include "cpufreq-dt.h"
+ 
++#ifndef CONFIG_SPACEMIT_K3_CPUFREQ
+ struct private_data {
+ 	struct list_head node;
+ 
+@@ -33,9 +34,11 @@
+ 	bool have_static_opps;
+ 	int opp_token;
+ };
++#endif
+ 
+ static LIST_HEAD(priv_list);
+ 
++#ifndef CONFIG_SPACEMIT_K3_CPUFREQ
+ static struct private_data *cpufreq_dt_find_data(int cpu)
+ {
+ 	struct private_data *priv;
+@@ -47,6 +50,24 @@
+ 
+ 	return NULL;
+ }
++#else
++struct private_data *cpufreq_dt_find_data(int cpu)
++{
++	struct private_data *priv;
++
++	list_for_each_entry(priv, &priv_list, node) {
++		if (cpumask_test_cpu(cpu, priv->cpus))
++			return priv;
++	}
++
++	return NULL;
++}
++
++void cpufreq_dt_add_data(struct private_data *priv)
++{
++	list_add(&priv->node, &priv_list);
++}
++#endif
+ 
+ static int set_target(struct cpufreq_policy *policy, unsigned int index)
+ {
+--- a/drivers/cpufreq/cpufreq-dt.h
++++ b/drivers/cpufreq/cpufreq-dt.h
+@@ -24,4 +24,20 @@
+ 
+ struct platform_device *cpufreq_dt_pdev_register(struct device *dev);
+ 
++
++#ifdef CONFIG_SPACEMIT_K3_CPUFREQ
++struct private_data {
++	struct list_head node;
++
++	cpumask_var_t cpus;
++	struct device *cpu_dev;
++	struct cpufreq_frequency_table *freq_table;
++	bool have_static_opps;
++	int opp_token;
++};
++
++struct private_data *cpufreq_dt_find_data(int cpu);
++void cpufreq_dt_add_data(struct private_data *priv);
++#endif
++
+ #endif /* __CPUFREQ_DT_H__ */
+--- a/drivers/cpufreq/Kconfig
++++ b/drivers/cpufreq/Kconfig
+@@ -204,6 +204,18 @@
+ 
+ comment "CPU frequency scaling drivers"
+ 
++config SPACEMIT_K3_CPUFREQ
++	bool "SpacemiT K3 CPU frequency scaling"
++	depends on ARCH_SPACEMIT && OF && COMMON_CLK
++	select CPUFREQ_DT
++	select CPUFREQ_DT_PLATDEV
++	select PM_OPP
++	help
++	  CPU frequency scaling support for the SpacemiT K3 SoC. Works
++	  with cpufreq-dt; a transition notifier reprograms the cluster
++	  PLLs for turbo frequencies. Voltage is left at the firmware
++	  defaults (no regulator scaling).
++
+ config CPUFREQ_DT
+ 	tristate "Generic DT based cpufreq driver"
+ 	depends on HAVE_CLK && OF
+--- a/drivers/cpufreq/Makefile
++++ b/drivers/cpufreq/Makefile
+@@ -15,6 +15,7 @@
+ obj-$(CONFIG_CPU_FREQ_GOV_ATTR_SET)	+= cpufreq_governor_attr_set.o
+ 
+ obj-$(CONFIG_CPUFREQ_DT)		+= cpufreq-dt.o
++obj-$(CONFIG_SPACEMIT_K3_CPUFREQ)	+= spacemit-k3-cpufreq.o
+ obj-$(CONFIG_CPUFREQ_DT_RUST)		+= rcpufreq_dt.o
+ obj-$(CONFIG_CPUFREQ_DT_PLATDEV)	+= cpufreq-dt-platdev.o
+ obj-$(CONFIG_CPUFREQ_VIRT)		+= virtual-cpufreq.o
+--- a/drivers/opp/core.c
++++ b/drivers/opp/core.c
+@@ -94,6 +94,16 @@
+ static bool assert_single_clk(struct opp_table *opp_table,
+ 			      unsigned int __always_unused index)
+ {
++	/*
++	 * Multi-clock OPP tables driven by dev_pm_opp_config_clks_simple
++	 * keep every clock at the rate of the same OPP entry, so
++	 * frequency-based lookups can safely use the first rate.
++	 */
++	if (IS_ENABLED(CONFIG_SPACEMIT_K3_CPUFREQ) &&
++	    opp_table->clk_count > 1 &&
++	    opp_table->config_clks == dev_pm_opp_config_clks_simple)
++		return true;
++
+ 	return !WARN_ON(opp_table->clk_count > 1);
+ }
+ 
+--- /dev/null
++++ b/drivers/cpufreq/spacemit-k3-cpufreq.c
+@@ -0,0 +1,329 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++#include <linux/cpufreq.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/init.h>
++#include <linux/cpumask.h>
++#include <linux/clk/clk-conf.h>
++#include <linux/pm_qos.h>
++#include <linux/notifier.h>
++#include <linux/platform_device.h>
++#include <linux/regulator/consumer.h>
++#include <linux/mutex.h>
++#include <linux/pm_opp.h>
++#include <linux/device.h>
++#include <linux/of.h>
++#include <linux/slab.h>
++#include "../opp/opp.h"
++#include "cpufreq-dt.h"
++
++#define TURBO0_FREQUENCY		(1000000000)
++#define STABLE_FREQUENCY		(819200000)
++
++/* PLL handles cached at first transition (see spacemit_processor_notifier) */
++static DEFINE_MUTEX(spacemit_pll_lock);
++static bool spacemit_plls_cached;
++static struct clk *spacemit_pll_clst0, *spacemit_pll_clst1;
++static struct clk *spacemit_pll_src, *spacemit_clt_pll_src;
++
++static int spacemit_processor_notifier(struct notifier_block *nb,
++                                  unsigned long event, void *data)
++{
++	int cpu;
++	struct device *cpu_dev;
++	struct cpufreq_freqs *freqs = (struct cpufreq_freqs *)data;
++	struct cpufreq_policy *policy = ( struct cpufreq_policy *)freqs->policy;
++	struct opp_table *opp_table;
++	struct clk *pll_clst0, *pll_clst1, *pll_src, *clt_pll_src;
++	int i;
++
++	cpu = cpumask_first(policy->related_cpus);
++	cpu_dev = get_cpu_device(cpu);
++	opp_table = _find_opp_table(cpu_dev);
++	if (IS_ERR_OR_NULL(opp_table))
++		return NOTIFY_DONE;
++
++	/*
++	 * Get the pll clk handles once and cache them: this notifier runs
++	 * on every frequency transition, per-call of_clk_get_by_name()
++	 * would leak a reference each time.
++	 */
++	mutex_lock(&spacemit_pll_lock);
++	if (!spacemit_plls_cached) {
++		spacemit_pll_clst0 = of_clk_get_by_name(opp_table->np, "pll_clst0");
++		spacemit_pll_clst1 = of_clk_get_by_name(opp_table->np, "pll_clst1");
++		spacemit_pll_src = of_clk_get_by_name(opp_table->np, "pll_src");
++		spacemit_clt_pll_src = of_clk_get_by_name(opp_table->np, "clt_pll_src");
++		spacemit_plls_cached = true;
++	}
++	pll_clst0 = spacemit_pll_clst0;
++	pll_clst1 = spacemit_pll_clst1;
++	pll_src = spacemit_pll_src;
++	clt_pll_src = spacemit_clt_pll_src;
++
++	if (event == CPUFREQ_PRECHANGE) {
++
++		if (freqs->new * 1000 > TURBO0_FREQUENCY) {
++			if (freqs->old * 1000 > TURBO0_FREQUENCY) {
++				for (i = 0; i < opp_table->clk_count; ++i)
++					clk_set_rate(opp_table->clks[i], STABLE_FREQUENCY);
++			}
++
++			/* 2.4G */
++			if (!IS_ERR(pll_clst0))
++				clk_set_rate(pll_clst0, freqs->new * 1000);
++			if (!IS_ERR(pll_clst1))
++				clk_set_rate(pll_clst1, freqs->new * 1000);
++		}
++	}
++
++	if (!IS_ERR(clt_pll_src) && !IS_ERR(pll_src))
++		clk_set_parent(clt_pll_src, pll_src);
++
++	if (event == CPUFREQ_POSTCHANGE) {
++		/* TODO */
++	}
++
++	mutex_unlock(&spacemit_pll_lock);
++	dev_pm_opp_put_opp_table(opp_table);
++
++	return 0;
++}
++static struct notifier_block spacemit_processor_notifier_block = {
++       .notifier_call = spacemit_processor_notifier,
++};
++
++static int spacemit_policy_notifier(struct notifier_block *nb,
++                                  unsigned long event, void *data)
++{
++	int cpu;
++	struct device *cpu_dev;
++	struct cpufreq_policy *policy = data;
++	struct opp_table *opp_table;
++
++	if (event != CPUFREQ_CREATE_POLICY)
++		return NOTIFY_DONE;
++
++	cpu = cpumask_first(policy->related_cpus);
++	cpu_dev = get_cpu_device(cpu);
++	opp_table = _find_opp_table(cpu_dev);
++	if (IS_ERR_OR_NULL(opp_table))
++		return NOTIFY_DONE;
++
++	if (policy->clk)
++		clk_put(policy->clk);
++
++	/* cover the policy->clk & opp_table->clk which has been set before */
++	policy->clk = opp_table->clks[0];
++	opp_table->clk = opp_table->clks[0];
++
++	dev_pm_opp_put_opp_table(opp_table);
++
++	return 0;
++}
++
++static struct notifier_block spacemit_policy_notifier_block = {
++       .notifier_call = spacemit_policy_notifier,
++};
++
++static int spacemit_init_cpufreq_table(struct device *dev,
++				       struct cpufreq_frequency_table **table)
++{
++	struct cpufreq_frequency_table *freq_table;
++	struct dev_pm_opp *opp;
++	unsigned long freq;
++	int i, count;
++
++	count = dev_pm_opp_get_opp_count(dev);
++	if (count <= 0)
++		return count ? count : -ENOENT;
++
++	freq_table = kcalloc(count + 1, sizeof(*freq_table), GFP_KERNEL);
++	if (!freq_table)
++		return -ENOMEM;
++
++	for (i = 0, freq = 0; i < count; i++, freq++) {
++		opp = dev_pm_opp_find_freq_ceil_indexed(dev, &freq, 0);
++		if (IS_ERR(opp)) {
++			kfree(freq_table);
++			return PTR_ERR(opp);
++		}
++		freq_table[i].driver_data = i;
++		freq_table[i].frequency = freq / 1000;
++		dev_pm_opp_put(opp);
++	}
++
++	freq_table[i].driver_data = i;
++	freq_table[i].frequency = CPUFREQ_TABLE_END;
++
++	*table = freq_table;
++	return 0;
++}
++
++static int spacemit_dt_cpufreq_pre_early_init(struct device *dev, int cpu)
++{
++	struct private_data *priv;
++	struct device *cpu_dev;
++	const char *reg_name[] = { "clst", NULL };
++	const char *clk_name[] = { "cls0", "cls1", NULL };
++	struct dev_pm_opp_config config = {
++		.regulator_names = reg_name,
++		.clk_names = clk_name,
++		.config_clks = dev_pm_opp_config_clks_simple,
++	};
++	int ret;
++
++	/* Check if this CPU is already covered by some other policy */
++	if (cpufreq_dt_find_data(cpu))
++		return 0;
++
++	cpu_dev = get_cpu_device(cpu);
++	if (!cpu_dev)
++		return -EPROBE_DEFER;
++
++	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	if (!alloc_cpumask_var(&priv->cpus, GFP_KERNEL))
++		return -ENOMEM;
++
++	cpumask_set_cpu(cpu, priv->cpus);
++	priv->cpu_dev = cpu_dev;
++
++	/*
++	 * Mainline DT does not wire the cluster regulator (clst-supply):
++	 * keep the firmware-set voltage and only scale frequency. This is
++	 * safe (never under-volted for the max OPP set by firmware).
++	 */
++	config.regulator_names = NULL;
++	/*
++	 * OPP layer will be taking care of regulators now, but it needs to know
++	 * the name of the regulator first.
++	 */
++	priv->opp_token = dev_pm_opp_set_config(cpu_dev, &config);
++	if (priv->opp_token < 0) {
++		ret = -EPROBE_DEFER;
++		goto free_cpumask;
++	}
++
++	/* Get OPP-sharing information from "operating-points-v2" bindings */
++	ret = dev_pm_opp_of_get_sharing_cpus(cpu_dev, priv->cpus);
++	if (ret)
++		goto out;
++
++	/*
++	 * Initialize OPP tables for all priv->cpus. They will be shared by
++	 * all CPUs which have marked their CPUs shared with OPP bindings.
++	 *
++	 * For platforms not using operating-points-v2 bindings, we do this
++	 * before updating priv->cpus. Otherwise, we will end up creating
++	 * duplicate OPPs for the CPUs.
++	 *
++	 * OPPs might be populated at runtime, don't fail for error here unless
++	 * it is -EPROBE_DEFER.
++	 */
++	ret = dev_pm_opp_of_cpumask_add_table(priv->cpus);
++	if (!ret) {
++		priv->have_static_opps = true;
++	} else if (ret == -EPROBE_DEFER) {
++		goto out;
++	}
++
++	/*
++	 * The OPP table must be initialized, statically or dynamically, by this
++	 * point.
++	 */
++	ret = dev_pm_opp_get_opp_count(cpu_dev);
++	if (ret <= 0) {
++		dev_err(cpu_dev, "OPP table can't be empty\n");
++		ret = -ENODEV;
++		goto out;
++	}
++
++	/*
++	 * dev_pm_opp_init_cpufreq_table() asserts a single clock per OPP
++	 * table; build the table manually using the indexed helpers which
++	 * support multi-clock OPP entries (cls0 + cls1).
++	 */
++	ret = spacemit_init_cpufreq_table(cpu_dev, &priv->freq_table);
++	if (ret) {
++		dev_err(cpu_dev, "failed to init cpufreq table: %d\n", ret);
++		goto out;
++	}
++
++	cpufreq_dt_add_data(priv);
++
++	return 0;
++
++out:
++	if (priv->have_static_opps)
++		dev_pm_opp_of_cpumask_remove_table(priv->cpus);
++	dev_pm_opp_put_regulators(priv->opp_token);
++free_cpumask:
++	free_cpumask_var(priv->cpus);
++	return ret;
++}
++
++static int spacemit_dt_cpufreq_pre_probe(struct platform_device *pdev)
++{
++	int cpu;
++
++	if (strncmp(pdev->name, "cpufreq-dt", 10) != 0)
++		return 0;
++
++	for_each_possible_cpu(cpu)
++		spacemit_dt_cpufreq_pre_early_init(&pdev->dev, cpu);
++
++	return 0;
++}
++
++static int __device_notifier_call(struct notifier_block *nb,
++				      unsigned long event, void *dev)
++{
++	struct platform_device *pdev = to_platform_device(dev);
++
++	switch (event) {
++	case BUS_NOTIFY_REMOVED_DEVICE:
++		break;
++	case BUS_NOTIFY_UNBOUND_DRIVER:
++		break;
++	case BUS_NOTIFY_BIND_DRIVER:
++		/* here */
++		spacemit_dt_cpufreq_pre_probe(pdev);
++		break;
++	case BUS_NOTIFY_ADD_DEVICE:
++		break;
++	default:
++		break;
++	}
++
++	return NOTIFY_DONE;
++}
++
++static struct notifier_block spacemit_platform_nb = {
++	.notifier_call = __device_notifier_call,
++};
++
++static int __init spacemit_processor_driver_init(void)
++{
++       int ret;
++
++	ret = cpufreq_register_notifier(&spacemit_processor_notifier_block, CPUFREQ_TRANSITION_NOTIFIER);
++	if (ret) {
++		pr_err("register cpufreq notifier failed\n");
++		return -EINVAL;
++	}
++
++       ret = cpufreq_register_notifier(&spacemit_policy_notifier_block, CPUFREQ_POLICY_NOTIFIER);
++       if (ret) {
++               pr_err("register cpufreq notifier failed\n");
++               return -EINVAL;
++       }
++
++	bus_register_notifier(&platform_bus_type, &spacemit_platform_nb);
++
++       return 0;
++}
++arch_initcall(spacemit_processor_driver_init);

--- a/spacemit/k3-pico-itx/patches/0015-dts-k3-com260-pcie.patch
+++ b/spacemit/k3-pico-itx/patches/0015-dts-k3-com260-pcie.patch
@@ -1,0 +1,36 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] riscv: dts: spacemit: k3: enable PCIe/NVMe on CoM260-IFX
+
+The CoM260-IFX (BPI-SM10) boots from an NVMe drive on PCIe port A,
+same x4 comb-phy groups 0/1 wiring as the Pico-ITX. Enable combphy
+and pcie0 on this board. (SD host support is being upstreamed
+separately.)
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+--- a/arch/riscv/boot/dts/spacemit/k3-com260-ifx.dts
++++ b/arch/riscv/boot/dts/spacemit/k3-com260-ifx.dts
+@@ -4,6 +4,8 @@
+  * Copyright (c) 2026 Yixun Lan <dlan@kernel.org>
+  */
+ 
++#include <dt-bindings/phy/phy.h>
++
+ #include "k3-com260.dtsi"
+ 
+ / {
+@@ -19,3 +21,14 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ };
++
++&combphy {
++	status = "okay";
++};
++
++&pcie0 {
++	phys = <&combphy 0 PHY_TYPE_PCIE>,
++	       <&combphy 1 PHY_TYPE_PCIE>;
++	phy-names = "phy0", "phy1";
++	status = "okay";
++};

--- a/spacemit/k3-pico-itx/patches/0016-remoteproc-spacemit-k3-rcpu.patch
+++ b/spacemit/k3-pico-itx/patches/0016-remoteproc-spacemit-k3-rcpu.patch
@@ -1,0 +1,952 @@
+From: liberodark <liberodark@gmail.com>
+Subject: [PATCH] remoteproc: spacemit: attach to K3 RCPU (mailbox + rproc)
+
+Port the vendor K3 mailbox and remoteproc drivers (renamed to avoid
+the TI K3 namespace). The RCPU management cores are started by the
+platform firmware; the kernel attaches to RCPU1 and brings up the
+rpmsg link over the vrings already reserved in the device tree. The
+RCPU thermal/fan service only activates once this link is up - without
+it the fan header (FAN_PWM) stays at 0% duty and the fan never spins.
+
+Signed-off-by: liberodark <liberodark@gmail.com>
+---
+--- a/arch/riscv/boot/dts/spacemit/k3.dtsi
++++ b/arch/riscv/boot/dts/spacemit/k3.dtsi
+@@ -1004,6 +1004,24 @@
+ 			#reset-cells = <1>;
+ 		};
+ 
++		mailbox4: mailbox@cac91000 {
++			compatible = "spacemit,k3-mailbox";
++			reg = <0x0 0xcac91000 0x0 0x400>;
++			interrupt-parent = <&saplic>;
++			interrupts = <217 IRQ_TYPE_LEVEL_HIGH>;
++			#mbox-cells = <1>;
++		};
++
++		rcpu1: remoteproc-rcpu1 {
++			compatible = "spacemit,k3-rproc";
++			mboxes = <&mailbox4 0>, <&mailbox4 1>;
++			mbox-names = "vq0", "vq1";
++			firmware-name = "rt24_os1_rcpu.elf";
++			memory-region = <&rcpu1_runtime>, <&rcpu1_heap>,
++					<&rcpu1_vdev0vring0>, <&rcpu1_vdev0buffer>,
++					<&rcpu1_vdev0vring1>, <&rcpu1_rsc_table>;
++		};
++
+ 		tsensor: thermal-sensor@d4018000 {
+ 			compatible = "spacemit,k3-tsensor";
+ 			reg = <0x0 0xd4018000 0x0 0x100>;
+--- a/drivers/mailbox/Kconfig
++++ b/drivers/mailbox/Kconfig
+@@ -221,6 +221,13 @@
+ 
+ 	  If unsure, say N.
+ 
++config SPACEMIT_K3_MAILBOX
++	tristate "SpacemiT K3 mailbox support"
++	depends on ARCH_SPACEMIT || COMPILE_TEST
++	help
++	  Inter-processor mailbox used to communicate with the K3 RCPU
++	  management cores (remoteproc/rpmsg transport).
++
+ config QCOM_APCS_IPC
+ 	tristate "Qualcomm APCS IPC driver"
+ 	depends on ARCH_QCOM || COMPILE_TEST
+--- a/drivers/mailbox/Makefile
++++ b/drivers/mailbox/Makefile
+@@ -84,3 +84,5 @@
+ obj-$(CONFIG_BCM74110_MAILBOX)	+= bcm74110-mailbox.o
+ 
+ obj-$(CONFIG_RISCV_SBI_MPXY_MBOX)	+= riscv-sbi-mpxy-mbox.o
++
++obj-$(CONFIG_SPACEMIT_K3_MAILBOX)	+= spacemit-k3-mailbox.o
+--- a/drivers/remoteproc/Kconfig
++++ b/drivers/remoteproc/Kconfig
+@@ -379,6 +379,18 @@
+ 
+ 	  It's safe to say N if not interested in using RPU r5f cores.
+ 
++config SPACEMIT_K3_RPROC
++	tristate "SpacemiT K3 RCPU remoteproc support"
++	depends on ARCH_SPACEMIT || COMPILE_TEST
++	depends on REMOTEPROC
++	select MAILBOX
++	select SPACEMIT_K3_MAILBOX
++	select RPMSG_VIRTIO
++	help
++	  Attach to the K3 RCPU management cores (started by platform
++	  firmware) and establish the rpmsg link. The RCPU thermal/fan
++	  service activates once the link is up.
++
+ endif # REMOTEPROC
+ 
+ endmenu
+--- a/drivers/remoteproc/Makefile
++++ b/drivers/remoteproc/Makefile
+@@ -40,3 +40,5 @@
+ obj-$(CONFIG_TI_K3_M4_REMOTEPROC)	+= ti_k3_m4_remoteproc.o ti_k3_common.o
+ obj-$(CONFIG_TI_K3_R5_REMOTEPROC)	+= ti_k3_r5_remoteproc.o ti_k3_common.o
+ obj-$(CONFIG_XLNX_R5_REMOTEPROC)	+= xlnx_r5_remoteproc.o
++
++obj-$(CONFIG_SPACEMIT_K3_RPROC)		+= spacemit-k3-rproc.o
+--- /dev/null
++++ b/drivers/mailbox/spacemit-k3-mailbox.c
+@@ -0,0 +1,298 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/bitops.h>
++#include <linux/clk.h>
++#include <linux/device.h>
++#include <linux/err.h>
++#include <linux/interrupt.h>
++#include <linux/io.h>
++#include <linux/kernel.h>
++#include <linux/mailbox_controller.h>
++#include <linux/mailbox_client.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_irq.h>
++#include <linux/platform_device.h>
++#include <linux/reset.h>
++#include <linux/spinlock.h>
++#include <linux/of_address.h>
++#include "spacemit-k3-mailbox.h"
++
++#define mbox_dbg(mbox, ...)	dev_dbg((mbox)->controller.dev, __VA_ARGS__)
++
++static irqreturn_t spacemit_mbox_irq(int irq, void *dev_id)
++{
++	struct spacemit_mailbox *mbox = dev_id;
++	struct mbox_chan *chan;
++	u32 status, msg;
++	int i, j;
++	mbox_msg_status_t mstatus;
++	unsigned long flags;
++
++	spin_lock_irqsave(&mbox->lock, flags);
++
++	status = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status) &
++		 readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_set);
++
++	if (!(status & 0xff)) {
++		spin_unlock_irqrestore(&mbox->lock, flags);
++		return IRQ_HANDLED;
++	}
++
++	for (i = 0; i < SPACEMIT_NUM_CHANNELS; ++i) {
++		chan = &mbox->controller.chans[i];
++
++		/* not full irq */
++		if (status & (1 << (i * 2 + 1))) {
++			/* disable not full irq */
++			j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_clr);
++			j |= (1 << (i * 2 + 1));
++			writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_clr);
++
++			j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status_clr);
++			j |= (1 << (i * 2 + 1));
++			writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status_clr);
++
++			if (chan->txdone_method & MBOX_TXDONE_BY_IRQ)
++				mbox_chan_txdone(chan, 0);
++		}
++
++		/* new msg irq */
++		if (status & (1 << (i * 2))) {
++
++			/* clear the fifo */
++			while (1) {
++				msg = readl((void *)&mbox->regs->mbox_msg[i]);
++				mstatus.val = readl((void *)&mbox->regs->msg_status[i]);
++				if (mstatus.bits.num_msg == 0)
++					break;
++			}
++			mbox_chan_received_data(chan, &msg);
++
++#if 0
++			/* disable the new msg irq */
++			j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_clr);
++			j |= (1 << (i * 2));
++			writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_clr);
++#endif
++			/* clear the irq pending */
++			j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status_clr);
++			j |= (1 << (i * 2));
++			writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status_clr);
++		}
++        }
++
++	spin_unlock_irqrestore(&mbox->lock, flags);
++
++	return IRQ_HANDLED;
++}
++
++static int spacemit_chan_send_data(struct mbox_chan *chan, void *data)
++{
++	int j;
++	unsigned long flags;
++	struct spacemit_mailbox *mbox = chan->con_priv;
++	u32 chan_num = chan - mbox->controller.chans;
++
++	spin_lock_irqsave(&mbox->lock, flags);
++
++#if 0
++	/* disable new msg irq */
++	j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_clr);
++	j |= (1 << (chan_num * 2));
++	writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_clr);
++
++	/* clear pending */
++	j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status_clr);
++	j |= (1 << (chan_num * 2));
++	writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_status_clr);
++#endif
++
++	/* enable the other end new msg irq */
++	j = readl((void *)&mbox->regs->mbox_irq[USER1_MBOX_OFFSET].irq_en_set);
++	j |= (1 << (chan_num * 2));
++	writel(j, (void *)&mbox->regs->mbox_irq[USER1_MBOX_OFFSET].irq_en_set);
++
++        /* send data */
++	writel('c', (void *)&mbox->regs->mbox_msg[chan_num]);
++#if 0
++        /* set other end new msg irq thresh */
++        j = readl((void *)&mbox->regs->mbox_thresh[USER1_MBOX_OFFSET].thresh0);
++        j |= 7 << (chan_num * 8);
++        writel(j, (void *)&mbox->regs->mbox_thresh[USER1_MBOX_OFFSET].thresh0);
++#endif
++	/* set not full thresh */
++	j = readl((void *)&mbox->regs->mbox_thresh[USER0_MBOX_OFFSET].thresh0);
++	j |= 1 << (chan_num * 8 + 4);
++	writel(j, (void *)&mbox->regs->mbox_thresh[USER0_MBOX_OFFSET].thresh0);
++
++	/* enable not full irq */
++	j = readl((void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_set);
++	j |= (1 << (chan_num * 2 + 1));
++	writel(j, (void *)&mbox->regs->mbox_irq[USER0_MBOX_OFFSET].irq_en_set);
++
++	spin_unlock_irqrestore(&mbox->lock, flags);
++
++	return 0;
++}
++
++static int spacemit_chan_startup(struct mbox_chan *chan)
++{
++	struct spacemit_mailbox *mbox = chan->con_priv;
++	u32 chan_num = chan - mbox->controller.chans;
++	u32 msg;
++	mbox_msg_status_t mstatus;
++	unsigned long flags;
++
++	spin_lock_irqsave(&mbox->lock, flags);
++
++	/* clear the fifo */
++	while (1) {
++		mstatus.val = readl((void *)&mbox->regs->msg_status[chan_num]);
++		msg = readl((void *)&mbox->regs->mbox_msg[chan_num]);
++		if (mstatus.bits.num_msg == 0)
++			break;
++	}
++
++	spin_unlock_irqrestore(&mbox->lock, flags);
++
++        return 0;
++}
++
++static void spacemit_chan_shutdown(struct mbox_chan *chan)
++{
++	struct spacemit_mailbox *mbox = chan->con_priv;
++	u32 chan_num = chan - mbox->controller.chans;
++	u32 msg, j;
++	mbox_msg_status_t mstatus;
++	unsigned long flags;
++
++	if (chan->cl->tx_prepare != NULL)
++		return;
++
++	spin_lock_irqsave(&mbox->lock, flags);
++
++	/* disable new msg irq */
++	j = readl((void *)&mbox->regs->mbox_irq[USER1_MBOX_OFFSET].irq_en_clr);
++	j |= (1 << (chan_num * 2));
++	writel(j, (void *)&mbox->regs->mbox_irq[USER1_MBOX_OFFSET].irq_en_clr);
++
++	/* flush the fifo */
++	while (1) {
++		mstatus.val = readl((void *)&mbox->regs->msg_status[chan_num]);
++		msg = readl((void *)&mbox->regs->mbox_msg[chan_num]);
++		if (mstatus.bits.num_msg == 0)
++			break;
++	}
++
++	/* clear pending */
++	j = readl((void *)&mbox->regs->mbox_irq[USER1_MBOX_OFFSET].irq_status_clr);
++	j |= (1 << (chan_num * 2));
++	writel(j, (void *)&mbox->regs->mbox_irq[USER1_MBOX_OFFSET].irq_status_clr);
++
++	spin_unlock_irqrestore(&mbox->lock, flags);
++}
++
++static bool spacemit_chan_last_tx_done(struct mbox_chan *chan)
++{
++	/* TODO */
++	return true;
++}
++
++static bool spacemit_chan_peek_data(struct mbox_chan *chan)
++{
++	struct spacemit_mailbox *mbox = chan->con_priv;
++	u32 chan_num = chan - mbox->controller.chans;
++
++	return readl((void *)&mbox->regs->msg_status[chan_num]);
++}
++
++static const struct mbox_chan_ops spacemit_chan_ops = {
++	.send_data    = spacemit_chan_send_data,
++	.startup      = spacemit_chan_startup,
++	.shutdown     = spacemit_chan_shutdown,
++	.last_tx_done = spacemit_chan_last_tx_done,
++	.peek_data    = spacemit_chan_peek_data,
++};
++
++static int spacemit_mailbox_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct mbox_chan *chans;
++	struct spacemit_mailbox *mbox;
++	int i, ret;
++
++	mbox = devm_kzalloc(dev, sizeof(*mbox), GFP_KERNEL);
++	if (!mbox)
++		return -ENOMEM;
++
++	chans = devm_kcalloc(dev, SPACEMIT_NUM_CHANNELS, sizeof(*chans), GFP_KERNEL);
++	if (!chans)
++		return -ENOMEM;
++
++	for (i = 0; i < SPACEMIT_NUM_CHANNELS; ++i)
++		chans[i].con_priv = mbox;
++
++	mbox->regs = (mbox_reg_desc_t *)of_iomap(pdev->dev.of_node, 0);
++	if (IS_ERR(mbox->regs)) {
++		ret = PTR_ERR(mbox->regs);
++		dev_err(dev, "Failed to map MMIO resource: %d\n", ret);
++		return -EINVAL;
++	}
++
++	mbox->ap_communicate = of_property_read_bool(pdev->dev.of_node, "ap-communicate");
++
++	/* request irq */
++	ret = devm_request_irq(dev, platform_get_irq(pdev, 0),
++			       spacemit_mbox_irq, 0, dev_name(dev), mbox);
++	if (ret) {
++		dev_err(dev, "Failed to register IRQ handler: %d\n", ret);
++		return ret;
++	}
++
++	/* register the mailbox controller */
++	mbox->controller.dev = dev;
++	mbox->controller.ops = &spacemit_chan_ops;
++	mbox->controller.chans = chans;
++	mbox->controller.num_chans = SPACEMIT_NUM_CHANNELS;
++	mbox->controller.txdone_irq = true;
++	mbox->controller.txdone_poll = false;
++	mbox->controller.txpoll_period = 5;
++
++	spin_lock_init(&mbox->lock);
++	platform_set_drvdata(pdev, mbox);
++
++	ret = mbox_controller_register(&mbox->controller);
++	if (ret) {
++		dev_err(dev, "Failed to register controller: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void spacemit_mailbox_remove(struct platform_device *pdev)
++{
++	struct spacemit_mailbox *mbox = platform_get_drvdata(pdev);
++
++	mbox_controller_unregister(&mbox->controller);
++}
++
++static const struct of_device_id spacemit_mailbox_of_match[] = {
++	{ .compatible = "spacemit,k3-mailbox", },
++	{},
++};
++MODULE_DEVICE_TABLE(of, spacemit_mailbox_of_match);
++
++static struct platform_driver spacemit_mailbox_driver = {
++	.driver = {
++		.name = "spacemit-mailbox",
++		.of_match_table = spacemit_mailbox_of_match,
++	},
++	.probe  = spacemit_mailbox_probe,
++	.remove = spacemit_mailbox_remove,
++};
++module_platform_driver(spacemit_mailbox_driver);
++
++MODULE_DESCRIPTION("spacemit Message Box driver");
++MODULE_LICENSE("GPL v2");
+--- /dev/null
++++ b/drivers/mailbox/spacemit-k3-mailbox.h
+@@ -0,0 +1,154 @@
++#ifndef __SPACEMIT_MAILBOX_H__
++#define __SPACEMIT_MAILBOX_H__
++
++#include <linux/kernel.h>
++#include <linux/mailbox_controller.h>
++#include <linux/spinlock.h>
++
++#define SPACEMIT_NUM_CHANNELS	4
++
++/* mailbox register description */
++typedef union mbox_msg {
++	u32 val;
++	struct {
++		u32 msg:32;
++	} bits;
++} mbox_msg_t;
++
++typedef union mbox_fifo_status {
++	u32 val;
++	struct {
++		u32 is_full:1;
++		u32 is_empty:1;
++		u32 reserved0:26;
++		u32 writefull:1;
++		u32 readempty:1;
++		u32 reserved1:2;
++	} bits;
++} mbox_fifo_status_t;
++
++
++typedef union mbox_msg_status {
++	u32 val;
++	struct {
++		u32 num_msg:4;
++		u32 reserved0:24;
++		u32 writefull:1;
++		u32 readempty:1;
++		u32 reserved1:2;
++	} bits;
++} mbox_msg_status_t;
++
++typedef union mbox_irq_status {
++	u32 val;
++	struct {
++		u32 new_msg0_status:1;
++		u32 not_msg0_full:1;
++		u32 new_msg1_status:1;
++		u32 not_msg1_full:1;
++		u32 new_msg2_status:1;
++		u32 not_msg2_full:1;
++		u32 new_msg3_status:1;
++		u32 not_msg3_full:1;
++		u32 reserved:24;
++	} bits;
++} mbox_irq_status_t;
++
++typedef union mbox_irq_status_clr {
++	u32 val;
++	struct {
++		u32 new_msg0_clr:1;
++		u32 not_msg0_full_clr:1;
++		u32 new_msg1_clr:1;
++		u32 not_msg1_full_clr:1;
++		u32 new_msg2_clr:1;
++		u32 not_msg2_full_clr:1;
++		u32 new_msg3_clr:1;
++		u32 not_msg3_full_clr:1;
++		u32 reserved:24;
++	} bits;
++} mbox_irq_status_clr_t;
++
++typedef union mbox_irq_enable_set {
++	u32 val;
++	struct {
++		u32 new_msg0_irq_en:1;
++		u32 not_msg0_full_irq_en:1;
++		u32 new_msg1_irq_en:1;
++		u32 not_msg1_full_irq_en:1;
++		u32 new_msg2_irq_en:1;
++		u32 not_msg2_full_irq_en:1;
++		u32 new_msg3_irq_en:1;
++		u32 not_msg3_full_irq_en:1;
++		u32 reserved:24;
++	} bits;
++} mbox_irq_enable_set_t;
++
++typedef union mbox_irq_enable_clr {
++	u32 val;
++	struct {
++		u32 new_msg0_irq_clr:1;
++		u32 not_msg0_full_irq_clr:1;
++		u32 new_msg1_irq_clr:1;
++		u32 not_msg1_full_irq_clr:1;
++		u32 new_msg2_irq_clr:1;
++		u32 not_msg2_full_irq_clr:1;
++		u32 new_msg3_irq_clr:1;
++		u32 not_msg3_full_irq_clr:1;
++		u32 reserved:24;
++	} bits;
++} mbox_irq_enable_clr_t;
++
++typedef struct mbox_irqthresh {
++	u32 val;
++	struct {
++		u32 mbox0_new_msg_thresh:4;
++		u32 mbox0_not_full_thresh:4;
++		u32 mbox1_new_msg_thresh:4;
++		u32 mbox1_not_full_thresh:4;
++		u32 mbox2_new_msg_thresh:4;
++		u32 mbox2_not_full_thresh:4;
++		u32 mbox3_new_msg_thresh:4;
++		u32 mbox3_not_full_thresh:4;
++	} bits;
++} mbox_irqthresh_t;
++
++typedef struct mbox_thresh {
++	mbox_irqthresh_t thresh0;
++	u32 reserved[3];
++} mbox_thresh_t;
++
++typedef struct mbox_irq {
++	mbox_irq_status_t irq_status;
++	mbox_irq_status_clr_t irq_status_clr;
++	mbox_irq_enable_set_t irq_en_set;
++	mbox_irq_enable_clr_t irq_en_clr;
++} mbox_irq_t;
++
++typedef struct mbox_reg_desc {
++	u32 mbox_version; /* 0x00 */
++	u32 reseved0[3]; /* 0x04 ~ 0x0c */
++	u32 mbox_sysconfig; /* 0x10 */
++	u32 reserved1[11]; /* 0x14 ~ 0x3c */
++	mbox_msg_t mbox_msg[4]; /* 0x40 ~ 0x4c */
++	u32 reserved2[12]; /* 0x50 ~ 0x7c */
++	mbox_fifo_status_t fifo_status[4]; /* 0x80 ~ 0x8c */
++	u32 reserved3[12]; /* 0x90 ~ 0xbc */
++	mbox_msg_status_t msg_status[4]; /* 0xc0 ~ 0xcc */
++	u32 reserved4[12]; /* 0xd0 ~ 0xfc */
++	mbox_irq_t mbox_irq[2]; /* 0x100 ~ 0x11c */
++	u32 reserved5[24]; /* 0x120 ~ 0x17c */
++	mbox_thresh_t mbox_thresh[2]; /* 0x180 */
++} mbox_reg_desc_t;
++
++struct spacemit_mailbox {
++	struct mbox_controller controller;
++	mbox_reg_desc_t *regs;
++	spinlock_t lock;
++	bool ap_communicate;
++};
++
++#define USER0_MBOX_OFFSET ((mbox->ap_communicate) ? 1 : 0)
++#define USER1_MBOX_OFFSET ((mbox->ap_communicate) ? 0 : 1)
++
++#endif /* __SPACEMIT_MAILBOX_H__ */
+--- /dev/null
++++ b/drivers/remoteproc/spacemit-k3-rproc.c
+@@ -0,0 +1,399 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/limits.h>
++#include <linux/module.h>
++#include <linux/io.h>
++#include <linux/regmap.h>
++#include <linux/mfd/syscon.h>
++#include <linux/of_device.h>
++#include <linux/of_reserved_mem.h>
++#include <linux/pm_runtime.h>
++#include <linux/remoteproc.h>
++#include <linux/reset.h>
++#include <linux/clk.h>
++#include <linux/clkdev.h>
++#include <linux/kthread.h>
++#include <linux/clk-provider.h>
++#include <linux/mailbox_client.h>
++#include <linux/completion.h>
++#include <linux/freezer.h>
++#include <linux/firmware.h>
++#include <linux/elf.h>
++#include <uapi/linux/sched/types.h>
++#include <uapi/linux/sched.h>
++#include <linux/sched/prio.h>
++#include <linux/rpmsg.h>
++#include <linux/pm_qos.h>
++#include <linux/delay.h>
++#include <linux/syscore_ops.h>
++#include <linux/fs.h>
++#include <linux/pm_domain.h>
++#include <linux/dma-map-ops.h>
++#include <linux/dma-direction.h>
++#include <linux/suspend.h>
++#include <linux/platform_device.h>
++#include "remoteproc_internal.h"
++#include "remoteproc_elf_helpers.h"
++
++#define MAX_MEM_BASE	2
++#define MAX_MBOX	2
++
++#define K3_MBOX_VQ0_ID	0
++#define K3_MBOX_VQ1_ID	1
++
++struct spacemit_mbox {
++	const char *name;
++	struct mbox_chan *chan;
++	struct mbox_client client;
++	struct task_struct *mb_thread;
++	bool kthread_running;
++	struct completion mb_comp;
++	int vq_id;
++};
++
++struct spacemit_rproc {
++	struct device *dev;
++	struct spacemit_mbox mb[MAX_MBOX];
++	unsigned int size;
++};
++
++static int spacemit_rproc_mem_alloc(struct rproc *rproc, struct rproc_mem_entry *mem)
++{
++	void __iomem *va = NULL;
++
++	dev_dbg(&rproc->dev, "map memory: %pa+%zx\n", &mem->dma, mem->len);
++	va = ioremap(mem->dma, mem->len);
++	if (!va) {
++		dev_err(&rproc->dev, "Unable to map memory region: %pa+%zx\n",
++			&mem->dma, mem->len);
++		return -ENOMEM;
++	}
++
++	/* Update memory entry va */
++	mem->va = va;
++
++	return 0;
++}
++
++static int spacemit_rproc_mem_release(struct rproc *rproc, struct rproc_mem_entry *mem)
++{
++	dev_dbg(&rproc->dev, "unmap memory: %pa\n", &mem->dma);
++
++	iounmap(mem->va);
++
++	return 0;
++}
++
++static int spacemit_rproc_prepare(struct rproc *rproc)
++{
++	struct device *dev = rproc->dev.parent;
++	struct device_node *np = dev->of_node;
++	struct of_phandle_iterator it;
++	struct rproc_mem_entry *mem;
++	struct reserved_mem *rmem;
++	int index = 0;
++
++	/* Register associated reserved memory regions */
++	of_phandle_iterator_init(&it, np, "memory-region", NULL, 0);
++	while (of_phandle_iterator_next(&it) == 0) {
++		rmem = of_reserved_mem_lookup(it.node);
++		if (!rmem) {
++			dev_err(&rproc->dev, "unable to acquire memory-region\n");
++			return -EINVAL;
++		}
++
++		if (rmem->base > U64_MAX) {
++			dev_err(&rproc->dev, "the rmem base is overflow\n");
++			return -EINVAL;
++		}
++
++		mem = rproc_mem_entry_init(dev, NULL,
++					   rmem->base,
++					   rmem->size, rmem->base,
++					   spacemit_rproc_mem_alloc,
++					   spacemit_rproc_mem_release,
++					   it.node->name);
++		if (!mem)
++			return -ENOMEM;
++
++		rproc_add_carveout(rproc, mem);
++		index++;
++	}
++
++	return 0;
++}
++
++static int spacemit_rproc_start(struct rproc *rproc)
++{
++	/* Do nothing: has been latched from spl */
++	return 0;
++}
++
++static int spacemit_rproc_stop(struct rproc *rproc)
++{
++	/* TODO */
++
++	return 0;
++}
++
++static void spacemit_rproc_kick(struct rproc *rproc, int vqid)
++{
++	struct spacemit_rproc *ddata = rproc->priv;
++	unsigned int i;
++	int err;
++
++	if (WARN_ON(vqid >= MAX_MBOX))
++		return;
++
++	for (i = 0; i < MAX_MBOX; i++) {
++		if (vqid != ddata->mb[i].vq_id)
++			continue;
++		if (!ddata->mb[i].chan)
++			return;
++		err = mbox_send_message(ddata->mb[i].chan, "kick");
++		if (err < 0)
++			dev_err(&rproc->dev, "%s: failed (%s, err:%d)\n",
++				__func__, ddata->mb[i].name, err);
++		return;
++	}
++}
++
++static int spacemit_rproc_attach(struct rproc *rproc)
++{
++	return 0;
++}
++
++static int spacemit_rproc_detach(struct rproc *rproc)
++{
++	return 0;
++}
++
++static struct resource_table* spacemit_get_loaded_rsc_table(
++				struct rproc *rproc, size_t *size)
++{
++	struct device *dev = rproc->dev.parent;
++	struct device_node *np = dev->of_node;
++	struct of_phandle_iterator it;
++	struct reserved_mem *rmem;
++
++	/* Register associated reserved memory regions */
++	of_phandle_iterator_init(&it, np, "memory-region", NULL, 0);
++	while (of_phandle_iterator_next(&it) == 0) {
++		rmem = of_reserved_mem_lookup(it.node);
++		if (!rmem) {
++			dev_err(&rproc->dev, "unable to acquire memory-region\n");
++			return NULL;
++		}
++
++		if (rmem->base > U64_MAX) {
++			dev_err(&rproc->dev, "the rmem base is overflow\n");
++			return NULL;
++		}
++
++		if (!strcmp(it.node->name, "rcpu0-rsc-table")) {
++			*size = rmem->size;
++			return (struct resource_table *)ioremap(rmem->base, rmem->size);
++		} else if (!strcmp(it.node->name, "rcpu1-rsc-table")) {
++			*size = rmem->size;
++			return (struct resource_table *)ioremap(rmem->base, rmem->size);
++		}
++	}
++
++	return NULL;
++}
++
++static struct rproc_ops spacemit_rproc_ops = {
++	.prepare	= spacemit_rproc_prepare,
++	.start		= spacemit_rproc_start,
++	.stop		= spacemit_rproc_stop,
++	.attach		= spacemit_rproc_attach,
++	.detach		= spacemit_rproc_detach,
++	.kick		= spacemit_rproc_kick,
++	.get_loaded_rsc_table	= spacemit_get_loaded_rsc_table,
++};
++
++static int __process_theread(void *arg)
++{
++	int ret;
++	struct mbox_client *cl = arg;
++	struct rproc *rproc = dev_get_drvdata(cl->dev);
++	struct spacemit_mbox *mb = container_of(cl, struct spacemit_mbox, client);
++	struct sched_param param = {.sched_priority = 0 };
++
++	mb->kthread_running = true;
++	ret = sched_setscheduler(current, SCHED_FIFO, &param);
++	set_freezable();
++
++	do {
++		try_to_freeze();
++		wait_for_completion_timeout(&mb->mb_comp, 10);
++		if (rproc_vq_interrupt(rproc, mb->vq_id) == IRQ_NONE)
++			dev_dbg(&rproc->dev, "no message found in vq%d\n", mb->vq_id);
++	} while (!kthread_should_stop());
++
++	mb->kthread_running = false;
++
++	return 0;
++}
++static void k3_rproc_mb_callback(struct mbox_client *cl, void *data)
++{
++	struct spacemit_mbox *mb = container_of(cl, struct spacemit_mbox, client);
++
++	complete(&mb->mb_comp);
++}
++
++static int spacemit_rproc_probe(struct platform_device *pdev)
++{
++	int ret, i;
++	const char *name;
++	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
++	const char *fw_name;
++	struct spacemit_rproc *priv;
++	struct mbox_client *cl;
++	struct rproc *rproc;
++
++	ret = rproc_of_parse_firmware(dev, 0, &fw_name);
++	if (ret < 0 && ret != -EINVAL)
++		return ret;
++
++	rproc = devm_rproc_alloc(dev, np->name, &spacemit_rproc_ops,
++				 fw_name, sizeof(*priv));
++	if (!rproc)
++		return -ENOMEM;
++
++	priv = rproc->priv;
++	priv->dev = dev;
++
++	platform_set_drvdata(pdev, rproc);
++
++	/* tx */
++	priv->mb[0].name = "vq0";
++	priv->mb[0].vq_id = K3_MBOX_VQ0_ID;
++	priv->mb[0].client.rx_callback = k3_rproc_mb_callback,
++	priv->mb[0].client.tx_block = true,
++
++	/* rx */
++	priv->mb[1].name = "vq1";
++	priv->mb[1].vq_id = K3_MBOX_VQ1_ID;
++	priv->mb[1].client.rx_callback = k3_rproc_mb_callback,
++	priv->mb[1].client.tx_block = true;
++
++	for (i = 0; i < MAX_MBOX; ++i) {
++		name = priv->mb[i].name;
++
++		cl = &priv->mb[i].client;
++		cl->dev = dev;
++		init_completion(&priv->mb[i].mb_comp);
++
++		priv->mb[i].chan = mbox_request_channel_byname(cl, name);
++		if (IS_ERR(priv->mb[i].chan)) {
++			dev_err(dev, "failed to request mbox channel\n");
++			ret = -EINVAL;
++			goto err_0;
++		}
++
++		if (priv->mb[i].vq_id >= 0) {
++			priv->mb[i].mb_thread = kthread_run(__process_theread, (void *)cl, name);
++			if (IS_ERR(priv->mb[i].mb_thread)) {
++				ret = PTR_ERR(priv->mb[i].mb_thread);
++				goto err_0;
++			}
++		}
++	}
++
++	rproc->auto_boot = true;
++	rproc->state = RPROC_DETACHED; 
++	ret = devm_rproc_add(dev, rproc);
++	if (ret) {
++		dev_err(dev, "rproc_add failed\n");
++		ret = -EINVAL;
++		goto err_0;
++	}
++
++	return 0;
++
++err_0:
++	while (--i >= 0) {
++		if (priv->mb[i].chan)
++			mbox_free_channel(priv->mb[i].chan);
++		if (priv->mb[i].mb_thread)
++			kthread_stop(priv->mb[i].mb_thread);
++	}
++
++	rproc_free(rproc);
++
++	return ret;
++}
++
++static void k3_rproc_free_mbox(struct rproc *rproc)
++{
++	struct spacemit_rproc *ddata = rproc->priv;
++	unsigned int i;
++
++	for (i = 0; i < MAX_MBOX; i++) {
++		if (ddata->mb[i].chan)
++			mbox_free_channel(ddata->mb[i].chan);
++		ddata->mb[i].chan = NULL;
++	}
++}
++
++static void spacemit_rproc_remove(struct platform_device *pdev)
++{
++	int i = 0;
++	struct rproc *rproc = platform_get_drvdata(pdev);
++	struct spacemit_rproc *ddata = rproc->priv;
++
++	for (i = 0; i < MAX_MBOX; ++i)
++		if (ddata->mb[i].kthread_running)
++			kthread_stop(ddata->mb[i].mb_thread);
++
++	rproc_del(rproc);
++	k3_rproc_free_mbox(rproc);
++	rproc_free(rproc);
++}
++
++static const struct of_device_id spacemit_rproc_of_match[] = {
++	{ .compatible = "spacemit,k3-rproc" },
++	{},
++};
++
++MODULE_DEVICE_TABLE(of, spacemit_rproc_of_match);
++
++static void spacemit_rproc_shutdown(struct platform_device *pdev)
++{
++	int i;
++	struct rproc *rproc;
++	struct spacemit_rproc *priv;
++
++	rproc = dev_get_drvdata(&pdev->dev);
++	priv = rproc->priv;
++
++	for (i = 0; i < MAX_MBOX; ++i) {
++		/* release the resource of rt thread */
++		if (priv->mb[i].kthread_running) {
++			if (!frozen((priv->mb[i].mb_thread)))
++				kthread_stop(priv->mb[i].mb_thread);
++		}
++		/* mbox_free_channel(priv->mb[i].chan); */
++	}
++}
++
++static struct platform_driver spacemit_rproc_driver = {
++	.probe = spacemit_rproc_probe,
++	.remove = spacemit_rproc_remove,
++	.shutdown = spacemit_rproc_shutdown,
++	.driver = {
++		.name = "spacemit-rproc",
++		.of_match_table = spacemit_rproc_of_match,
++	},
++};
++
++static __init int spacemit_rproc_driver_init(void)
++{
++	return platform_driver_register(&spacemit_rproc_driver);
++}
++device_initcall(spacemit_rproc_driver_init);
++
++MODULE_LICENSE("GPL v2");
++MODULE_DESCRIPTION("sapcemit remote processor control driver");

--- a/spacemit/k3-pico-itx/sd-image.nix
+++ b/spacemit/k3-pico-itx/sd-image.nix
@@ -33,7 +33,7 @@
   image.fileName = "${config.image.baseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}-k3-pico-itx.img";
 
   sdImage = {
-    expandOnBoot = false;
+    expandOnBoot = true;
     firmwarePartitionOffset = 12;
     firmwarePartitionName = "ESP";
     firmwareSize = 256;


### PR DESCRIPTION
Wait for https://github.com/NixOS/nixos-hardware/pull/1964

###### Description of changes
Move vendor kernel to mainline kernel. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

