### PR TITLE
thinkpad: t14: gen6: initial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ See code for all available configurations.
 | [Lenovo ThinkPad T14 AMD Gen 3](lenovo/thinkpad/t14/amd/gen3)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen3>`         | `lenovo-thinkpad-t14-amd-gen3`         |
 | [Lenovo ThinkPad T14 AMD Gen 4](lenovo/thinkpad/t14/amd/gen4)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen4>`         | `lenovo-thinkpad-t14-amd-gen4`         |
 | [Lenovo ThinkPad T14 AMD Gen 5](lenovo/thinkpad/t14/amd/gen5)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen5>`         | `lenovo-thinkpad-t14-amd-gen5`         |
+| [Lenovo ThinkPad T14 AMD Gen 6](lenovo/thinkpad/t14/amd/gen6)                     | `<nixos-hardware/lenovo/thinkpad/t14/amd/gen6>`         | `lenovo-thinkpad-t14-amd-gen6`         |
 | [Lenovo ThinkPad T14](lenovo/thinkpad/t14)                                        | `<nixos-hardware/lenovo/thinkpad/t14>`                  | `lenovo-thinkpad-t14`                  |
 | [Lenovo ThinkPad T14 Intel Gen 1](lenovo/thinkpad/t14/intel/gen1)                 | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1>`       | `lenovo-thinkpad-t14-intel-gen1`       |
 | [Lenovo ThinkPad T14 Intel Gen 1 (Nvidia)](lenovo/thinkpad/t14/intel/gen1/nvidia) | `<nixos-hardware/lenovo/thinkpad/t14/intel/gen1/nvidia>`| `lenovo-thinkpad-t14-intel-gen1-nvidia`|

--- a/flake.nix
+++ b/flake.nix
@@ -291,6 +291,7 @@
           lenovo-thinkpad-t14-amd-gen3 = import ./lenovo/thinkpad/t14/amd/gen3;
           lenovo-thinkpad-t14-amd-gen4 = import ./lenovo/thinkpad/t14/amd/gen4;
           lenovo-thinkpad-t14-amd-gen5 = import ./lenovo/thinkpad/t14/amd/gen5;
+          lenovo-thinkpad-t14-amd-gen6 = import ./lenovo/thinkpad/t14/amd/gen6;
           lenovo-thinkpad-t14-intel-gen1 = import ./lenovo/thinkpad/t14/intel/gen1;
           lenovo-thinkpad-t14-intel-gen1-nvidia = import ./lenovo/thinkpad/t14/intel/gen1/nvidia;
           lenovo-thinkpad-t14-intel-gen6 = import ./lenovo/thinkpad/t14/intel/gen6;

--- a/lenovo/thinkpad/t14/amd/gen6/README.md
+++ b/lenovo/thinkpad/t14/amd/gen6/README.md
@@ -1,0 +1,18 @@
+# Firmware
+
+This laptop requires MediaTek firmware to work, sadly the Wi-Fi + Bluetooth chip (MT7925) is
+soldered on board and can't be changed.  The firmware is unfree, and is enabled via
+`hardware.enableAllFirmware`, so you need to allow installation of unfree packages or enable unfree
+firmware manually:
+
+```nix
+nixpkgs.config.allowUnfreePredicate =
+  pkg:
+  builtins.elem (lib.getName pkg) [
+    "broadcom-bt-firmware"
+    "b43-firmware"
+    "xone-dongle-firmware"
+    "facetimehd-calibration"
+    "facetimehd-firmware"
+  ];
+```

--- a/lenovo/thinkpad/t14/amd/gen6/default.nix
+++ b/lenovo/thinkpad/t14/amd/gen6/default.nix
@@ -1,0 +1,10 @@
+{
+  ...
+}:
+{
+  imports = [
+    ../.
+    ../../../../../common/wifi/mediatek/mt7925
+    ../../../../../common/wifi/mediatek/mt7925/iwd.nix
+  ];
+}


### PR DESCRIPTION
I've recently purchased a T14 g6 AMD, some tweaks are needed for wifi to work :). 

###### Description of changes
- Enabled MediaTek  support for T14

###### Things done

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

