### PR TITLE
lenovo/legion: clean up legacy X11 driver overrides and initrd settings

### DIFF
--- a/lenovo/legion/15ach6h/hybrid/default.nix
+++ b/lenovo/legion/15ach6h/hybrid/default.nix
@@ -13,6 +13,7 @@
 
   hardware.nvidia = {
     powerManagement.enable = lib.mkDefault true;
+    powerManagement.finegrained = lib.mkDefault true;
 
     prime = {
       amdgpuBusId = lib.mkDefault "PCI:6:0:0";

--- a/lenovo/legion/15ach6h/hybrid/default.nix
+++ b/lenovo/legion/15ach6h/hybrid/default.nix
@@ -11,26 +11,12 @@
     ../../../../common/pc/ssd
   ];
 
-  # Still needs to load at some point if we want X11 to work
-  boot.kernelModules = [ "amdgpu" ];
+  hardware.nvidia = {
+    powerManagement.enable = lib.mkDefault true;
 
-  # modesetting just doesn't work (on X11?), so get rid of it by only explicitly declaring nvidia
-  # Needed due to https://github.com/NixOS/nixos-hardware/commit/630a8e3e4eea61d35524699f2f59dbc64886357d
-  # See also https://github.com/NixOS/nixos-hardware/issues/628
-  # options.services.xserver.drivers will have a amdgpu entry from using the prime stuff in nixpkgs
-  services.xserver.videoDrivers = [ "nvidia" ];
-
-  hardware = {
-    amdgpu.initrd.enable = false;
-
-    nvidia = {
-      modesetting.enable = lib.mkDefault true;
-      powerManagement.enable = lib.mkDefault true;
-
-      prime = {
-        amdgpuBusId = lib.mkDefault "PCI:6:0:0";
-        nvidiaBusId = "PCI:1:0:0";
-      };
+    prime = {
+      amdgpuBusId = lib.mkDefault "PCI:6:0:0";
+      nvidiaBusId = "PCI:1:0:0";
     };
   };
 }

--- a/lenovo/legion/15ach6h/nvidia/default.nix
+++ b/lenovo/legion/15ach6h/nvidia/default.nix
@@ -12,6 +12,7 @@
   # of nix cannot implement such an operation as canceling an import.
   hardware = {
     nvidia.prime.offload.enable = false;
+    nvidia.powerManagement.finegrained = false;
   }
   // lib.optionalAttrs (options ? amdgpu.opencl.enable) {
     # introduced in https://github.com/NixOS/nixpkgs/pull/319865

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -15,6 +15,7 @@
 
   hardware.nvidia = {
     powerManagement.enable = lib.mkDefault true;
+    powerManagement.finegrained = lib.mkDefault true;
     dynamicBoost.enable = lib.mkDefault true;
 
     prime = {

--- a/lenovo/legion/16ach6h/hybrid/default.nix
+++ b/lenovo/legion/16ach6h/hybrid/default.nix
@@ -13,27 +13,13 @@
     ../edid
   ];
 
-  # Still needs to load at some point if we want X11 to work
-  boot.kernelModules = [ "amdgpu" ];
+  hardware.nvidia = {
+    powerManagement.enable = lib.mkDefault true;
+    dynamicBoost.enable = lib.mkDefault true;
 
-  # modesetting just doesn't work (on X11?), so get rid of it by only explicitly declaring nvidia
-  # Needed due to https://github.com/NixOS/nixos-hardware/commit/630a8e3e4eea61d35524699f2f59dbc64886357d
-  # See also https://github.com/NixOS/nixos-hardware/issues/628
-  # options.services.xserver.drivers will have a amdgpu entry from using the prime stuff in nixpkgs
-  services.xserver.videoDrivers = [ "nvidia" ];
-
-  hardware = {
-    amdgpu.initrd.enable = false;
-
-    nvidia = {
-      modesetting.enable = lib.mkDefault true;
-      powerManagement.enable = lib.mkDefault true;
-      dynamicBoost.enable = lib.mkDefault true;
-
-      prime = {
-        amdgpuBusId = lib.mkDefault "PCI:5:0:0";
-        nvidiaBusId = "PCI:1:0:0";
-      };
+    prime = {
+      amdgpuBusId = lib.mkDefault "PCI:5:0:0";
+      nvidiaBusId = "PCI:1:0:0";
     };
   };
 }

--- a/lenovo/legion/16ach6h/nvidia/default.nix
+++ b/lenovo/legion/16ach6h/nvidia/default.nix
@@ -12,6 +12,7 @@
   # of nix cannot implement such an operation as canceling an import.
   hardware = {
     nvidia.prime.offload.enable = false;
+    nvidia.powerManagement.finegrained = false;
   }
   // lib.optionalAttrs (options ? amdgpu.opencl.enable) {
     # introduced in https://github.com/NixOS/nixpkgs/pull/319865

--- a/lenovo/legion/16achg6/hybrid/default.nix
+++ b/lenovo/legion/16achg6/hybrid/default.nix
@@ -13,6 +13,7 @@
   hardware = {
     nvidia = {
       powerManagement.enable = lib.mkDefault true;
+      powerManagement.finegrained = lib.mkDefault true;
       open = lib.mkDefault false;
 
       prime = {

--- a/lenovo/legion/16achg6/hybrid/default.nix
+++ b/lenovo/legion/16achg6/hybrid/default.nix
@@ -10,12 +10,8 @@
     ../../../../common/pc/ssd
   ];
 
-  services.xserver.videoDrivers = [ "nvidia" ];
-  boot.initrd.kernelModules = [ "amdgpu" ];
-
   hardware = {
     nvidia = {
-      modesetting.enable = lib.mkDefault true;
       powerManagement.enable = lib.mkDefault true;
       open = lib.mkDefault false;
 

--- a/lenovo/legion/16achg6/nvidia/default.nix
+++ b/lenovo/legion/16achg6/nvidia/default.nix
@@ -5,6 +5,7 @@
   services.xserver.videoDrivers = [ "nvidia" ];
   hardware = {
     nvidia.prime.offload.enable = false;
+    nvidia.powerManagement.finegrained = false;
   }
   // lib.optionalAttrs (options ? amdgpu.opencl.enable) {
     # introduced in https://github.com/NixOS/nixpkgs/pull/319865

--- a/lenovo/legion/16aph8/default.nix
+++ b/lenovo/legion/16aph8/default.nix
@@ -19,7 +19,6 @@
   ];
 
   hardware.nvidia = {
-    modesetting.enable = lib.mkDefault true;
     powerManagement.enable = lib.mkDefault false;
     powerManagement.finegrained = lib.mkDefault false;
     open = lib.mkDefault false;
@@ -29,9 +28,6 @@
       nvidiaBusId = "PCI:1:0:0";
     };
   };
-
-  # Avoid issues with modesetting causing blank screen
-  services.xserver.videoDrivers = [ "nvidia" ];
 
   # AMD has better battery life with PPD over TLP:
   # https://community.frame.work/t/responded-amd-7040-sleep-states/38101/13

--- a/lenovo/legion/16arh7h/hybrid/default.nix
+++ b/lenovo/legion/16arh7h/hybrid/default.nix
@@ -7,24 +7,16 @@
   imports = [
     ../../../../common/cpu/amd
     ../../../../common/cpu/amd/pstate.nix
+    ../../../../common/gpu/amd
     ../../../../common/gpu/nvidia/prime.nix # prime offload
     ../../../../common/gpu/nvidia/ampere # use open drivers
     ../../../../common/pc/laptop
     ../../../../common/pc/ssd
   ];
 
-  boot.kernelModules = [ "amdgpu" ];
-  services.xserver.videoDrivers = [
-    "amdgpu"
-    "nvidia"
-  ];
-
   hardware = {
-    amdgpu.initrd.enable = false;
-
     nvidia = {
       package = config.boot.kernelPackages.nvidiaPackages.latest;
-      modesetting.enable = lib.mkDefault true;
       powerManagement.enable = lib.mkDefault true;
       powerManagement.finegrained = lib.mkDefault true;
       prime = {


### PR DESCRIPTION
###### Description of changes

Clean up legacy driver overrides and initrd settings across Lenovo Legion profiles (`15ach6h/hybrid`, `16ach6h/hybrid`, `16achg6/hybrid`, `16arh7h/hybrid`, `16aph8`):

- **Fixes dGPU power/fan regressions on Wayland:** Hardcoding `services.xserver.videoDrivers = [ "nvidia" ];` stripped `modesetting` and caused Wayland compositors (like KWin on Plasma 6) to treat the laptop as an NVIDIA-only machine. As a result, the compositor ran all desktop UI rendering on the RTX dGPU instead of the AMD iGPU, causing continuous 15W–40W power draw, elevated temperatures (~58°C at idle), and aggressive fan spin (2600–3500+ RPM) during light usage (those stats come from my own use-case, hardware and testings). Removing the override allows `common/gpu/amd` (`modesetting`) and `common/gpu/nvidia` (`nvidia`) to merge cleanly via `mkDefault`.
- **Restores default early KMS:** Removes `hardware.amdgpu.initrd.enable = false;` so the AMD iGPU initializes in stage-1 for native resolution boot.
- **Cleans up redundant options:** Removes redundant `boot.kernelModules = [ "amdgpu" ]` and `hardware.nvidia.modesetting.enable = lib.mkDefault true;`.
- **Aligns AMD profiles:** Adds `common/gpu/amd` to `16arh7h/hybrid`.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input