### PR TITLE
lenovo p14s amd gen6: add camera suspend quirk

### DIFF
--- a/lenovo/thinkpad/p14s/amd/gen6/default.nix
+++ b/lenovo/thinkpad/p14s/amd/gen6/default.nix
@@ -5,4 +5,8 @@
     ../.
     ../../../../../common/cpu/amd/pstate.nix
   ];
+
+  # Prevent the integrated RGB camera from dying during suspend.
+  # This issue was observed on Linux 6.18.38.
+  boot.kernelParams = [ "usbcore.quirks=30c9:00f4:b" ];
 }


### PR DESCRIPTION
###### Description of changes

On my P14s the camera dies when I suspend and then wake. Adding the quirk fixes this.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

