### PR TITLE
qnap/ts-x33: init TS-233 and TS-433 profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ See code for all available configurations.
 | [Purism Librem 13v3](purism/librem/13v3)                                          | `<nixos-hardware/purism/librem/13v3>`                   | `purism-librem-13v3`                   |
 | [Purism Librem 15v3](purism/librem/15v3)                                          | `<nixos-hardware/purism/librem/15v3>`                   | `purism-librem-15v3`                   |
 | [Purism Librem 5r4](purism/librem/5r4)                                            | `<nixos-hardware/purism/librem/5r4>`                    | `purism-librem-5r4`                    |
+| [QNAP TS-233](qnap/ts-233)                                                        | `<nixos-hardware/qnap/ts-233>`                          | `qnap-ts-233`                          |
+| [QNAP TS-433](qnap/ts-433)                                                        | `<nixos-hardware/qnap/ts-433>`                          | `qnap-ts-433`                          |
 | [Radxa ROCK 3C](radxa/rock-3c)                                                    | `<nixos-hardware/radxa/rock-3c>`                        | `radxa-rock-3c`                        |
 | [Radxa ROCK 4C+](radxa/rock-4c-plus)                                              | `<nixos-hardware/radxa/rock-4c-plus>`                   | `rock-4c-plus`                         |
 | [Radxa ROCK 5 Model B](radxa/rock-5b)                                             | `<nixos-hardware/radxa/rock-5b>`                        | `rock-5b`                              |

--- a/flake.nix
+++ b/flake.nix
@@ -413,6 +413,8 @@
           purism-librem-13v3 = import ./purism/librem/13v3;
           purism-librem-15v3 = import ./purism/librem/15v3;
           purism-librem-5r4 = import ./purism/librem/5r4;
+          qnap-ts-233 = import ./qnap/ts-233;
+          qnap-ts-433 = import ./qnap/ts-433;
           razer-blade-14-RZ09-0530 = import ./razer/blade/14/RZ09-0530;
           raspberry-pi-2 = import ./raspberry-pi/2;
           raspberry-pi-3 = import ./raspberry-pi/3;

--- a/qnap/ts-233/README.md
+++ b/qnap/ts-233/README.md
@@ -1,0 +1,20 @@
+# QNAP TS-233
+
+See the [TS-x33 family documentation][family] for bootloader, installation,
+storage layout, and common hardware support.
+
+The 1 GbE jack uses the RK3568 GMAC with the `dwmac_rk` driver, which loads
+automatically.
+
+TS-233 revisions with mainboard PCB 12 or newer and backplane PCB 11 or newer
+have per-drive power controls. Linux 7.1 and newer provide the composed
+`rockchip/rk3568-qnap-ts233-pcb-12-11.dtb` for these revisions. After confirming
+both PCB revisions from the VPD EEPROMs, select it with:
+
+```nix
+hardware.deviceTree.name = "rockchip/rk3568-qnap-ts233-pcb-12-11.dtb";
+```
+
+Older boards must keep the default DTB.
+
+[family]: ../ts-x33

--- a/qnap/ts-233/default.nix
+++ b/qnap/ts-233/default.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+
+{
+  imports = [ ../ts-x33 ];
+
+  hardware.deviceTree.name = lib.mkDefault "rockchip/rk3568-qnap-ts233.dtb";
+}

--- a/qnap/ts-433/README.md
+++ b/qnap/ts-433/README.md
@@ -1,0 +1,21 @@
+# QNAP TS-433
+
+See the [TS-x33 family documentation][family] for bootloader, installation,
+storage layout, and common hardware support.
+
+The 1 GbE jack uses the RK3568 GMAC with the `dwmac_rk` driver. The upper 2.5
+GbE jack uses a PCIe RTL8125B with the in-tree `r8169` driver. Both drivers load
+automatically; the profile enables redistributable firmware for the RTL8125B.
+
+TS-433 revisions with mainboard PCB 12 or newer and backplane PCB 10 or newer
+have per-drive power controls. Linux 7.1 and newer provide the composed
+`rockchip/rk3568-qnap-ts433-pcb-12-10.dtb` for these revisions. After confirming
+both PCB revisions from the VPD EEPROMs, select it with:
+
+```nix
+hardware.deviceTree.name = "rockchip/rk3568-qnap-ts433-pcb-12-10.dtb";
+```
+
+Older boards must keep the default DTB.
+
+[family]: ../ts-x33

--- a/qnap/ts-433/default.nix
+++ b/qnap/ts-433/default.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+
+{
+  imports = [ ../ts-x33 ];
+
+  # The PCIe AHCI controller serves drive bays 3 and 4.
+  boot.initrd.availableKernelModules = [ "ahci" ];
+
+  hardware = {
+    deviceTree.name = lib.mkDefault "rockchip/rk3568-qnap-ts433.dtb";
+    # The RTL8125B 2.5GbE controller can use firmware from linux-firmware.
+    enableRedistributableFirmware = lib.mkDefault true;
+  };
+}

--- a/qnap/ts-x33/README.md
+++ b/qnap/ts-x33/README.md
@@ -1,0 +1,48 @@
+# QNAP TS-x33 family
+
+These profiles expect a mainline U-Boot installation and use its extlinux
+support. The TS-233 and TS-433 share an upstream U-Boot configuration; see the
+[upstream TS-433 documentation][u-boot] for build and flashing instructions.
+Prebuilt reproducible model-specific images are available from the
+[TS-233/TS-433 bootloader builder][builder].
+
+A dedicated ext4 partition on the internal eMMC, mounted at `/boot`, is
+recommended for the extlinux configuration, kernels, initrds, and device trees;
+the root filesystem can remain on SATA or USB. The generated
+`/boot/extlinux/extlinux.conf` appears as `/extlinux/extlinux.conf` to U-Boot.
+FAT32 also works but is only useful when compatibility with other firmware is
+needed.
+
+Mainline U-Boot boots the standard [NixOS aarch64 installer ISO][installer]
+when written to a USB drive. Installation requires a 3.3 V USB-to-TTL serial
+adapter with a 4-pin JST PH connector (2.0 mm pitch) at 115200 8N1. Connect TX,
+RX, and ground only; do not connect VCC. This adapter is separate from the
+USB-A-to-A cable used for maskrom flashing.
+
+## PCB revision
+
+Read the mainboard and backplane VPD product strings from their read-only
+EEPROMs:
+
+```console
+$ sudo dd if="$(printf '%s\n' /sys/bus/i2c/devices/*-0054/eeprom)" bs=1 skip=66 count=22 status=none | tr -d '\000'; echo
+$ sudo dd if="$(printf '%s\n' /sys/bus/i2c/devices/*-0056/eeprom)" bs=1 skip=106 count=22 status=none | tr -d '\000'; echo
+```
+
+The first line is the mainboard and the second is the backplane. For example,
+`70-006Q0B2-001-120-RS` reports mainboard PCB 12, while
+`70-010Q0B3-000-110-RS` reports backplane PCB 11. Compare both revisions with
+the requirements on the model-specific page before selecting a PCB-specific
+device tree.
+
+The kernel device tree configures the QNAP MCU, which handles fan control,
+case-temperature monitoring, red drive fault LEDs, USB and status LEDs, the
+power button, buzzer, and peripheral power-off. No userspace fan-control service
+is needed.
+
+Green drive LEDs are GPIO-controlled and default to the global `disk-activity`
+trigger. Current mainline Linux does not expose the chassis LAN LED.
+
+[builder]: https://github.com/dbast/qnap-ts-433-bootloader-builder
+[installer]: https://nixos.org/download/#nixos-iso
+[u-boot]: https://docs.u-boot.org/en/stable/board/qnap/ts433.html

--- a/qnap/ts-x33/default.nix
+++ b/qnap/ts-x33/default.nix
@@ -1,0 +1,47 @@
+{ lib, pkgs, ... }:
+
+{
+  boot = {
+    # TS-233 device-tree support requires Linux 6.19 or newer.
+    kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
+    initrd = {
+      # Allow booting from the eMMC or USB in addition to SATA.
+      availableKernelModules = [
+        "dwc3"
+        "ehci_platform"
+        "mmc_block"
+        "ohci_platform"
+        "phy_rockchip_inno_usb2"
+        "sdhci_of_dwcmshc"
+        "uas"
+        "usb_storage"
+        "xhci_plat_hcd"
+      ];
+
+      # Load the Rockchip SATA PHY and controller before the initrd searches
+      # for filesystems.
+      kernelModules = [
+        "phy_rockchip_naneng_combphy"
+        "ahci_dwc"
+      ];
+    };
+
+    # QNAP configures this serial console for 115200 rather than Rockchip's
+    # commonly used 1500000 baud.
+    kernelParams = [ "console=ttyS2,115200n8" ];
+
+    # Let the external battery-backed RTC selected by the device tree become
+    # rtc0 instead of the RK809 PMIC's RTC.
+    blacklistedKernelModules = [ "rtc_rk808" ];
+
+    # Mainline U-Boot loads NixOS generations from extlinux.conf.
+    loader = {
+      generic-extlinux-compatible.enable = lib.mkDefault true;
+      grub.enable = lib.mkDefault false;
+    };
+  };
+
+  hardware.deviceTree.enable = lib.mkDefault true;
+  nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+}

--- a/tests/nixos-tests.nix
+++ b/tests/nixos-tests.nix
@@ -25,6 +25,8 @@ let
     "nxp-imx8mq-evk"
     "nxp-imx8qm-mek"
     "nxp-imx93-evk"
+    "qnap-ts-233"
+    "qnap-ts-433"
     "ucm-imx95"
   ];
 


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
Add shared extlinux, eMMC, USB, and native SATA configuration for the QNAP TS-x33 family. Select model-specific device trees and enable PCIe AHCI and RTL8125B firmware for the TS-433.

Document MCU support, network controllers and PCB revision overlays.

Tested with QNAP TS-233 + TS-433 + nixOS 26.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

