### PR TITLE
hp/victus/15-fa2724tx: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ See code for all available configurations.
 | [HP Probook 440G5](hp/probook/440G5)                                              | `<nixos-hardware/hp/probook/440G5>`                     | `hp-probook-440G5`                     |
 | [HP Laptop 14s-dq2024nf](hp/laptop/14s-dq2024nf)                                  | `<nixos-hardware/hp/laptop/14s-dq2024nf>`               | `hp-laptop-14s-dq2024nf`               |
 | [HP Probook 460G11](hp/probook/460g11)                                            | `<nixos-hardware/hp/probook/460g11>`                    | `hp-probook-46011`                     |
+| [HP Victus 15-fa2724tx](hp/victus/15-fa2724tx)                                    | `<nixos-hardware/hp/victus/15-fa2724tx>`                | `hp-victus-15-fa2724tx`    |
 | [Huawei Matebook X Pro (2020)](huawei/machc-wa)                                   | `<nixos-hardware/huawei/machc-wa>`                      | `huawei-machc-wa`                      |
 | [i.MX8QuadMax Multisensory Enablement Kit](nxp/imx8qm-mek/)                       | `<nixos-hardware/nxp/imx8qm-mek>`                       | `nxp-imx8qm-mek`                       |
 | [Intel NUC 5i5RYB](intel/nuc/5i5ryb/)                                             | `<nixos-hardware/intel/nuc/5i5ryb>`                     | `intel-nuc-5i5ryb`                     |

--- a/flake.nix
+++ b/flake.nix
@@ -209,6 +209,7 @@
           hp-probook-460G11 = import ./hp/probook/460G11;
           hp-laptop-14s-dq2024nf = import ./hp/laptop/14s-dq2024nf;
           hp-laptop-15s-fq1xxx = import ./hp/laptop/15s-fq1xxx;
+          hp-victus-15-fa2724tx = import ./hp/victus/15-fa2724tx;
           huawei-machc-wa = import ./huawei/machc-wa;
           hp-notebook-14-df0023 = import ./hp/notebook/14-df0023;
           intel-nuc-5i5ryb = import ./intel/nuc/5i5ryb;

--- a/hp/victus/15-fa2724tx/default.nix
+++ b/hp/victus/15-fa2724tx/default.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   imports = [
     ../../../common/cpu/intel/raptor-lake
     ../../../common/gpu/nvidia/ampere

--- a/hp/victus/15-fa2724tx/default.nix
+++ b/hp/victus/15-fa2724tx/default.nix
@@ -1,7 +1,7 @@
 {...}: {
   imports = [
     ../../../common/cpu/intel/raptor-lake
-    ../../../common/gpu/intel/nvidia/ampere
+    ../../../common/gpu/nvidia/ampere
     ../../../common/pc/laptop
     ../../../common/pc/ssd
   ];

--- a/hp/victus/15-fa2724tx/default.nix
+++ b/hp/victus/15-fa2724tx/default.nix
@@ -1,0 +1,8 @@
+{...}: {
+  imports = [
+    ../../../common/cpu/intel/raptor-lake
+    ../../../common/gpu/intel/nvidia/ampere
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+  ];
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Adds HP Victus 15-fa2724tx. (Also initializes the hp/victus folder)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

