### PR TITLE
common/gpu/amd: add hardware.amdgpu.dcDebugMask options

### DIFF
--- a/common/gpu/amd/dc-debug-mask.nix
+++ b/common/gpu/amd/dc-debug-mask.nix
@@ -1,0 +1,36 @@
+# Flag values from drivers/gpu/drm/amd/include/amd_shared.h
+{ config, lib, ... }:
+let
+  flags = {
+    disablePipeSplit = 1;
+    disableStutter = 2;
+    disableDsc = 4;
+    disableClockGating = 8;
+    disablePsr = 16;
+    disableMpo = 64;
+    disablePsrSu = 512;
+    disableReplay = 1024;
+    disableIps = 2048;
+  };
+
+  cfg = config.hardware.amdgpu.dcDebugMask;
+
+  mask = lib.foldlAttrs (
+    acc: name: bit:
+    if cfg.${name} then lib.bitOr acc bit else acc
+  ) 0 flags;
+in
+{
+  options.hardware.amdgpu.dcDebugMask = lib.mapAttrs (
+    _name: bit:
+    lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Set flag 0x${lib.toHexString bit} in amdgpu.dcdebugmask.";
+    }
+  ) flags;
+
+  config = lib.mkIf (mask != 0) {
+    boot.kernelParams = [ "amdgpu.dcdebugmask=0x${lib.toHexString mask}" ];
+  };
+}

--- a/common/gpu/amd/default.nix
+++ b/common/gpu/amd/default.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 
 {
+  imports = [ ./dc-debug-mask.nix ];
+
   config = {
     services.xserver.videoDrivers = lib.mkDefault [ "modesetting" ];
 

--- a/framework/13-inch/common/amd.nix
+++ b/framework/13-inch/common/amd.nix
@@ -6,18 +6,18 @@
     ../../../common/gpu/amd
   ];
 
-  boot.kernelParams = [
-    # There seems to be an issue with panel self-refresh (PSR) that
-    # causes hangs for users.
-    #
-    # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
-    # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
-    "amdgpu.dcdebugmask=0x10"
-  ]
-  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
-  ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [
-    "rtc_cmos.use_acpi_alarm=1"
-  ];
+  # There seems to be an issue with panel self-refresh (PSR) that
+  # causes hangs for users.
+  #
+  # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
+  # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
+  hardware.amdgpu.dcDebugMask.disablePsr = lib.mkDefault true;
+
+  boot.kernelParams =
+    # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+    lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [
+      "rtc_cmos.use_acpi_alarm=1"
+    ];
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13

--- a/framework/16-inch/amd-ai-300-series/default.nix
+++ b/framework/16-inch/amd-ai-300-series/default.nix
@@ -21,8 +21,9 @@
 
   # The following mitigations fix various graphics issues
   # See https://gist.github.com/lbrame/f9034b1a9fe4fc2d2835c5542acb170a#user-content-quick-version-apply-the-mitigations-i-am-personally-using
+  hardware.amdgpu.dcDebugMask.disableReplay = lib.mkDefault true;
+
   boot.kernelParams = [
-    "amdgpu.dcdebugmask=0x410"
     "amdgpu.sg_display=0"
     "amdgpu.abmlevel=0"
   ];

--- a/framework/16-inch/common/amd.nix
+++ b/framework/16-inch/common/amd.nix
@@ -6,18 +6,18 @@
     ../../../common/gpu/amd
   ];
 
-  boot.kernelParams = [
-    # There seems to be an issue with panel self-refresh (PSR) that
-    # causes hangs for users.
-    #
-    # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
-    # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
-    "amdgpu.dcdebugmask=0x10"
-  ]
-  # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
-  ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [
-    "rtc_cmos.use_acpi_alarm=1"
-  ];
+  # There seems to be an issue with panel self-refresh (PSR) that
+  # causes hangs for users.
+  #
+  # https://community.frame.work/t/fedora-kde-becomes-suddenly-slow/58459
+  # https://gitlab.freedesktop.org/drm/amd/-/issues/3647
+  hardware.amdgpu.dcDebugMask.disablePsr = lib.mkDefault true;
+
+  boot.kernelParams =
+    # Workaround for SuspendThenHibernate: https://lore.kernel.org/linux-kernel/20231106162310.85711-1-mario.limonciello@amd.com/
+    lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.8") [
+      "rtc_cmos.use_acpi_alarm=1"
+    ];
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13


### PR DESCRIPTION
This allows to combine several such options to get the right
hex value without any repeated kernel params.
Before this, the framework AI 300 got both 0x10 and 0x410 on
the cmdline with the order depending on the module system eval
order.

This also allows users to re-enable PSR on framework machines.
