### PR TITLE
mnt/reform: convert update patches to derivation

### DIFF
--- a/mnt/reform/updateKernelPatches.nix
+++ b/mnt/reform/updateKernelPatches.nix
@@ -1,4 +1,5 @@
 {
+  runCommand,
   lib,
   fetchFromGitLab,
 }:
@@ -7,6 +8,8 @@ let
   sources = lib.importJSON ./sources.json;
   reformDebianPackages = fetchFromGitLab sources.reformDebianPackages;
 in
-map (lib.removePrefix "${reformDebianPackages}/") (
-  lib.filesystem.listFilesRecursive "${reformDebianPackages}/linux/patches${lib.versions.majorMinor sources.modDirVersion}"
-)
+runCommand "mnt-reform-kernel-patches" { } ''
+  shopt -s globstar
+  cd ${reformDebianPackages}
+  echo "[ $(printf '"%s"' linux/patches${lib.versions.majorMinor sources.modDirVersion}/**/*.patch) ]" > $out
+''

--- a/mnt/reform/updateKernelPatches.sh
+++ b/mnt/reform/updateKernelPatches.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 
-nix eval .#mnt-reform-kernel-patches > kernelPatches.nix
+nix build .#mnt-reform-kernel-patches
+cp result kernelPatches.nix
 nix fmt kernelPatches.nix


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes
This PR changes the updateKernelPackages script to use a derivation instead of a value in the flake.
With this change `nix search . ^` works again. So this should fix #2013 at least for the search part. The fact that no archives are created is still a problem.

###### Things done

I have checked that the output of the script is still the same.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

