### PR TITLE
raspberry-pi: migrate PoE HATs to config.txt overlays

### DIFF
--- a/raspberry-pi/4/poe-hat.nix
+++ b/raspberry-pi/4/poe-hat.nix
@@ -1,232 +1,35 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
-let
-  cfg = config.hardware.raspberry-pi."4".poe-hat;
-in
 {
-  options.hardware = {
-    raspberry-pi."4".poe-hat = {
-      enable = lib.mkEnableOption "support for the Raspberry Pi POE Hat";
-      fan = lib.mkOption {
-        type = lib.types.submodule {
-          options = {
-            temperature0 = lib.mkOption {
-              type = lib.types.int;
-              default = 40000;
-              description = "Temperature threshold 0.";
-            };
-            hysteresis0 = lib.mkOption {
-              type = lib.types.int;
-              default = 2000;
-              description = "Temperature hysteresis 0.";
-            };
-            temperature1 = lib.mkOption {
-              type = lib.types.int;
-              default = 45000;
-              description = "Temperature threshold 1.";
-            };
-            hysteresis1 = lib.mkOption {
-              type = lib.types.int;
-              default = 2000;
-              description = "Temperature hysteresis 1.";
-            };
-            temperature2 = lib.mkOption {
-              type = lib.types.int;
-              default = 50000;
-              description = "Temperature threshold 2.";
-            };
-            hysteresis2 = lib.mkOption {
-              type = lib.types.int;
-              default = 2000;
-              description = "Temperature hysteresis 2.";
-            };
-            temperature3 = lib.mkOption {
-              type = lib.types.int;
-              default = 55000;
-              description = "Temperature threshold 3.";
-            };
-            hysteresis3 = lib.mkOption {
-              type = lib.types.int;
-              default = 5000;
-              description = "Temperature hysteresis 3.";
-            };
-          };
-        };
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "hardware"
+        "raspberry-pi"
+        "4"
+        "poe-hat"
+      ]
+      ''
+        Use the stock rpi-poe firmware overlay instead:
 
-        default = { };
-        description = "Fan configuration.";
-      };
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
-    # doesn't work for the CM module, so we exclude e.g. bcm2711-rpi-cm4.dts
-    hardware.deviceTree.filter = "bcm2711-rpi-4*.dtb";
-
-    hardware.deviceTree = {
-      overlays = [
-        # Equivalent to: https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
-        {
-          name = "rpi-poe-overlay";
-          dtsText = ''
-            /*
-            * Overlay for the Raspberry Pi POE HAT.
-            */
-            /dts-v1/;
-            /plugin/;
-
-            / {
-              compatible = "brcm,bcm2711";
-
-              fragment@0 {
-                target-path = "/";
-                __overlay__ {
-                  fan: pwm-fan {
-                    compatible = "pwm-fan";
-                    cooling-levels = <0 1 10 100 255>;
-                    #cooling-cells = <2>;
-                    pwms = <&fwpwm 0 80000  0>;
-                  };
-                };
+          hardware.raspberry-pi.configtxt.deviceTreeOverlays."board-type=0x11" = [
+            {
+              rpi-poe = {
+                poe_fan_temp0 = 40000;
+                poe_fan_temp0_hyst = 2000;
+                poe_fan_temp1 = 45000;
+                poe_fan_temp1_hyst = 2000;
+                poe_fan_temp2 = 50000;
+                poe_fan_temp2_hyst = 2000;
+                poe_fan_temp3 = 55000;
+                poe_fan_temp3_hyst = 5000;
               };
+            }
+          ];
 
-              fragment@1 {
-                target = <&cpu_thermal>;
-                __overlay__ {
-                  polling-delay = <2000>; /* milliseconds */
-                };
-              };
-
-              fragment@2 {
-                target = <&thermal_trips>;
-                __overlay__ {
-                  trip0: trip0 {
-                    temperature = <${toString cfg.fan.temperature0}>;
-                    hysteresis = <${toString cfg.fan.hysteresis0}>;
-                    type = "active";
-                  };
-                  trip1: trip1 {
-                    temperature = <${toString cfg.fan.temperature1}>;
-                    hysteresis = <${toString cfg.fan.hysteresis1}>;
-                    type = "active";
-                  };
-                  trip2: trip2 {
-                    temperature = <${toString cfg.fan.temperature2}>;
-                    hysteresis = <${toString cfg.fan.hysteresis2}>;
-                    type = "active";
-                  };
-                  trip3: trip3 {
-                    temperature = <${toString cfg.fan.temperature3}>;
-                    hysteresis = <${toString cfg.fan.hysteresis3}>;
-                    type = "active";
-                  };
-                };
-              };
-
-              fragment@3 {
-                target = <&cooling_maps>;
-                __overlay__ {
-                  map0 {
-                    trip = <&trip0>;
-                    cooling-device = <&fan 0 1>;
-                  };
-                  map1 {
-                    trip = <&trip1>;
-                    cooling-device = <&fan 1 2>;
-                  };
-                  map2 {
-                    trip = <&trip2>;
-                    cooling-device = <&fan 2 3>;
-                  };
-                  map3 {
-                    trip = <&trip3>;
-                    cooling-device = <&fan 3 4>;
-                  };
-                };
-              };
-
-              fragment@4 {
-                target-path = "/__overrides__";
-                params: __overlay__ {
-                  poe_fan_temp0 =		<&trip0>,"temperature:0";
-                  poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
-                  poe_fan_temp1 =		<&trip1>,"temperature:0";
-                  poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
-                  poe_fan_temp2 =		<&trip2>,"temperature:0";
-                  poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
-                  poe_fan_temp3 =		<&trip3>,"temperature:0";
-                  poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
-                  poe_fan_i2c =		<&fwpwm>,"status=disabled",
-                        <&poe_mfd>,"status=okay",
-                        <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-                };
-              };
-
-              fragment@5 {
-                target = <&firmware>;
-                __overlay__ {
-                  fwpwm: pwm {
-                    compatible = "raspberrypi,firmware-poe-pwm";
-                    #pwm-cells = <2>;
-                  };
-                };
-              };
-
-              fragment@6 {
-                target = <&i2c0>;
-                i2c_bus: __overlay__ {
-                  #address-cells = <1>;
-                  #size-cells = <0>;
-
-                  poe_mfd: poe@51 {
-                    compatible = "raspberrypi,poe-core";
-                    reg = <0x51>;
-                    status = "disabled";
-
-                    poe_mfd_pwm: poe_pwm@f0 {
-                      compatible = "raspberrypi,poe-pwm";
-                      reg = <0xf0>;
-                      status = "okay";
-                      #pwm-cells = <2>;
-                    };
-                  };
-                };
-              };
-
-              fragment@7 {
-                target = <&i2c0if>;
-                __dormant__ {
-                  status = "okay";
-                };
-              };
-
-              fragment@8 {
-                target = <&i2c0mux>;
-                __dormant__ {
-                  status = "okay";
-                };
-              };
-
-              __overrides__ {
-                poe_fan_temp0 =		<&trip0>,"temperature:0";
-                poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
-                poe_fan_temp1 =		<&trip1>,"temperature:0";
-                poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
-                poe_fan_temp2 =		<&trip2>,"temperature:0";
-                poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
-                poe_fan_temp3 =		<&trip3>,"temperature:0";
-                poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
-                i2c =			<0>, "+5+6",
-                      <&fwpwm>,"status=disabled",
-                      <&i2c_bus>,"status=okay",
-                      <&poe_mfd>,"status=okay",
-                      <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-              };
-            };
-          '';
-        }
-      ];
-    };
-  };
+        These are the overlay defaults. Parameters that were not customized can
+        be omitted.
+      ''
+    )
+  ];
 }

--- a/raspberry-pi/4/poe-plus-hat.nix
+++ b/raspberry-pi/4/poe-plus-hat.nix
@@ -1,282 +1,35 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
-let
-  cfg = config.hardware.raspberry-pi."4".poe-plus-hat;
-in
 {
-  options.hardware = {
-    raspberry-pi."4".poe-plus-hat = {
-      enable = lib.mkEnableOption "support for the Raspberry Pi PoE+ HAT";
-      fan = lib.mkOption {
-        type = lib.types.submodule {
-          options = {
-            temperature0 = lib.mkOption {
-              type = lib.types.int;
-              default = 40000;
-              description = "Temperature threshold 0.";
-            };
-            hysteresis0 = lib.mkOption {
-              type = lib.types.int;
-              default = 2000;
-              description = "Temperature hysteresis 0.";
-            };
-            temperature1 = lib.mkOption {
-              type = lib.types.int;
-              default = 45000;
-              description = "Temperature threshold 1.";
-            };
-            hysteresis1 = lib.mkOption {
-              type = lib.types.int;
-              default = 2000;
-              description = "Temperature hysteresis 1.";
-            };
-            temperature2 = lib.mkOption {
-              type = lib.types.int;
-              default = 50000;
-              description = "Temperature threshold 2.";
-            };
-            hysteresis2 = lib.mkOption {
-              type = lib.types.int;
-              default = 2000;
-              description = "Temperature hysteresis 2.";
-            };
-            temperature3 = lib.mkOption {
-              type = lib.types.int;
-              default = 55000;
-              description = "Temperature threshold 3.";
-            };
-            hysteresis3 = lib.mkOption {
-              type = lib.types.int;
-              default = 5000;
-              description = "Temperature hysteresis 3.";
-            };
-          };
-        };
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "hardware"
+        "raspberry-pi"
+        "4"
+        "poe-plus-hat"
+      ]
+      ''
+        Use the stock rpi-poe-plus firmware overlay instead:
 
-        default = { };
-        description = "Fan configuration.";
-      };
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
-    # doesn't work for the CM module, so we exclude e.g. bcm2711-rpi-cm4.dts
-    hardware.deviceTree.filter = "bcm2711-rpi-4*.dtb";
-
-    hardware.deviceTree = {
-      overlays = [
-        # Combined equivalent to:
-        # * https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
-        # * https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
-        {
-          name = "rpi-poe-plus-overlay";
-          dtsText = ''
-            /*
-            * Overlay for the Raspberry Pi POE HAT.
-            */
-            /dts-v1/;
-            /plugin/;
-
-            / {
-              compatible = "brcm,bcm2711";
-
-              fragment@0 {
-                target-path = "/";
-                __overlay__ {
-                  fan: pwm-fan {
-                    compatible = "pwm-fan";
-                    cooling-levels = <0 1 10 100 255>;
-                    #cooling-cells = <2>;
-                    pwms = <&fwpwm 0 80000 0>;
-                  };
-                };
+          hardware.raspberry-pi.configtxt.deviceTreeOverlays."board-type=0x11" = [
+            {
+              rpi-poe-plus = {
+                poe_fan_temp0 = 40000;
+                poe_fan_temp0_hyst = 2000;
+                poe_fan_temp1 = 45000;
+                poe_fan_temp1_hyst = 2000;
+                poe_fan_temp2 = 50000;
+                poe_fan_temp2_hyst = 2000;
+                poe_fan_temp3 = 55000;
+                poe_fan_temp3_hyst = 5000;
               };
+            }
+          ];
 
-              fragment@1 {
-                target = <&cpu_thermal>;
-                __overlay__ {
-                  polling-delay = <2000>; /* milliseconds */
-                };
-              };
-
-              fragment@2 {
-                target = <&thermal_trips>;
-                __overlay__ {
-                  trip0: trip0 {
-                    temperature = <${toString cfg.fan.temperature0}>;
-                    hysteresis = <${toString cfg.fan.hysteresis0}>;
-                    type = "active";
-                  };
-                  trip1: trip1 {
-                    temperature = <${toString cfg.fan.temperature1}>;
-                    hysteresis = <${toString cfg.fan.hysteresis1}>;
-                    type = "active";
-                  };
-                  trip2: trip2 {
-                    temperature = <${toString cfg.fan.temperature2}>;
-                    hysteresis = <${toString cfg.fan.hysteresis2}>;
-                    type = "active";
-                  };
-                  trip3: trip3 {
-                    temperature = <${toString cfg.fan.temperature3}>;
-                    hysteresis = <${toString cfg.fan.hysteresis3}>;
-                    type = "active";
-                  };
-                };
-              };
-
-              fragment@3 {
-                target = <&cooling_maps>;
-                __overlay__ {
-                  map0 {
-                    trip = <&trip0>;
-                    cooling-device = <&fan 0 1>;
-                  };
-                  map1 {
-                    trip = <&trip1>;
-                    cooling-device = <&fan 1 2>;
-                  };
-                  map2 {
-                    trip = <&trip2>;
-                    cooling-device = <&fan 2 3>;
-                  };
-                  map3 {
-                    trip = <&trip3>;
-                    cooling-device = <&fan 3 4>;
-                  };
-                };
-              };
-
-              fragment@4 {
-                target-path = "/__overrides__";
-                params: __overlay__ {
-                  poe_fan_temp0 =		<&trip0>,"temperature:0";
-                  poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
-                  poe_fan_temp1 =		<&trip1>,"temperature:0";
-                  poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
-                  poe_fan_temp2 =		<&trip2>,"temperature:0";
-                  poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
-                  poe_fan_temp3 =		<&trip3>,"temperature:0";
-                  poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
-                  poe_fan_i2c =		<&fwpwm>,"status=disabled",
-                        <&poe_mfd>,"status=okay",
-                        <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-                };
-              };
-
-              fragment@5 {
-                target = <&firmware>;
-                __overlay__ {
-                  fwpwm: pwm {
-                    compatible = "raspberrypi,firmware-poe-pwm";
-                    #pwm-cells = <2>;
-                  };
-                };
-              };
-
-              fragment@6 {
-                target = <&i2c0>;
-                i2c_bus: __overlay__ {
-                  #address-cells = <1>;
-                  #size-cells = <0>;
-
-                  poe_mfd: poe@51 {
-                    compatible = "raspberrypi,poe-core";
-                    reg = <0x51>;
-                    status = "disabled";
-
-                    poe_mfd_pwm: poe_pwm@f0 {
-                      compatible = "raspberrypi,poe-pwm";
-                      reg = <0xf0>;
-                      status = "okay";
-                      #pwm-cells = <2>;
-                    };
-                  };
-                };
-              };
-
-              fragment@7 {
-                target = <&i2c0if>;
-                __dormant__ {
-                  status = "okay";
-                };
-              };
-
-              fragment@8 {
-                target = <&i2c0mux>;
-                __dormant__ {
-                  status = "okay";
-                };
-              };
-
-              __overrides__ {
-                poe_fan_temp0 =		<&trip0>,"temperature:0";
-                poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
-                poe_fan_temp1 =		<&trip1>,"temperature:0";
-                poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
-                poe_fan_temp2 =		<&trip2>,"temperature:0";
-                poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
-                poe_fan_temp3 =		<&trip3>,"temperature:0";
-                poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
-                i2c =			<0>, "+5+6",
-                      <&fwpwm>,"status=disabled",
-                      <&i2c_bus>,"status=okay",
-                      <&poe_mfd>,"status=okay",
-                      <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-              };
-            };
-
-            // SPDX-License-Identifier: (GPL-2.0 OR MIT)
-            // Overlay for the Raspberry Pi PoE+ HAT.
-
-            / {
-              compatible = "brcm,bcm2711";
-
-              fragment@10 {
-                target-path = "/";
-                __overlay__ {
-                  rpi_poe_power_supply: rpi-poe-power-supply {
-                    compatible = "raspberrypi,rpi-poe-power-supply";
-                    firmware = <&firmware>;
-                    status = "okay";
-                  };
-                };
-              };
-              fragment@11 {
-                target = <&poe_mfd>;
-                __overlay__ {
-                  rpi-poe-power-supply@f2 {
-                    compatible = "raspberrypi,rpi-poe-power-supply";
-                    reg = <0xf2>;
-                    status = "okay";
-                  };
-                };
-              };
-
-              __overrides__ {
-                i2c =	<0>, "+5+6",
-                  <&fwpwm>,"status=disabled",
-                  <&rpi_poe_power_supply>,"status=disabled",
-                  <&i2c_bus>,"status=okay",
-                  <&poe_mfd>,"status=okay",
-                  <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-              };
-            };
-
-            &fan {
-              cooling-levels = <0 32 64 128 255>;
-            };
-
-            &params {
-              poe_fan_i2c = <&fwpwm>,"status=disabled",
-                      <&rpi_poe_power_supply>,"status=disabled",
-                      <&poe_mfd>,"status=okay",
-                      <&fan>,"pwms:0=",<&poe_mfd_pwm>;
-            };
-          '';
-        }
-      ];
-    };
-  };
+        These are the overlay defaults. Parameters that were not customized can
+        be omitted.
+      ''
+    )
+  ];
 }

--- a/raspberry-pi/README.md
+++ b/raspberry-pi/README.md
@@ -6,7 +6,7 @@ NixOS profiles and modules for Raspberry Pi boards.
 
 - `common/` has the shared bits: the `linux-rpi` kernel build (vendor defconfig, matching firmware), the `config.txt` generation module, a pinned wireless firmware, and the firmware-partition install module.
 - `2/`, `3/`, `4/`, `5/` are the board profiles. Each one picks the right kernel and kernel params. Pi 4 and 5 also set DT filters and the initrd modules they need.
-- The extra files under `4/` are opt-in toggles for Pi 4 hardware: audio, dwc2, GPIO, I2C, LEDs, the PoE HATs, touchscreens, and so on.
+- The extra files under `4/` are opt-in toggles for Pi 4 hardware: audio, dwc2, GPIO, I2C, LEDs, touchscreens, and so on.
 
 ## Using a board profile
 
@@ -113,6 +113,25 @@ Overlays render after `settings`. This order keeps base parameters such as `dtpa
 Each parameter becomes its own `dtparam` line rather than an addition to the `dtoverlay` line, which keeps them clear of the 98-character line limit. Booleans render as `on` or `off`. Use `null` with `mkForce` to remove a parameter.
 
 The module concatenates lists from separate modules, but the order is not the order of definition. If one overlay must load before another, set the order with `mkBefore` or `mkAfter`.
+
+#### PoE HATs
+
+The original [PoE HAT](https://www.raspberrypi.com/products/poe-hat/) and the [PoE+ HAT](https://www.raspberrypi.com/products/poe-plus-hat/) use the stock `rpi-poe` and `rpi-poe-plus` overlays. Both HATs support the Pi 3B+ and Pi 4B.
+
+```nix
+{
+  hardware.raspberry-pi.configtxt.deviceTreeOverlays."board-type=0x11" = [
+    {
+      rpi-poe = {
+        poe_fan_temp0 = 50000;
+        poe_fan_temp0_hyst = 2000;
+      };
+    }
+  ];
+}
+```
+
+Use `board-type=0x0d` for the Pi 3B+ and `board-type=0x11` for the Pi 4B. Replace `rpi-poe` with `rpi-poe-plus` for the PoE+ HAT. All overlay parameters are optional.
 
 To supply your own file, set `configtxt.file`. The module then ignores `settings` and `deviceTreeOverlays`.
 


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Removes the PoE HAT and PoE+ HAT modules in favour of the stock [`rpi-poe`][1] and [`rpi-poe-plus`][2] firmware overlays through `hardware.raspberry-pi.configtxt.deviceTreeOverlays`.

The old Pi 4 options now use `mkRemovedOptionModule` with a direct mapping for every fan setting. The README documents the shorter form and the exact board filters supported by the [PoE HAT][3] and [PoE+ HAT][4].

The changes are split into two commits: the first moves the existing modules to shared Pi 3 and Pi 4 support, and the second removes them in favour of the generic overlay API.

Part of #1946.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

[1]: https://github.com/raspberrypi/linux/blob/ce0873cb5e0c24dd4730d87f4777982035733a0d/arch/arm/boot/dts/overlays/README#L4648-L4668
[2]: https://github.com/raspberrypi/linux/blob/ce0873cb5e0c24dd4730d87f4777982035733a0d/arch/arm/boot/dts/overlays/README#L4671-L4691
[3]: https://www.raspberrypi.com/products/poe-hat/
[4]: https://www.raspberrypi.com/products/poe-plus-hat/