### PR TITLE
raspberry-pi: remove DigiAMP+ module

### DIFF
--- a/raspberry-pi/4/digi-amp-plus.nix
+++ b/raspberry-pi/4/digi-amp-plus.nix
@@ -1,91 +1,42 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
-let
-  cfg = config.hardware.raspberry-pi."4".digi-amp-plus;
-in
 {
-  options.hardware = {
-    raspberry-pi."4".digi-amp-plus = {
-      enable = lib.mkEnableOption "support for the IQaudIO DigiAMP+ Hat";
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "hardware"
+        "raspberry-pi"
+        "4"
+        "digi-amp-plus"
+      ]
+      ''
+        Use the stock iqaudio-dacplus firmware overlay instead:
 
-      unmuteAmp = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to "one-shot" unmute when kernel module first loads.
-        '';
-      };
+          {
+            boot.loader.generic-extlinux-compatible.useGenerationDeviceTree =
+              false;
 
-      autoMuteAmp = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Unmute the amp when an ALSA device is opened by a client. Mute, with a five-second delay when the ALSA device is closed.
-          (Reopening the device within the five-second close window will cancel mute.)
-        '';
-      };
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    hardware.raspberry-pi."4".apply-overlays-dtmerge.enable = lib.mkDefault true;
-
-    hardware.deviceTree = {
-      overlays = [
-        # Adapted from to: https://github.com/raspberrypi/linux/blob/3ed6d34d53e94ecbebc64c8fa3d1b6d3c41db8fb/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
-        # changes:
-        # - modified top-level "compatible" field from bcm2835 to bcm2711
-        # - s/i2s_clk_producer/i2s/ (name on bcm2711 platform)
-        {
-          name = "iqaudio-digiampplus-overlay";
-          dtsText = ''
-            /dts-v1/;
-            /plugin/;
-
-            / {
-              compatible = "brcm,bcm2711";
-
-              fragment@0 {
-                target = <&i2s>;
-                __overlay__ {
-                  status = "okay";
+            hardware.raspberry-pi.configtxt.deviceTreeOverlays.pi4 = [
+              {
+                iqaudio-dacplus = {
+                  auto_mute_amp = true;
+                  unmute_amp = false;
                 };
-              };
+              }
+            ];
+          }
 
-              fragment@1 {
-                target = <&i2c1>;
-                __overlay__ {
-                  #address-cells = <1>;
-                  #size-cells = <0>;
-                  status = "okay";
+        Keep the old boolean values. Map autoMuteAmp to auto_mute_amp and
+        unmuteAmp to unmute_amp.
 
-                  pcm5122@4c {
-                    #sound-dai-cells = <0>;
-                    compatible = "ti,pcm5122";
-                    reg = <0x4c>;
-                    AVDD-supply = <&vdd_3v3_reg>;
-                    DVDD-supply = <&vdd_3v3_reg>;
-                    CPVDD-supply = <&vdd_3v3_reg>;
-                    status = "okay";
-                  };
-                };
-              };
+        On a running system, set hardware.raspberry-pi.firmware.enable to true.
 
-              fragment@2 {
-                target = <&sound>;
-                iqaudio_dac: __overlay__ {
-                  compatible = "iqaudio,iqaudio-dac";
-                  i2s-controller = <&i2s>;
-                  mute-gpios = <&gpio 22 0>;
-                  status = "okay";
-                  ${lib.optionalString cfg.unmuteAmp "iqaudio-dac,unmute-amp;"}
-                  ${lib.optionalString cfg.autoMuteAmp "iqaudio-dac,auto-mute-amp;"}
-                };
-              };
-            };
-          '';
-        }
-      ];
-    };
-  };
+        For NixOS-Hardware specific firmware setup, read:
+        raspberry-pi/README.md.
+
+        For digiamp specific details, see:
+        https://www.raspberrypi.com/documentation/accessories/audio.html#raspberry-pi-digiamp
+      ''
+    )
+  ];
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

Removes `hardware.raspberry-pi."4".digi-amp-plus` in favour of the stock `iqaudio-dacplus` firmware overlay through `hardware.raspberry-pi.configtxt.deviceTreeOverlays`.

The migration keeps the old `autoMuteAmp` and `unmuteAmp` defaults and behaviour. It uses [`iqaudio-dacplus`][1] instead of [`rpi-digiampplus`][2] (because the latter makes `unmute_amp` disable auto-mute).


Part of #1946.

cc: @doronbehar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

[1]: https://github.com/raspberrypi/linux/blob/rpi-6.18.y/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
[2]: https://github.com/raspberrypi/linux/blob/rpi-6.18.y/arch/arm/boot/dts/overlays/rpi-digiampplus-overlay.dts