### PR TITLE
raspberry-pi: remove DWC2 module

### DIFF
--- a/raspberry-pi/4/dwc2.nix
+++ b/raspberry-pi/4/dwc2.nix
@@ -1,86 +1,34 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
-let
-  cfg = config.hardware.raspberry-pi."4".dwc2;
-in
 {
-  options.hardware = {
-    raspberry-pi."4".dwc2 = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Enable the UDC controller to support USB OTG gadget functions.
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "hardware"
+        "raspberry-pi"
+        "4"
+        "dwc2"
+      ]
+      ''
+        Use the stock dwc2 firmware overlay instead:
 
-          In order to verify that this works, connect the Raspberry Pi with
-          another computer via the USB C cable, and then do one of:
+          {
+            boot.loader.generic-extlinux-compatible.useGenerationDeviceTree =
+              false;
 
-          - `modprobe g_serial`
-          - `modprobe g_mass_storage file=/path/to/some/iso-file.iso`
+            hardware.raspberry-pi.configtxt.deviceTreeOverlays.pi4 = [
+              { dwc2 = { }; }
+            ];
+          }
 
-          On the Raspberry Pi, `dmesg` should then show success-indicating output
-          that is related to the dwc2 and g_serial/g_mass_storage modules.
-          On the other computer, a serial/mass-storage device should pop up in
-          the system logs.
+        If you set dr_mode on the old option, add it to the overlay. For
+        example:
 
-          For more information about what gadget functions exist along with handy
-          guides on how to test them, please refer to:
-          https://www.kernel.org/doc/Documentation/usb/gadget-testing.txt
-        '';
-      };
-      dr_mode = lib.mkOption {
-        type = lib.types.enum [
-          "host"
-          "peripheral"
-          "otg"
-        ];
-        default = "otg";
-        description = ''
-          Dual role mode setting for the dwc2 USB controller driver.
-        '';
-      };
-    };
-  };
+          { dwc2.dr_mode = "host"; }
 
-  config = lib.mkIf cfg.enable {
-    # Configure for modesetting in the device tree
-    hardware.deviceTree = {
-      overlays = [
-        # this *should* be equivalent to (which doesn't work):
-        # https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/dwc2-overlay.dts
-        # but actually it's obtained using
-        # dtc -I dtb -O dts ${config.hardware.deviceTree.kernelPackage}/dtbs/overlays/dwc2.dtbo
-        # (changes: modified top-level "compatible" field)
-        # which is slightly different and works
-        {
-          name = "dwc2-overlay";
-          dtsText = ''
-            /dts-v1/;
-            /plugin/;
-
-            / {
-              compatible = "brcm,bcm2711";
-
-              fragment@0 {
-                target = <&usb>;
-                #address-cells = <0x01>;
-                #size-cells = <0x01>;
-
-                __overlay__ {
-                  compatible = "brcm,bcm2835-usb";
-                  dr_mode = "${cfg.dr_mode}";
-                  g-np-tx-fifo-size = <0x20>;
-                  g-rx-fifo-size = <0x22e>;
-                  g-tx-fifo-size = <0x200 0x200 0x200 0x200 0x200 0x100 0x100>;
-                  status = "okay";
-                  phandle = <0x01>;
-                };
-              };
-            };
-          '';
-        }
-      ];
-    };
-  };
+        For CM4 and firmware-partition setup, see "DWC2 USB controller" in
+        raspberry-pi/README.md.
+      ''
+    )
+  ];
 }

--- a/raspberry-pi/README.md
+++ b/raspberry-pi/README.md
@@ -6,7 +6,7 @@ NixOS profiles and modules for Raspberry Pi boards.
 
 - `common/` has the shared bits: the `linux-rpi` kernel build (vendor defconfig, matching firmware), the `config.txt` generation module, a pinned wireless firmware, and the firmware-partition install module.
 - `2/`, `3/`, `4/`, `5/` are the board profiles. Each one picks the right kernel and kernel params. Pi 4 and 5 also set DT filters and the initrd modules they need.
-- The extra files under `4/` are opt-in toggles for Pi 4 hardware: audio, dwc2, GPIO, I2C, LEDs, touchscreens, and so on.
+- The extra files under `4/` are opt-in toggles for Pi 4 hardware: audio, GPIO, I2C, LEDs, touchscreens, and so on.
 
 ## Using a board profile
 
@@ -68,7 +68,7 @@ dtparam=audio=on
 dtparam=i2c_arm=on
 ```
 
-Top-level attrs are conditional sections (`all`, `pi4`, `pi5`, `cm4`, and so on). Nesting stacks filters. To drop a default, set the key to `null` with `mkForce`.
+Top-level attrs are conditional sections (`all`, `pi4`, `pi5`, `cm4`, and so on). Nesting stacks filters. Set a board profile's `mkDefault` value to `null` to remove it. Use `mkForce null` when overriding a value with normal priority.
 
 Every rendered group opens with `[all]` and then its own filters. Filters of different types stack rather than replace, so `[all]` is what clears the previous group before the next one starts.
 
@@ -80,6 +80,8 @@ Overlays go in `configtxt.deviceTreeOverlays`, not in a `dtoverlay` key under `s
 
 ```nix
 {
+  boot.loader.generic-extlinux-compatible.useGenerationDeviceTree = false;
+
   hardware.raspberry-pi.configtxt.deviceTreeOverlays.pi4 = [
     { dwc2.dr_mode = "host"; }
     {
@@ -113,6 +115,39 @@ Overlays render after `settings`. This order keeps base parameters such as `dtpa
 Each parameter becomes its own `dtparam` line rather than an addition to the `dtoverlay` line, which keeps them clear of the 98-character line limit. Booleans render as `on` or `off`. Use `null` with `mkForce` to remove a parameter.
 
 The module concatenates lists from separate modules, but the order is not the order of definition. If one overlay must load before another, set the order with `mkBefore` or `mkAfter`.
+
+The Raspberry Pi firmware applies these overlays before U-Boot starts. Set `boot.loader.generic-extlinux-compatible.useGenerationDeviceTree = false` so U-Boot keeps that device tree instead of loading one from the NixOS generation. Enabling `hardware.raspberry-pi.firmware.uboot.enable` sets this automatically.
+
+The firmware partition must contain the generated `config.txt` and stock overlays. SD image builds populate it automatically. On a running system, set `hardware.raspberry-pi.firmware.enable = true`.
+
+#### DWC2 USB controller
+
+Use the stock `dwc2` overlay to enable the USB 2.0 controller on the Pi 4B USB-C connector:
+
+```nix
+{
+  hardware.raspberry-pi.configtxt.deviceTreeOverlays."board-type=0x11" = [
+    { dwc2 = { }; }
+  ];
+}
+```
+
+`board-type=0x11` matches the Pi 4B. The broader `pi4` filter also matches Pi 400, CM4, and CM4S.
+
+[Raspberry Pi OS sets `otg_mode=1` on CM4](https://github.com/RPi-Distro/pi-gen/blob/master/stage1/00-boot-files/files/config.txt#L39-L43), and [nixos-hardware sets the same default](./common/config-txt-defaults.nix). Set it to `null` before loading DWC2:
+
+```nix
+{
+  hardware.raspberry-pi.configtxt = {
+    settings.cm4.otg_mode = null;
+    deviceTreeOverlays.cm4 = [
+      { dwc2 = { }; }
+    ];
+  };
+}
+```
+
+The `cm4` filter matches CM4 only. Set `dwc2.dr_mode` to `host`, `peripheral`, or `otg` to override the overlay default. The overlay also accepts `g-rx-fifo-size` and `g-np-tx-fifo-size`.
 
 #### PoE HATs
 


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Removes `hardware.raspberry-pi."4".dwc2` in favour of [the stock `dwc2` firmware overlay](https://github.com/raspberrypi/linux/blob/rpi-6.18.y/arch/arm/boot/dts/overlays/dwc2-overlay.dts) through `hardware.raspberry-pi.configtxt.deviceTreeOverlays`.

The removal message maps the old `dr_mode` option and explains the CM4 `otg_mode=1` conflict. The README includes Pi 4B and CM4 examples, including the extlinux setting needed to preserve firmware-applied overlays.

Part of #1946.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

