### PR TITLE
TUXEDO: load Motorcomm YT6801 only if kernel is below v7.0

### DIFF
--- a/tuxedo/infinitybook/pro14/gen10/default.nix
+++ b/tuxedo/infinitybook/pro14/gen10/default.nix
@@ -4,8 +4,10 @@
     ../../.
   ];
 
-  # Add Motorcomm YT6801 Driver if available
+  # Add Motorcomm YT6801 Driver if available and kernel version is below 7.0
   boot.extraModulePackages =
     with config.boot;
-    lib.lists.optional (kernelPackages ? yt6801) kernelPackages.yt6801;
+    lib.lists.optional (
+      (lib.versionOlder kernelPackages.kernel.version "7.0") && (kernelPackages ? yt6801)
+    ) kernelPackages.yt6801;
 }

--- a/tuxedo/infinitybook/pro14/gen9/default.nix
+++ b/tuxedo/infinitybook/pro14/gen9/default.nix
@@ -4,8 +4,10 @@
     ../../.
   ];
 
-  # Add Motorcomm YT6801 Driver if available
+  # Add Motorcomm YT6801 Driver if available and kernel version is below 7.0
   boot.extraModulePackages =
     with config.boot;
-    lib.lists.optional (kernelPackages ? yt6801) kernelPackages.yt6801;
+    lib.lists.optional (
+      (lib.versionOlder kernelPackages.kernel.version "7.0") && (kernelPackages ? yt6801)
+    ) kernelPackages.yt6801;
 }

--- a/tuxedo/infinitybook/pro15/gen10/default.nix
+++ b/tuxedo/infinitybook/pro15/gen10/default.nix
@@ -4,8 +4,10 @@
     ../../.
   ];
 
-  # Add Motorcomm YT6801 Driver if available
+  # Add Motorcomm YT6801 Driver if available and kernel version is below 7.0
   boot.extraModulePackages =
     with config.boot;
-    lib.lists.optional (kernelPackages ? yt6801) kernelPackages.yt6801;
+    lib.lists.optional (
+      (lib.versionOlder kernelPackages.kernel.version "7.0") && (kernelPackages ? yt6801)
+    ) kernelPackages.yt6801;
 }


### PR DESCRIPTION
###### Description of changes

TUXEDO used to recommend to install the Motorcomm YT6801 driver
manually, unless using one of their WebFAI-supported distributions.[^1]

However, starting with version v7.0[^2], the kernel has first-class
supported for the driver.

It's worth pointing out, that users may still manually apply
`linuxKernel.packages.*.yt6801` in order to load the external kernel
module, provided by the vendor directly.[^3]

[^1]: https://www.tuxedocomputers.com/en/Motorcomm-YT6801-txtmotorcomm-yt6801-paket.tuxedo
[^2]: https://github.com/torvalds/linux/commit/02ff155ea2812ea25a086665522fd4fa196ef0ce
[^3]: https://github.com/NixOS/nixpkgs/blob/nixos-26.05/pkgs/os-specific/linux/yt6801/default.nix

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input