### PR TITLE
common/gpu/intel/whiskey-lake: set legacy computeRuntime

### DIFF
--- a/common/gpu/intel/whiskey-lake/default.nix
+++ b/common/gpu/intel/whiskey-lake/default.nix
@@ -3,5 +3,8 @@
 
   boot.kernelParams = [ "i915.enable_guc=2" ];
 
-  hardware.intelgpu.vaapiDriver = "intel-media-driver";
+  hardware.intelgpu = {
+    computeRuntime = "legacy";
+    vaapiDriver = "intel-media-driver";
+  };
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Whiskey Lake is Gen8, (same as Coffee Lake[^1]), and supported by the legacy intel compute-runtime.

See https://github.com/intel/compute-runtime/issues/574#issuecomment-1280441944

Note that the link to the FAQ there is outdated, here’s the current link:

https://github.com/intel/compute-runtime/blob/master/documentation/FAQ.md#how-can-i-check-that-my-specific-device-is-supported-by-the-driver

And here’s the supported device list of the legacy driver (branch `releases/24.35`[^2]):

https://github.com/intel/compute-runtime/blob/releases/24.35/shared/source/dll/devices/devices_base.inl

The Device IDs for Whiskey Lake processors[^3] are `0x3EA0`, `0x3EA1`, both supported:

- https://github.com/intel/compute-runtime/blob/6c940d1663613ee170a53e6187dceeb01f6e2031/shared/source/dll/devices/devices_base.inl#L283
- https://github.com/intel/compute-runtime/blob/6c940d1663613ee170a53e6187dceeb01f6e2031/shared/source/dll/devices/devices_base.inl#L274

I thus synced this module with `coffee-lake`:
https://github.com/NixOS/nixos-hardware/blob/0471accf8d0a8210b31d947497d179ecc99e0021/common/gpu/intel/coffee-lake/default.nix#L10-L13

[^1]: https://en.wikipedia.org/wiki/Intel_Graphics_Technology#Capabilities_(GPU_video_acceleration)
[^2]: https://github.com/intel/compute-runtime/blob/master/documentation/LEGACY_PLATFORMS.md#maintenance-expectations
[^3]: See the model links here: https://en.wikipedia.org/wiki/Whiskey_Lake

Continuation of https://github.com/NixOS/nixos-hardware/commit/e049c10c3e9f9e48e6f984c7993c7bd447395fb6.

Tested on a Lenovo ThinkPad T490 with an Intel® Core™ i7-8665U processor:

https://www.intel.com/content/www/us/en/products/sku/193563/intel-core-i78665u-processor-8m-cache-up-to-4-80-ghz/specifications.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

