### PR TITLE
raspberry-pi: add wireless firmware to Pi 3 and 5

### DIFF
--- a/raspberry-pi/3/default.nix
+++ b/raspberry-pi/3/default.nix
@@ -35,4 +35,5 @@
     "console=tty0"
   ];
 
+  hardware.firmware = [ (pkgs.callPackage ../common/raspberry-pi-wireless-firmware.nix { }) ];
 }

--- a/raspberry-pi/5/default.nix
+++ b/raspberry-pi/5/default.nix
@@ -49,4 +49,6 @@ in
       message = "The Raspberry Pi 5 requires a newer kernel version (>=6.1.54). Please upgrade nixpkgs for this system.";
     }
   ];
+
+  hardware.firmware = [ (pkgs.callPackage ../common/raspberry-pi-wireless-firmware.nix { }) ];
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Pi 4 already installs nixos-hardware's pinned wireless firmware package. Pi 3 and Pi 5 only received firmware when another module, such as the generic SD image, enabled the broader redistributable firmware set.

Add the same package to both profiles. Systems importing only a board profile now use the 2026-03-21 firmware instead of relying on nixpkgs' older 2025-04-08 package.

cc: @doronbehar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

