### PR TITLE
Added configuration for Lenovo ThinkPad P14s Intel G6

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad P14s Intel Gen 2](lenovo/thinkpad/p14s/intel/gen2)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen2>`      | `lenovo-thinkpad-p14s-intel-gen2`      |
 | [Lenovo ThinkPad P14s Intel Gen 3](lenovo/thinkpad/p14s/intel/gen3)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen3>`      | `lenovo-thinkpad-p14s-intel-gen3`      |
 | [Lenovo ThinkPad P14s Intel Gen 5](lenovo/thinkpad/p14s/intel/gen5)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen5>`      | `lenovo-thinkpad-p14s-intel-gen5`      |
+| [Lenovo ThinkPad P14s Intel Gen 6](lenovo/thinkpad/p14s/intel/gen6)               | `<nixos-hardware/lenovo/thinkpad/p14s/intel/gen6>`      | `lenovo-thinkpad-p14s-intel-gen6`      |
 | [Lenovo ThinkPad P15v Intel Gen 3](lenovo/thinkpad/p15v/intel/gen3)                | `<nixos-hardware/lenovo/thinkpad/p15v/intel/gen3>`      | `lenovo-thinkpad-p15v-intel-gen3`      |
 | [Lenovo ThinkPad P16s AMD Gen 1](lenovo/thinkpad/p16s/amd/gen1)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen1>`        | `lenovo-thinkpad-p16s-amd-gen1`        |
 | [Lenovo ThinkPad P16s AMD Gen 2](lenovo/thinkpad/p16s/amd/gen2)                   | `<nixos-hardware/lenovo/thinkpad/p16s/amd/gen2>`        | `lenovo-thinkpad-p16s-amd-gen2`        |

--- a/flake.nix
+++ b/flake.nix
@@ -273,6 +273,7 @@
           lenovo-thinkpad-p14s-intel-gen2 = import ./lenovo/thinkpad/p14s/intel/gen2;
           lenovo-thinkpad-p14s-intel-gen3 = import ./lenovo/thinkpad/p14s/intel/gen3;
           lenovo-thinkpad-p14s-intel-gen5 = import ./lenovo/thinkpad/p14s/intel/gen5;
+          lenovo-thinkpad-p14s-intel-gen6 = import ./lenovo/thinkpad/p14s/intel/gen6;
           lenovo-thinkpad-p15v-intel-gen3 = import ./lenovo/thinkpad/p15v/intel/gen3;
           lenovo-thinkpad-p16s-amd-gen1 = import ./lenovo/thinkpad/p16s/amd/gen1;
           lenovo-thinkpad-p16s-amd-gen2 = import ./lenovo/thinkpad/p16s/amd/gen2;

--- a/lenovo/thinkpad/p14s/intel/gen6/default.nix
+++ b/lenovo/thinkpad/p14s/intel/gen6/default.nix
@@ -1,0 +1,19 @@
+{ lib, pkgs, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../../common/gpu/nvidia/prime.nix
+    ../../../../../common/gpu/nvidia/blackwell
+  ];
+
+  hardware = {
+    intelgpu.driver = "xe";
+    nvidia = {
+      prime = {
+        intelBusId = "PCI:0:2:0";
+        nvidiaBusId = "PCI:1:0:0";
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Added configuration for Lenovo ThinkPad P14s Intel G6. Compared to G5, we only have newer Intel processors with `xe` drivers and `blackwell` GPUs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

