### PR TITLE
raspberry-pi: add gpio-fan overlay

### DIFF
--- a/raspberry-pi/common/default.nix
+++ b/raspberry-pi/common/default.nix
@@ -3,6 +3,7 @@
     ./config-txt.nix
     ./config-txt-defaults.nix
     ./firmware.nix
+    ./gpio-fan.nix
   ];
 
   boot.initrd.availableKernelModules = [

--- a/raspberry-pi/common/gpio-fan.nix
+++ b/raspberry-pi/common/gpio-fan.nix
@@ -1,0 +1,43 @@
+# Upstream overlay source:
+# https://github.com/raspberrypi/linux/blob/rpi-6.18.y/arch/arm/boot/dts/overlays/gpio-fan-overlay.dts
+
+{ config, lib, ... }:
+
+let
+  cfg = config.hardware.raspberry-pi.gpio-fan;
+in
+{
+  options.hardware.raspberry-pi.gpio-fan = {
+    enable = lib.mkEnableOption "support for Raspberry Pi-style GPIO fan control";
+
+    pin = lib.mkOption {
+      type = lib.types.int;
+      default = 12;
+      description = "BCM GPIO pin used to switch the fan.";
+    };
+
+    temperature = lib.mkOption {
+      type = lib.types.int;
+      default = 55000;
+      description = "CPU temperature in millicelsius at which the fan turns on.";
+    };
+
+    hysteresis = lib.mkOption {
+      type = lib.types.int;
+      default = 10000;
+      description = "Temperature hysteresis in millicelsius before the fan turns off.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.raspberry-pi.configtxt.deviceTreeOverlays.all = [
+      {
+        gpio-fan = {
+          gpiopin = cfg.pin;
+          temp = cfg.temperature;
+          hyst = cfg.hysteresis;
+        };
+      }
+    ];
+  };
+}


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Adds `hardware.raspberry-pi.gpio-fan`, using the upstream [`gpio-fan` device tree overlay][1].
 
The module exposes the GPIO pin, temperature threshold, and hysteresis settings through `hardware.raspberry-pi.configtxt.deviceTreeOverlays`. This avoids the in-tree DTS proposed in #1826 and makes the option available to every Raspberry Pi profile.

cc: @matiasyocca @doronbehar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

[1]: https://github.com/raspberrypi/linux/blob/rpi-6.18.y/arch/arm/boot/dts/overlays/gpio-fan-overlay.dts