### PR TITLE
k3-pico-itx: fix sdcard cross-build

### DIFF
--- a/spacemit/k3-pico-itx/sd-image.nix
+++ b/spacemit/k3-pico-itx/sd-image.nix
@@ -84,13 +84,13 @@
     populateRootCommands = "";
 
     postBuildCommands = ''
-      eval $(${pkgs.util-linux}/bin/partx $img -o START,SECTORS --nr 2 --pairs)
+      eval $(${pkgs.buildPackages.util-linux}/bin/partx $img -o START,SECTORS --nr 2 --pairs)
       ROOTFS_START=$START
       ROOTFS_SECTORS=$SECTORS
 
       truncate -s '+2M' $img
 
-      ${pkgs.util-linux}/bin/sfdisk $img <<EOF
+      ${pkgs.buildPackages.util-linux}/bin/sfdisk $img <<EOF
           label: gpt
           unit: sectors
           sector-size: 512


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Fixes building the sdcard image from a non-riscv64 machine.

cc: @liberodark 

(note, I've also had to do some other workarounds that might be cross-related, I'm not sure yet. Either way, I still think this is a valid/appropriate fix)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

