### PR TITLE
common/gpu/nvidia/prime: enable switcheroo-control by default

### DIFF
--- a/common/gpu/nvidia/prime.nix
+++ b/common/gpu/nvidia/prime.nix
@@ -8,6 +8,7 @@
   };
 
   config = {
+    services.switcherooControl.enable = lib.mkDefault true;
 
     hardware.nvidia.prime = {
       offload = {

--- a/dell/xps/15-9510/nvidia/default.nix
+++ b/dell/xps/15-9510/nvidia/default.nix
@@ -5,9 +5,6 @@
     ../../../../common/gpu/nvidia/ampere
   ];
 
-  #D-Bus service to check the availability of dual-GPU
-  services.switcherooControl.enable = lib.mkDefault true;
-
   hardware = {
     graphics = {
       enable = lib.mkDefault true;


### PR DESCRIPTION
###### Description of changes

Enables `services.switcherooControl.enable = lib.mkDefault true;` in `common/gpu/nvidia/prime.nix`.

`switcheroo-control` is the D-Bus daemon used by desktop environments (such as KDE Plasma and GNOME) to detect dual-GPU availability, enable right-click "Run with dedicated graphics processor" in application launchers, and automatically launch apps that specify `PrefersNonDefaultGPU=true` on the discrete GPU.

Since `common/gpu/nvidia/prime.nix` is imported exclusively by hybrid multi-GPU laptop configurations that configure PRIME render offload, enabling this D-Bus service by default provides automatic desktop integration out of the box for all profiles importing this module.

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and importing it via `<nixos-hardware>` or Flake input