### PR TITLE
Fix no output after boot on raspberry pi 5

### DIFF
--- a/raspberry-pi/5/default.nix
+++ b/raspberry-pi/5/default.nix
@@ -17,6 +17,7 @@ in
     kernelPackages = lib.mkDefault (
       pkgs.linuxPackagesFor (pkgs.callPackage ../common/kernel.nix { rpiVersion = 5; })
     );
+    kernelParams = ["console=tty0"];
     initrd.availableKernelModules = [
       "nvme"
       "pcie-brcmstb"


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Added console=tty0 to fix no output after boot. an issue described in the wiki.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

