### PR TITLE
Acer Chromebook Spin 714 (Kano) addition.

### DIFF
--- a/acer/chromebook/cp714-1wn/alsa-ucm-conf-cros.nix
+++ b/acer/chromebook/cp714-1wn/alsa-ucm-conf-cros.nix
@@ -13,6 +13,10 @@ alsa-ucm-conf.overrideAttrs (oldAttrs: {
 
   postInstall = ''
     cp -rf $crosSrc/ucm2 $out/share/alsa/
+
+    mkdir -p $out/share/alsa/ucm2/sof-nau8825
+    cp $crosSrc/ucm2/conf.d/sof-nau8825/HiFi.conf $out/share/alsa/ucm2/sof-nau8825/
+    cp $crosSrc/ucm2/conf.d/sof-nau8825/sof-nau8825.conf $out/share/alsa/ucm2/sof-nau8825/
   '';
 
   meta = oldAttrs.meta // {

--- a/acer/chromebook/cp714-1wn/alsa-ucm-conf-cros.nix
+++ b/acer/chromebook/cp714-1wn/alsa-ucm-conf-cros.nix
@@ -1,0 +1,24 @@
+{
+  alsa-ucm-conf,
+  fetchFromGitHub,
+}:
+
+alsa-ucm-conf.overrideAttrs (oldAttrs: {
+  crosSrc = fetchFromGitHub {
+    owner = "WeirdTreeThing";
+    repo = "alsa-ucm-conf-cros";
+    rev = "a4e92135fd49e669b5ce096439289e05e25ae90c";
+    hash = "sha256-3TpzjmWuOn8+eIdj0BUQk2TeAU7BzPBi3FxAmZ3zkN8=";
+  };
+
+  postInstall = ''
+    cp -rf $crosSrc/ucm2 $out/share/alsa/
+  '';
+
+  meta = oldAttrs.meta // {
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+})

--- a/acer/chromebook/cp714-1wn/default.nix
+++ b/acer/chromebook/cp714-1wn/default.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, ... }:
+
+let
+  alsa-ucm-conf-cros = pkgs.callPackage ./alsa-ucm-conf-cros.nix { };
+in
+{
+  environment.systemPackages = [ alsa-ucm-conf-cros ];
+
+  environment.pathsToLink = [ "/share/alsa" ];
+
+  environment.sessionVariables.ALSA_CONFIG_UCM2 = lib.mkDefault "${alsa-ucm-conf-cros}/share/alsa/ucm2";
+
+  services.pipewire.wireplumber.extraConfig."51-increase-headroom" = {
+    "monitor.alsa.rules" = [
+      {
+        matches = [
+          {
+            "node.name" = "~alsa_output.*";
+          }
+        ];
+        actions = {
+          "update-props" = {
+            "api.alsa.headroom" = 4096;
+          };
+        };
+      }
+    ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
         {
           acer-aspire-4810t = import ./acer/aspire/4810t;
           acer-predator-helios-300-ph315-51 = import ./acer/predator/helios/300/ph315-51;
+          acer-chromebook-cp714-1wn = import ./acer/chromebook/cp714-1wn;
           airis-n990 = import ./airis/n990;
           aoostar-r1-n100 = import ./aoostar/r1/n100;
           apple-imac-12-2 = import ./apple/imac/12-2;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

This PR adds nixos-hardware configuration for the Acer Chromebook Spin 714 cp714-1wn (Board name Kano)

###### TODO
- [x] Add keyd configuration
- [x] Disable TPM - Not needed
- [x] Include common intel module.
- [x] Include laptop module.
- [x] Add `hardware.sensor.iio.enable`
- [x] Investigate adding `libinput.enable`
- [x] nixfmt
- [x] Add device to readme
- [x] Do we need `boot.kernelParams = [ "iomem=relaxed" ];` - Not needed
- [x] Do we need `hardware.enableRedistributableFirmware = lib.mkDefault true;` - Not needed

###### dmesg errors follow up
With the changes already in this PR audio and mic works without any issues for me however dmesg does show these errors:

```
[ 3192.046776] sof-audio-pci-intel-tgl 0000:00:1f.3: sof_ipc3_pcm_hw_params: pcm7 (Bluetooth), dir 0: STREAM_PCM_PARAMS ipc failed for stream_tag 1
[ 3192.046786] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC error (-22): at snd_soc_pcm_component_prepare() on 0000:00:1f.3
[ 3192.048355] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx error for 0x60010000 (msg/reply size: 108/20): -22
[ 3192.048377] sof-audio-pci-intel-tgl 0000:00:1f.3: sof_ipc3_pcm_hw_params: pcm100 (DMIC16kHz), dir 1: STREAM_PCM_PARAMS ipc failed for stream_tag 2
[ 3192.048391] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC error (-22): at snd_soc_pcm_component_prepare() on 0000:00:1f.3
```

Will look into this more once everything this PR is merged with the rest of the TODO.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

