### PR TITLE
intel/nuc/8i7beh: add coffee-lake intel gpu, pc, sdd imports

### DIFF
--- a/intel/nuc/8i7beh/default.nix
+++ b/intel/nuc/8i7beh/default.nix
@@ -2,7 +2,7 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
+    ../../../common/cpu/intel/coffee-lake
   ];
 
   services.thermald.enable = lib.mkDefault true;

--- a/intel/nuc/8i7beh/default.nix
+++ b/intel/nuc/8i7beh/default.nix
@@ -3,6 +3,8 @@
 {
   imports = [
     ../../../common/cpu/intel/coffee-lake
+    ../../../common/pc
+    ../../../common/pc/ssd
   ];
 
   services.thermald.enable = lib.mkDefault true;


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

- Add coffee-lake intel gpu imports.
- Add pc, pc/ssd imports.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input
(successfully, in 5 units).
