### PR TITLE
 raspberry-pi/4: audio overlay, target audio -> sound

### DIFF
--- a/raspberry-pi/4/audio.nix
+++ b/raspberry-pi/4/audio.nix
@@ -27,7 +27,7 @@ in
             / {
               compatible = "brcm,bcm2711";
               fragment@0 {
-                target = <&audio>;
+                target = <&sound>;
 
                 __overlay__ {
                   status = "okay";

--- a/raspberry-pi/4/audio.nix
+++ b/raspberry-pi/4/audio.nix
@@ -38,13 +38,5 @@ in
         }
       ];
     };
-
-    # set tsched=0 in pulseaudio config to avoid audio glitches
-    # see https://wiki.archlinux.org/title/PulseAudio/Troubleshooting#Glitches,_skips_or_crackling
-    hardware.pulseaudio.configFile = lib.mkOverride 990 (
-      pkgs.runCommand "default.pa" { } ''
-        sed 's/module-udev-detect$/module-udev-detect tsched=0/' ${config.hardware.pulseaudio.package}/etc/pulse/default.pa > $out
-      ''
-    );
   };
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Audio target is no more, it's called sound in recent kernels.

Also drops broken and not needed pulseaudio config override.

Closes #703 #1849

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

