### PR TITLE
Added Acer Nitro AN517-41 hardware config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See code for all available configurations.
 | Model                                                                             | Path                                                    | Flake Module                           |
 | --------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------- |
 | [Acer Aspire 4810T](acer/aspire/4810t)                                            | `<nixos-hardware/acer/aspire/4810t>`                    | `acer-aspire-4810t`                    |
+| [Acer Nitro AN517-41](acer/nitro/an517-41)                                        | `<nixos-hardware/acer/nitro/an517-41>`                  | `acer-nitro-an517-41`                  |
 | [Acer Predator Helios 300 (PH315-51)](acer/predator/helios/300/ph315-51/)         | `<nixos-hardware/acer/predator/helios/300/ph315-51/>`   | `acer-predator-helios-300-ph315-51`    |
 | [Airis N990](airis/n990)                                                          | `<nixos-hardware/airis/n990>`                           | `airis-n990`                           |
 | [Apple iMac 12,2](apple/imac/12-2)                                                | `<nixos-hardware/apple/imac/12-2>`                      | `apple-imac-12-2`                      |

--- a/acer/battery.nix
+++ b/acer/battery.nix
@@ -1,0 +1,21 @@
+{ lib, config, ... }:
+let
+  cfg = config.hardware.acer.battery;
+in
+{
+  options.hardware.acer.battery = with lib; {
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to enable the Acer battery control kernel module.";
+    };
+    enableHealthMode = mkEnableOption "to limit battery charge to 80% and save battery health.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.extraModulePackages = [ config.boot.kernelPackages.acer-wmi-battery ];
+    boot.kernelModules = [ "acer-wmi-battery" ];
+
+    boot.extraModprobeConfig = lib.mkIf cfg.enableHealthMode "options acer-wmi-battery enable_health_mode=1";
+  };
+}

--- a/acer/nitro/an517-41/default.nix
+++ b/acer/nitro/an517-41/default.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+{
+  imports = [
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../../common/cpu/amd
+    ../../../common/cpu/amd/pstate.nix
+    ../../../common/gpu/nvidia/ampere
+    ../../../common/gpu/nvidia/prime.nix
+
+    ../../battery.nix
+  ];
+
+  hardware.nvidia = {
+    prime = {
+      amdgpuBusId = "PCI:5@0:0:0";
+      nvidiaBusId = "PCI:1@0:0:0";
+    };
+    # Consider moving this to common/gpu/nvidia folder (works for Ampere or later)
+    dynamicBoost.enable = lib.mkDefault true;
+    powerManagement = {
+      enable = lib.mkDefault true;
+      finegrained = lib.mkDefault true;
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
         in
         {
           acer-aspire-4810t = import ./acer/aspire/4810t;
+          acer-nitro-an517-41 = import ./acer/nitro/an517-41;
           acer-predator-helios-300-ph315-51 = import ./acer/predator/helios/300/ph315-51;
           airis-n990 = import ./airis/n990;
           aoostar-r1-n100 = import ./aoostar/r1/n100;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

This PR adds a hardware configuration for Acer Nitro AN517-41, along with a shared `acer/battery.nix` module (not imported in other Acer models yet) which installs the acer-wmi-battery driver and allows enabling battery health mode via `hardware.acer.battery.enableHealthMode` (limits charge to 80%).

###### Things done

- Added acer/nitro/an517-41` configuration (no README) based on my own NixOS configuration (it works on my laptop)
- Followed steps in CONTRIBUTING.md (adding to flake and main README)
- Ran `nix run .#run-tests`, no issues (except I had to run `tests/run.py --jobs 4` because I get OOM'd otherwise and the script in `tests/run-tests.nix` doesn't pass through parameters so `nix run .#run-tests -- --jobs 4` didn't change the outcome but I think that's for another PR)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

