### PR TITLE
framework: Remove dhowett's driver

### DIFF
--- a/framework/13-inch/12th-gen-intel/default.nix
+++ b/framework/13-inch/12th-gen-intel/default.nix
@@ -25,10 +25,7 @@
         # This enables the brightness and airplane mode keys to work
         # https://community.frame.work/t/12th-gen-not-sending-xf86monbrightnessup-down/20605/11
         "hid-sensor-hub"
-      ]
-      # This fixes controller crashes during sleep
-      # https://community.frame.work/t/tracking-fn-key-stops-working-on-popos-after-a-while/21208/32
-      ++ lib.optional (config.hardware.framework.enableKmod == false) "cros_ec_lpcs";
+      ];
 
       boot.kernelParams = [
         # For Power consumption

--- a/framework/README.md
+++ b/framework/README.md
@@ -51,17 +51,6 @@ For the Framework 13 laptops, there are common configuration modules available u
 including some modules specific to AMD- or Intel-based laptops. By preference, there will already be a specialised
 module for your model's configuration. Otherwise, it can be added alongside the existing modules.
 
-## OS integration
-
-`hardware.framework.enableKmod` enables the [community-created Framework kernel
-module](https://github.com/DHowett/framework-laptop-kmod) which exposes EC functionality like battery charge limit,
-privacy switches, and system LEDs as standard driver interfaces. This enables, for example, configuring the charge limit
-using the KDE settings GUI. The option is enabled by default when NixOS `>= 24.05` and linux kernel version `>= 6.10`.
-
-On AMD Framework 13 and 16, before kernel 6.10, additional kernel patches are required for the kernel module to function
-properly. Manually setting `hardware.framework.enableKmod = true` will apply the patches, requiring a kernel
-recompilation.
-
 ## Support Tools
 
 ### fw-ectool

--- a/framework/kmod.nix
+++ b/framework/kmod.nix
@@ -4,32 +4,16 @@
   ...
 }:
 {
-  options.hardware.framework.enableKmod =
-    (lib.mkEnableOption "the community-created Framework kernel module that allows interacting with the embedded controller from sysfs.")
-    // {
-      # enable by default on NixOS >= 24.05 and kernel >= 6.10
-      default = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.10";
-      defaultText = "enabled by default if kernel >= 6.10";
-    };
-
-  config = lib.mkIf config.hardware.framework.enableKmod {
-    assertions = [
-      {
-        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.10";
-        message = "The framework laptop kernel module requires Linux 6.10 or above";
-      }
+  boot = {
+    # Make sure that EC drivers are loaded
+    kernelModules = [
+      "cros_ec"
+      "cros_ec_lpcs"
     ];
 
-    boot = {
-      extraModulePackages = with config.boot.kernelPackages; [
-        framework-laptop-kmod
-      ];
-
-      # https://github.com/DHowett/framework-laptop-kmod?tab=readme-ov-file#usage
-      kernelModules = [
-        "cros_ec"
-        "cros_ec_lpcs"
-      ];
-    };
+    # Make sure that the charge control driver is loaded
+    extraModProbeConfig = ''
+      options cros_charge_control probe-with_fwk_charge_control=1
+    '';
   };
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Most of it (Battery Charge Control and LED control) has been upstream for a while. Only fan control and privacy switches hasn't.

The module hasn't been updated in two years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

