### PR TITLE
raspberry-pi/common/kernel: 6.18.34-stable_20260609 -> 6.18.39-stable_20260724

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -10,9 +10,9 @@
 
 let
   # NOTE: raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.18.34";
-  tag = "stable_20260609";
-  hash = "sha256-ok++36dh9o4e7AC5RErW00/r23rGxufe0PYXz5Dzy5U=";
+  modDirVersion = "6.18.39";
+  tag = "stable_20260724";
+  hash = "sha256-IT/SkF458oLmnFIPbN76Qp6s8KVxKQOC02XmN7NRdBc=";
   inherit (lib.kernel) freeform yes no;
 in
 (buildLinux (


### PR DESCRIPTION
###### Description of changes

https://github.com/raspberrypi/linux/releases/tag/stable_20260724

cc: @doronbehar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

