### PR TITLE
Add Dell Vostro 5501

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ See code for all available configurations.
 | [Dell Precision 5570](dell/precision/5570)                                        | `<nixos-hardware/dell/precision/5570>`                  | `dell-precision-5570`                  |
 | [Dell Precision 5820](dell/precision/5820)                                        | `<nixos-hardware/dell/precision/5820>`                  | `dell-precision-5820`                  |
 | [Dell Precision 7520](dell/precision/7520)                                        | `<nixos-hardware/dell/precision/7520>`                  | `dell-precision-7520`                  |
+| [Dell Vostro 5501](dell/vostro/5501)                                              | `<nixos-hardware/dell/vostro/5501>`                     | `dell-vostro-5501`                     |
+| [Dell Vostro 5501, nvidia](dell/vostro/5501/nvidia)                               | `<nixos-hardware/dell/vostro/5501/nvidia>`              | `dell-vostro-5501-nvidia`              |
 | [Dell XPS 13 7390](dell/xps/13-7390)                                              | `<nixos-hardware/dell/xps/13-7390>`                     | `dell-xps-13-7390`                     |
 | [Dell XPS 13 9300](dell/xps/13-9300)                                              | `<nixos-hardware/dell/xps/13-9300>`                     | `dell-xps-13-9300`                     |
 | [Dell XPS 13 9310](dell/xps/13-9310)                                              | `<nixos-hardware/dell/xps/13-9310>`                     | `dell-xps-13-9310`                     |

--- a/dell/vostro/5501/README.md
+++ b/dell/vostro/5501/README.md
@@ -1,0 +1,17 @@
+# Dell Vostro 5501
+
+## Specifications
+
+- **CPU:** 10th Generation Intel Core i3-1005G1 / i5-1035G1 / i7-1065G7 (Ice Lake)
+- **iGPU:** Intel UHD Graphics / Intel Iris Plus Graphics
+- **dGPU (Optional):** NVIDIA GeForce MX330 (2 GB GDDR5)
+
+
+## USB-C ACPI Error Messages
+
+If you encounter ACPI errors related to `ucsi_acpi` regarding USB Power Delivery sink roles, you can add the following in your system's `configuration.nix`:
+
+
+```nix
+boot.kernelParams = [ "ucsi_acpi.sink_has_roles=0" ];
+```

--- a/dell/vostro/5501/default.nix
+++ b/dell/vostro/5501/default.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../../../common/pc/laptop
+    ../../../common/pc/ssd
+    ../../../common/cpu/intel/ice-lake
+  ];
+
+  hardware.intelgpu = {
+    vaapiDriver = lib.mkDefault "intel-media-driver";
+  };
+
+  services.thermald.enable = lib.mkDefault true;
+}

--- a/dell/vostro/5501/nvidia/default.nix
+++ b/dell/vostro/5501/nvidia/default.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ../.
+    ../../../../common/gpu/nvidia/prime.nix
+  ];
+
+  hardware.nvidia.prime = {
+    intelBusId = lib.mkDefault "PCI:0:2:0";
+    nvidiaBusId = lib.mkDefault "PCI:1:0:0";
+  };
+
+  hardware.nvidia.open = lib.mkDefault false;
+  hardware.nvidia.powerManagement.enable = lib.mkDefault true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,8 @@
           dell-precision-5570 = import ./dell/precision/5570;
           dell-precision-5820 = import ./dell/precision/5820;
           dell-precision-7520 = import ./dell/precision/7520;
+          dell-vostro-5501 = import ./dell/vostro/5501;
+          dell-vostro-5501-nvidia = import ./dell/vostro/5501/nvidia;
           dell-xps-13-7390 = import ./dell/xps/13-7390;
           dell-xps-13-9300 = import ./dell/xps/13-9300;
           dell-xps-13-9310 = import ./dell/xps/13-9310;


### PR DESCRIPTION
###### Description of changes

This PR adds a hardware profile for the Dell Vostro 5501. Since this model is available as both an Intel-only system and with an optional discrete GPU, two profiles are added: 
- `dell/vostro/5501` (Intel integrated graphics)
- `dell/vostro/5501/nvidia` (Intel iGPU + NVIDIA GeForce MX330)

###### Things done

- Added `dell/vostro/5501` and `dell/vostro/5501/nvidia` along with a `README.md`.
- Updated repository `README.md` and `flake.nix` exports.
- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input