### PR TITLE
raspberry-pi/kernel: enable kexec

### DIFF
--- a/raspberry-pi/common/kernel.nix
+++ b/raspberry-pi/common/kernel.nix
@@ -70,6 +70,11 @@ in
       NET_CLS_BPF = lib.mkForce yes;
       NLS_CODEPAGE_437 = lib.mkForce yes;
       FB_SIMPLE = yes;
+
+      # Required by nixos-anywhere
+      KEXEC = yes;
+      KEXEC_FILE = yes;
+      PROC_KCORE = yes;
     }
     # nixpkgs defaults to lazy preempt on kernel version >=6.18
     # arm64 vendor defconfigs (bcm2711, bcm2712) use full preempt


### PR DESCRIPTION
###### Description of changes

This PR enables `kexec` in the kernel. This enables the kernel to be used with e.g. [nixos-anywhere](https://github.com/nix-community/nixos-anywhere).

###### Things done
- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

