### PR TITLE
pc/laptop: do not enable tlp if tuned is enabled

### DIFF
--- a/common/pc/laptop/default.nix
+++ b/common/pc/laptop/default.nix
@@ -3,5 +3,7 @@
 {
   imports = [ ../. ];
 
-  services.tlp.enable = lib.mkDefault (!config.services.power-profiles-daemon.enable);
+  services.tlp.enable = lib.mkDefault (
+    !config.services.power-profiles-daemon.enable && !config.services.tuned.enable
+  );
 }


### PR DESCRIPTION
<!-- Please read the CONTRIBUTING.md guidelines before submitting: https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md -->

###### Description of changes

TuneD is a maintained alternative for power-profile-daemon. If the user manually enables it we should not try to enable TLP, otherwise they will conflict with each other.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

