### PR TITLE
Add Lenovo Thinkpad E14 Gen7

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ See code for all available configurations.
 | [Lenovo ThinkPad A475](lenovo/thinkpad/a475)                                      | `<nixos-hardware/lenovo/thinkpad/a475>`                 | `lenovo-thinkpad-a475`                 |
 | [Lenovo ThinkPad E14 (AMD)](lenovo/thinkpad/e14/amd)                              | `<nixos-hardware/lenovo/thinkpad/e14/amd>`              | `lenovo-thinkpad-e14-amd`              |
 | [Lenovo ThinkPad E14 (Intel - Gen 1)](lenovo/thinkpad/e14/intel)                  | `<nixos-hardware/lenovo/thinkpad/e14/intel>`            | `lenovo-thinkpad-e14-intel`            |
-| [Lenovo ThinkPad E14 (Intel - Gen 4)](lenovo/thinkpad/e14/intel/gen4)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen4>`       | `lenovo-thinkpad-e14-intel-gen4`       |
 | [Lenovo ThinkPad E14 (Intel - Gen 2)](lenovo/thinkpad/e14/intel/gen2)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen2>`       | `lenovo-thinkpad-e14-intel-gen2`       |
+| [Lenovo ThinkPad E14 (Intel - Gen 4)](lenovo/thinkpad/e14/intel/gen4)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen4>`       | `lenovo-thinkpad-e14-intel-gen4`       |
 | [Lenovo ThinkPad E14 (Intel - Gen 6)](lenovo/thinkpad/e14/intel/gen6)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen6>`       | `lenovo-thinkpad-e14-intel-gen6`       |
 | [Lenovo ThinkPad E14 (Intel - Gen 7)](lenovo/thinkpad/e14/intel/gen7)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen7>`       | `lenovo-thinkpad-e14-intel-gen7`       |
 | [Lenovo ThinkPad E15 (Intel)](lenovo/thinkpad/e15/intel)                          | `<nixos-hardware/lenovo/thinkpad/e15/intel>`            | `lenovo-thinkpad-e15-intel`            |

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad E14 (Intel - Gen 4)](lenovo/thinkpad/e14/intel/gen4)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen4>`       | `lenovo-thinkpad-e14-intel-gen4`       |
 | [Lenovo ThinkPad E14 (Intel - Gen 2)](lenovo/thinkpad/e14/intel/gen2)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen2>`       | `lenovo-thinkpad-e14-intel-gen2`       |
 | [Lenovo ThinkPad E14 (Intel - Gen 6)](lenovo/thinkpad/e14/intel/gen6)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen6>`       | `lenovo-thinkpad-e14-intel-gen6`       |
+| [Lenovo ThinkPad E14 (Intel - Gen 7)](lenovo/thinkpad/e14/intel/gen7)             | `<nixos-hardware/lenovo/thinkpad/e14/intel/gen7>`       | `lenovo-thinkpad-e14-intel-gen7`       |
 | [Lenovo ThinkPad E15 (Intel)](lenovo/thinkpad/e15/intel)                          | `<nixos-hardware/lenovo/thinkpad/e15/intel>`            | `lenovo-thinkpad-e15-intel`            |
 | [Lenovo ThinkPad E470](lenovo/thinkpad/e470)                                      | `<nixos-hardware/lenovo/thinkpad/e470>`                 | `lenovo-thinkpad-e470`                 |
 | [Lenovo ThinkPad E495](lenovo/thinkpad/e495)                                      | `<nixos-hardware/lenovo/thinkpad/e495>`                 | `lenovo-thinkpad-e495`                 |

--- a/flake.nix
+++ b/flake.nix
@@ -255,6 +255,7 @@
           lenovo-thinkpad-e14-intel-gen2 = import ./lenovo/thinkpad/e14/intel/gen2;
           lenovo-thinkpad-e14-intel-gen4 = import ./lenovo/thinkpad/e14/intel/gen4;
           lenovo-thinkpad-e14-intel-gen6 = import ./lenovo/thinkpad/e14/intel/gen6;
+          lenovo-thinkpad-e14-intel-gen7 = import ./lenovo/thinkpad/e14/intel/gen7;
           lenovo-thinkpad-e15-intel = import ./lenovo/thinkpad/e15/intel;
           lenovo-thinkpad-e470 = import ./lenovo/thinkpad/e470;
           lenovo-thinkpad-e495 = import ./lenovo/thinkpad/e495;

--- a/lenovo/thinkpad/e14/intel/gen7/default.nix
+++ b/lenovo/thinkpad/e14/intel/gen7/default.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../.
+    ../../../../../common/cpu/intel/raptor-lake
+  ];
+
+  hardware.intelgpu.driver = "xe";
+  services.throttled.enable = lib.mkDefault false;
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Adds profile for the Lenovo Thinkpad E14 Gen7

I've been running running it in my own [flake.nix](https://codeberg.org/husjon/nixos-config/src/branch/main/flake.nix#L12-L15) for the past days.

###### Things done
Note: Also sorted the Lenovo Thinkpad E14 entries in the README as Gen4 was above Gen2 (this commit can be removed if needed)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

