### PR TITLE
dell/xps/13-9350: lunar-lake cpu + ipu7 webcam support

### DIFF
--- a/dell/xps/13-9350/default.nix
+++ b/dell/xps/13-9350/default.nix
@@ -2,7 +2,7 @@
 
 {
   imports = [
-    ../../../common/cpu/intel
+    ../../../common/cpu/intel/lunar-lake
     ../../../common/pc/laptop
     ../../../common/pc/laptop/ssd
   ];


### PR DESCRIPTION
This XPS 13 9350 refresh ships an Intel Core Ultra (Lunar Lake) CPU rather
than the original 2015/2016 Skylake chip that the model number originally
referred to, so it needs the lunar-lake CPU profile instead of the generic
one.

Lunar Lake integrates an IPU7 camera ISP. Enable `hardware.ipu7` (merged in
NixOS/nixpkgs#542085) with `platform = "ipu7x"` (Lunar Lake's PCI ID
8086:645d) to get a working webcam, following the same pattern as
`dell/latitude/9430`'s `hardware.ipu6` usage.

Tested on real hardware; webcam and hardware ISP work.
